### PR TITLE
More Path.Combine.

### DIFF
--- a/NitroxClient/GameLogic/Logic.cs
+++ b/NitroxClient/GameLogic/Logic.cs
@@ -24,7 +24,7 @@ namespace NitroxClient.GameLogic
         public Terrain Terrain { get; }
         public IPacketSender PacketSender { get; }
         public IClientBridge ClientBridge { get; }
-        
+
         public Logic(IClientBridge clientBridge, VisibleCells visibleCells, DeferringPacketReceiver packetReceiver)
         {
             Log.Info("Initializing Multiplayer GameLogic...");

--- a/NitroxModel/Helper/SteamFinder.cs
+++ b/NitroxModel/Helper/SteamFinder.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Win32;
+﻿using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Logger;
-using System.IO;
-using System.Text.RegularExpressions;
 
 namespace NitroxModel.Helper
 {
@@ -16,16 +16,16 @@ namespace NitroxModel.Helper
                 return Optional<string>.Empty();
             }
 
-            string appsPath = (string)ReadRegistrySafe("Software\\Valve\\Steam", "SteamPath") + "/steamapps/";
+            string appsPath = Path.Combine((string)ReadRegistrySafe("Software\\Valve\\Steam", "SteamPath"), "steamapps");
 
-            if (File.Exists(appsPath + $"appmanifest_{appid.ToString()}.acf"))
+            if (File.Exists(Path.Combine(appsPath, $"appmanifest_{appid.ToString()}.acf")))
             {
                 return Optional<string>.Of(Path.Combine(Path.Combine(appsPath, "common"), gameName));
             }
             else
             {
-                string path = SearchAllInstalations(appsPath + "libraryfolders.vdf", appid, gameName);
-                if (path == "")
+                string path = SearchAllInstallations(Path.Combine(appsPath, "libraryfolders.vdf"), appid, gameName);
+                if (path == null)
                 {
                     Log.Info($"It appears you don't have {gameName} installed anywhere. The game files are needed to run the server.");
                 }
@@ -37,7 +37,7 @@ namespace NitroxModel.Helper
             return Optional<string>.Empty();
         }
 
-        private static string SearchAllInstalations(string libraryfolders, int appid, string gameName)
+        private static string SearchAllInstallations(string libraryfolders, int appid, string gameName)
         {
             StreamReader file = new StreamReader(libraryfolders);
             string line;
@@ -54,11 +54,11 @@ namespace NitroxModel.Helper
                 {
                     if (File.Exists(Path.Combine(value, $"steamapps/appmanifest_{appid.ToString()}.acf")))
                     {
-                        return Path.Combine(Path.Combine(value, "steamapps/common/"), gameName);
+                        return Path.Combine(Path.Combine(value, "steamapps/common"), gameName);
                     }
                 }
             }
-            return "";
+            return null;
         }
 
         private static object ReadRegistrySafe(string path, string key)

--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -4,11 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel.Logger;
 using NitroxServer.GameLogic.Spawning;
 using NitroxServer.UnityStubs;
-using NitroxModel.DataStructures.Util;
 
 namespace NitroxServer.Serialization
 {
@@ -81,15 +81,15 @@ namespace NitroxServer.Serialization
 
         public void ParseFile(Int3 batchId, string pathPrefix, string suffix, List<EntitySpawnPoint> spawnPoints)
         {
-            Optional<String> subnauticaPath = SteamFinder.FindSteamGamePath(264710, "Subnautica");
+            Optional<string> subnauticaPath = SteamFinder.FindSteamGamePath(264710, "Subnautica");
 
-            if(subnauticaPath.IsEmpty())
+            if (subnauticaPath.IsEmpty())
             {
                 throw new InvalidOperationException("Could not locate subnautica root");
             }
 
-            string path = Path.Combine(subnauticaPath.Get(), "SNUnmanagedData/Build18") + "/";
-            string fileName = path + pathPrefix + "batch-cells-" + batchId.x + "-" + batchId.y + "-" + batchId.z + "-" + suffix + ".bin";
+            string path = Path.Combine(subnauticaPath.Get(), "SNUnmanagedData/Build18");
+            string fileName = Path.Combine(path, pathPrefix + "batch-cells-" + batchId.x + "-" + batchId.y + "-" + batchId.z + "-" + suffix + ".bin");
 
             if (!File.Exists(fileName))
             {


### PR DESCRIPTION
For platform-independent filename support. And to reduce confusion when not all paths have a trailing separator.