### PR TITLE
Fix bug that prevented fishes to load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+NitroxServer/Properties/Settings\.Designer\.cs
+
+NitroxServer/Properties/Settings\.settings

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -82,6 +82,11 @@
     <Compile Include="Player.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
     <Compile Include="Serialization\BatchCellsParser.cs" />
     <Compile Include="Serialization\LootDistributionsParser.cs" />
     <Compile Include="Serialization\ServerProtobufSerializer.cs" />
@@ -94,6 +99,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NitroxModel\NitroxModel.csproj">

--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -81,7 +81,7 @@ namespace NitroxServer.Serialization
         public void ParseFile(Int3 batchId, string pathPrefix, string suffix, List<EntitySpawnPoint> spawnPoints)
         {
             // This isn't always gonna work.
-            string path = @"C:\Program Files (x86)\Steam\steamapps\common\Subnautica\SNUnmanagedData\Build18\";
+            string path = Properties.Settings.Default.BuildDir;
             string fileName = path + pathPrefix + "batch-cells-" + batchId.x + "-" + batchId.y + "-" + batchId.z + "-" + suffix + ".bin";
 
             if (!File.Exists(fileName))


### PR DESCRIPTION
This removes the absolute path in BatchCellsParser and introduces a settings variable. You now have to right-click on NitroxServer and click Properties. Then go to settings and create a new file. Then you have to add a property called "BuildDir" with the value to the Build18 folder of Subnautica.