### PR TITLE
Fixed a "Invalid IL code" error

### DIFF
--- a/NitroxPatcher/Patches/ArmsController_Update_Patch.cs
+++ b/NitroxPatcher/Patches/ArmsController_Update_Patch.cs
@@ -17,7 +17,7 @@ namespace NitroxPatcher.Patches
         private static readonly FieldInfo reconfigureWorldTarget = TARGET_CLASS.GetField("reconfigureWorldTarget", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo reconfigure = TARGET_CLASS.GetMethod("Reconfigure", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        private static readonly Type armAiming = TARGET_CLASS.GetNestedType("armAiming", BindingFlags.NonPublic);
+        private static readonly Type armAiming = TARGET_CLASS.GetNestedType("ArmAiming", BindingFlags.NonPublic);
         private static readonly MethodInfo armAimingUpdate = armAiming.GetMethod("Update", BindingFlags.Public | BindingFlags.Instance);
         private static readonly MethodInfo updateHandIKWeights = TARGET_CLASS.GetMethod("UpdateHandIKWeights", BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/NitroxPatcher/Patches/ArmsController_Update_Patch.cs
+++ b/NitroxPatcher/Patches/ArmsController_Update_Patch.cs
@@ -17,7 +17,7 @@ namespace NitroxPatcher.Patches
         private static readonly FieldInfo reconfigureWorldTarget = TARGET_CLASS.GetField("reconfigureWorldTarget", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo reconfigure = TARGET_CLASS.GetMethod("Reconfigure", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        private static readonly Type armAiming = TARGET_CLASS.GetNestedType("ArmAiming", BindingFlags.NonPublic);
+        private static readonly Type armAiming = TARGET_CLASS.GetNestedType("armAiming", BindingFlags.NonPublic);
         private static readonly MethodInfo armAimingUpdate = armAiming.GetMethod("Update", BindingFlags.Public | BindingFlags.Instance);
         private static readonly MethodInfo updateHandIKWeights = TARGET_CLASS.GetMethod("UpdateHandIKWeights", BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/NitroxPatcher/Patches/ConstructorInput_OnCraftingBegin_Patch.cs
+++ b/NitroxPatcher/Patches/ConstructorInput_OnCraftingBegin_Patch.cs
@@ -28,11 +28,8 @@ namespace NitroxPatcher.Patches
 
                 if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
                 {
-                    /*
-                     * TransientLocalObjectManager.Add(TransientLocalObjectManager.TransientObjectType.CONSTRUCTOR_INPUT_CRAFTED_GAMEOBJECT, gameObject);
-                     */
-                    yield return new ValidatedCodeInstruction(OpCodes.Ldc_I4_0);
-                    yield return new ValidatedCodeInstruction(OpCodes.Ldloc_0);
+                    yield return new ValidatedCodeInstruction(OpCodes.Ldc_I4_0); //CONSTRUCTOR_INPUT_CRAFTED_GAMEOBJECT
+                    yield return new ValidatedCodeInstruction(OpCodes.Ldloc_2); //gameobject localvariable
                     yield return new ValidatedCodeInstruction(OpCodes.Call, typeof(TransientLocalObjectManager).GetMethod("Add", BindingFlags.Static | BindingFlags.Public, null, new Type[] { TransientObjectType.CONSTRUCTOR_INPUT_CRAFTED_GAMEOBJECT.GetType(), typeof(object) }, null));
                 }
             }


### PR DESCRIPTION
Hello, first pull request.
I found that when you join a server the following message would show up in the output_log.txt;
`InvalidProgramException: Invalid IL code in (wrapper dynamic-method) ConstructorInput:OnCraftingBegin_Patch0`
And the client would then fail to connect.
This should fix it, I have also tested it:
![image](https://user-images.githubusercontent.com/1584195/35188206-bcdadb14-fe31-11e7-9c7d-3146b1bfac77.png)
