### PR TITLE
Nitroxconsole

### DIFF
--- a/ClientTester/Commands/DefaultCommands/AniCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/AniCommand.cs
@@ -13,7 +13,7 @@ namespace ClientTester.Commands.DefaultCommands
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 2);
+            AssertMinimumArgs(args, 2);
 
             AnimChangeState state;
 

--- a/ClientTester/Commands/DefaultCommands/ChatCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/ChatCommand.cs
@@ -13,7 +13,7 @@ namespace ClientTester.Commands.DefaultCommands
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 1);
+            AssertMinimumArgs(args, 1);
 
             if (args.Length >= 2)
             {

--- a/ClientTester/Commands/DefaultCommands/DropCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/DropCommand.cs
@@ -13,7 +13,7 @@ namespace ClientTester.Commands.DefaultCommands
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 4);
+            AssertMinimumArgs(args, 4);
 
             client.Logic.Item.Dropped(new GameObject(), UWE.Utils.ParseEnum<TechType>(args[0]), CommandManager.GetVectorFromArgs(args, 1));
         }

--- a/ClientTester/Commands/DefaultCommands/MoveCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/MoveCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Timers;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.ServerModel;
 using NitroxModel.DataStructures.Util;
 using UnityEngine;

--- a/ClientTester/Commands/DefaultCommands/MoveyCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/MoveyCommand.cs
@@ -1,4 +1,5 @@
-﻿using NitroxModel.DataStructures.ServerModel;
+﻿using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.ServerModel;
 using NitroxModel.DataStructures.Util;
 using UnityEngine;
 
@@ -15,7 +16,7 @@ namespace ClientTester.Commands.DefaultCommands
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 1);
+            AssertMinimumArgs(args, 1);
 
             float y = client.ClientPos.y;
             client.ClientPos.y = float.Parse(args[0]);

--- a/ClientTester/Commands/DefaultCommands/PickupCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/PickupCommand.cs
@@ -11,7 +11,7 @@
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 4);
+            AssertMinimumArgs(args, 4);
 
             client.Logic.Item.PickedUp(CommandManager.GetVectorFromArgs(args, 1), args[0], "");
         }

--- a/ClientTester/Commands/DefaultCommands/PlayerStatsCommand.cs
+++ b/ClientTester/Commands/DefaultCommands/PlayerStatsCommand.cs
@@ -16,7 +16,7 @@ namespace ClientTester.Commands.DefaultCommands
 
         public override void Execute(MultiplayerClient client, string[] args)
         {
-            assertMinimumArgs(args, 1);
+            AssertMinimumArgs(args, 1);
 
             IEnumerable<object> numericArgs = args
                 .Skip(1)

--- a/ClientTester/Commands/NitroxCommand.cs
+++ b/ClientTester/Commands/NitroxCommand.cs
@@ -7,7 +7,7 @@
         public string Syntax;
         public abstract void Execute(MultiplayerClient client, string[] args);
 
-        protected void assertMinimumArgs(string[] args, int totalArgs)
+        protected void AssertMinimumArgs(string[] args, int totalArgs)
         {
             if (args.Length < totalArgs)
             {

--- a/NitroxClient/Communication/ClientBridge.cs
+++ b/NitroxClient/Communication/ClientBridge.cs
@@ -113,10 +113,10 @@ namespace NitroxClient.Communication
 
                 CurrentState = ClientBridgeState.Connected;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 CurrentState = ClientBridgeState.Failed;
-                throw ex;
+                throw;
             }
         }
 
@@ -143,11 +143,11 @@ namespace NitroxClient.Communication
 
                 CurrentState = ClientBridgeState.ReservationRejected;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 TryStopClient();
                 CurrentState = ClientBridgeState.Failed;
-                throw ex;
+                throw;
             }
         }
 

--- a/NitroxClient/Debuggers/BaseDebugger.cs
+++ b/NitroxClient/Debuggers/BaseDebugger.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using UnityEngine;

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -19,8 +19,6 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         bool notifyingUnableToJoin = false;
         bool shouldFocus;
 
-        private GameObject multiplayerClient;
-
         public void Awake()
         {
             DontDestroyOnLoad(gameObject);
@@ -44,54 +42,6 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             {
                 unableToJoinWindowRect = GUILayout.Window(GUIUtility.GetControlID(FocusType.Keyboard), joinServerWindowRect, RenderUnableToJoinDialog, "Unable to Join Session");
             }
-        }
-
-        private IEnumerator NegotiateSession(string serverIp)
-        {
-            Log.InGame("Negotiating session...");
-
-            if (Multiplayer.Main == null)
-            {
-                Log.InGame("Critical error, Multiplayer main unset.");
-            }
-            Multiplayer.Main.NegotiatePlayerSlotReservation(serverIp, username);
-
-            Log.InGame("Waiting for reservation...");
-            yield return new WaitUntil(() => Multiplayer.Logic.ClientBridge.CurrentState != Communication.ClientBridgeState.WaitingForRerservation);
-
-            switch (Multiplayer.Logic.ClientBridge.CurrentState)
-            {
-                case Communication.ClientBridgeState.Reserved:
-                    Log.InGame("Launching game...");
-                    StartCoroutine(LaunchSession());
-                    break;
-                case Communication.ClientBridgeState.ReservationRejected:
-                    Log.InGame("Reservation rejected...");
-                    notifyingUnableToJoin = true;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        private IEnumerator LaunchSession()
-        {
-            Log.InGame("Launching game...");
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            IEnumerator startNewGame = (IEnumerator)uGUI_MainMenu.main.ReflectionCall("StartNewGame", false, false, GameMode.Survival);
-            StartCoroutine(startNewGame);
-
-            Log.InGame("Waiting for game to load...");
-            //Wait until game starts
-            yield return new WaitUntil(() => LargeWorldStreamer.main != null);
-            yield return new WaitUntil(() => LargeWorldStreamer.main.IsReady() || LargeWorldStreamer.main.IsWorldSettled());
-            yield return new WaitUntil(() => !PAXTerrainController.main.isWorking);
-
-            Log.InGame("Joining Multiplayer Session...");
-            Multiplayer.Main.JoinSession();
-
-            Destroy(gameObject);
         }
 
         private GUISkin GetGUISkin(string skinName, int labelWidth)
@@ -164,24 +114,14 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 
         private void StartMultiplayerClient()
         {
-            if (multiplayerClient == null)
-            {
-                multiplayerClient = new GameObject();
-                multiplayerClient.AddComponent<Multiplayer>();
-            }
-
-            StartCoroutine(NegotiateSession(ServerIp));
+            Multiplayer.Main.SetUserData(ServerIp, username);
+            Multiplayer.Main.enabled = true;
             joiningServer = false;
         }
 
         private void StopMultiplayerClient()
         {
-            if (multiplayerClient != null)
-            {
-                Destroy(multiplayerClient);
-                multiplayerClient = null;
-            }
-
+            Multiplayer.Main.enabled = false;
             joiningServer = false;
         }
 

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -1,10 +1,6 @@
 ﻿using NitroxClient.Unity.Helper;
-using System.Collections;
-using NitroxModel.Helper;
 using UnityEngine;
-using NitroxModel.Logger;
 using NitroxModel;
-using System.ComponentModel;
 using NitroxModel.PlayerSlot;
 
 namespace NitroxClient.MonoBehaviours.Gui.MainMenu

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -163,6 +163,7 @@ namespace NitroxClient.MonoBehaviours
                 Log.InGame("Launching game...");
 #pragma warning disable CS0618 // Type or member is obsolete
                 IEnumerator startNewGame = (IEnumerator)uGUI_MainMenu.main.ReflectionCall("StartNewGame", false, false, GameMode.Survival);
+#pragma warning restore CS0618 // Type or member is obsolete
                 StartCoroutine(startNewGame);
 
                 Log.InGame("Waiting for game to load...");

--- a/NitroxClient/MonoBehaviours/MultiplayerManager.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerManager.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NitroxClient.Communication;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Logger;
+using NitroxModel.NitroxConsole;
+using NitroxModel.NitroxConsole.Events;
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours
+{
+    public class MultiplayerManager : MonoBehaviour
+    {
+        private const string DEFAULT_IP_ADDRESS = "127.0.0.1";
+        private Multiplayer multiplayer;
+
+        private void Awake()
+        {
+            CreatMultiplayer();
+            NitroxConsole.Main.AddCommand(OnConsoleCommand);
+        }
+
+        private void CreatMultiplayer()
+        {
+            GameObject go = new GameObject("Multiplayer");
+            go.SetActive(false); // disable GameObject so Multiplayer isn't enabled on AddComponent.
+            
+            multiplayer = go.AddComponent<Multiplayer>();
+            multiplayer.enabled = false;
+
+            go.transform.SetParent(transform);
+            go.SetActive(true);
+        }
+
+        [NitroxCommand("mplayer")]
+        [NitroxCommandArg("username", CommandArgInput.Type.STRING, true, "user", "u")]
+        [NitroxCommandArg("ipaddress", CommandArgInput.Type.STRING, "ip", "i")]
+        private void OnConsoleCommand(CommandEventArgs e)
+        {
+            if (Multiplayer.Main.enabled)
+            {
+                Log.InGame("Already connected to a server");
+                return;
+            }
+            
+            multiplayer.SetUserData(e.Get<string>("ipaddress").OrElse(DEFAULT_IP_ADDRESS), e.Get<string>("username").Get());
+            multiplayer.enabled = true;
+        }
+    }
+}

--- a/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
+++ b/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
@@ -1,18 +1,37 @@
-﻿using NitroxClient.MonoBehaviours.Gui.MainMenu;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using NitroxClient.Communication.Packets.Processors;
+using NitroxClient.MonoBehaviours.Gui.MainMenu;
+using NitroxModel.Logger;
+using NitroxModel.NitroxConsole;
+using NitroxModel.NitroxConsole.Events;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours
 {
     public class NitroxBootstrapper : MonoBehaviour
     {
+        public static NitroxBootstrapper Main { get; private set; }
+
         public void Awake()
         {
+            Main = this;
+
+            // Please don't kill me..
             DontDestroyOnLoad(gameObject);
             gameObject.AddComponent<SceneCleanerPreserve>();
 
+            // Global managers WITHOUT child objects.
+            gameObject.AddComponent<NitroxConsoleUI>();
             gameObject.AddComponent<MainMenuMods>();
             gameObject.AddComponent<CodePatchManager>();
+
+            // Global managers WITH child objects.
             CreateDebugger();
+            CreateMultiplayer();
+
+            NitroxConsole.Main.AddCommand(QuitGameCommand);
         }
 
         private void CreateDebugger()
@@ -21,6 +40,20 @@ namespace NitroxClient.MonoBehaviours
             debugger.name = "Debug manager";
             debugger.AddComponent<NitroxDebugManager>();
             debugger.transform.SetParent(transform);
+        }
+
+        private void CreateMultiplayer()
+        {
+            GameObject mp = new GameObject();
+            mp.name = "Multiplayer manager";
+            mp.AddComponent<MultiplayerManager>();
+            mp.transform.SetParent(transform);
+        }
+
+        [NitroxCommand("quit")]
+        private static void QuitGameCommand(CommandEventArgs e)
+        {
+            Application.Quit();
         }
     }
 }

--- a/NitroxClient/MonoBehaviours/NitroxConsoleUi.cs
+++ b/NitroxClient/MonoBehaviours/NitroxConsoleUi.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Generic;
+using NitroxClient.Unity.Helper;
+using NitroxModel.Logger;
+using NitroxModel.NitroxConsole;
+using NitroxModel.NitroxConsole.Events;
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours
+{
+    public class NitroxConsoleUI : MonoBehaviour
+    {
+        public bool IsRendering { get; private set; }
+        /// <summary>
+        /// Speed multiplier used when scrolling with the arrow keys (like <see cref="KeyCode.UpArrow"/> or <see cref="KeyCode.PageDown"/>).
+        /// </summary>
+        public float ArrowScrollSpeedMult { get; } = 500;
+
+        /// <summary>
+        /// Multiplicative multiplier on top of <see cref="ArrowScrollSpeedMult"/> when holding down shift.
+        /// </summary>
+        public float ArrowScrollSpeedShiftMult { get; } = 3;
+        public Vector2 ScrollPosition
+        {
+            get { return scrollPosition; }
+            set
+            {
+                if (value.x < 0)
+                {
+                    value.x = 0;
+                }
+
+                if (value.y < 0)
+                {
+                    value.y = 0;
+                }
+
+                scrollPosition = value;
+            }
+        }
+
+        private string consoleInput;
+        private Queue<string> consoleText = new Queue<string>();
+        private Vector2 scrollPosition = Vector2.zero;
+        private const string CONTROL_CONSOLEINPUT = "consoleinput";
+        private const int MAX_CONSOLETEXT_LINES = 1000;
+        private bool isReturnDown;
+        private Rect consoleTextArea;
+
+        public string ConsoleInput
+        {
+            get { return consoleInput ?? ""; }
+            set
+            {
+                consoleInput = value;
+            }
+        }
+
+        public void AddText(string text)
+        {
+            consoleText.Enqueue(text);
+            while (consoleText.Count > MAX_CONSOLETEXT_LINES)
+            {
+                consoleText.Dequeue();
+            }
+        }
+
+        public void AddErrorText(string errorText)
+        {
+            AddText($"<color=red>{errorText}</color>");
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.BackQuote))
+            {
+                IsRendering = !IsRendering;
+            }
+
+            if (!IsRendering)
+            {
+                return;
+            }
+
+            if (isReturnDown)
+            {
+                isReturnDown = false;
+                NitroxConsole.Main.Submit(ConsoleInput);
+                ConsoleInput = null;
+            }
+        }
+
+        private float GetFullScrollSpeedMult(Event evt)
+        {
+            if (evt.shift)
+            {
+                return ArrowScrollSpeedMult * ArrowScrollSpeedShiftMult * Time.deltaTime;
+            }
+            return ArrowScrollSpeedMult * Time.deltaTime;
+        }
+
+        private void OnEnable()
+        {
+            NitroxConsole.Main.CommandReceived += OnCommandReceived;
+            NitroxConsole.Main.InvalidCommandReceived += OnInvalidCommandReceived;
+        }
+
+        private void OnDisable()
+        {
+            NitroxConsole.Main.CommandReceived -= OnCommandReceived;
+            NitroxConsole.Main.InvalidCommandReceived -= OnInvalidCommandReceived;
+        }
+
+        private void OnInvalidCommandReceived(object sender, CommandCandidateEventArgs e)
+        {
+            AddErrorText($"Invalid console command: {e.Value}, Error: {e.State}{(!string.IsNullOrEmpty(e.StateMessage) ? $", Message: {e.StateMessage}" : "")}");
+        }
+
+        private void OnCommandReceived(object sender, CommandEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(e.HandlerMessage))
+            {
+                if (e.HasError)
+                {
+                    AddErrorText(e.HandlerMessage);
+                }
+                else
+                {
+                    AddText(e.HandlerMessage);
+                }
+                return;
+            }
+            AddText($"Command executed: {e.Value}");
+        }
+
+        private void OnGUI()
+        {
+            if (!IsRendering)
+            {
+                return;
+            }
+
+            Event evt = Event.current;
+            if (evt.isKey)
+            {
+                if (evt.type == EventType.KeyDown)
+                {
+                    switch (evt.keyCode)
+                    {
+                        case KeyCode.BackQuote:
+                            if (GUI.GetNameOfFocusedControl() == CONTROL_CONSOLEINPUT)
+                            {
+                                ConsoleInput = null;
+                                NitroxConsole.Main.HistoryMoveAfterNow();
+                                IsRendering = false;
+                            }
+                            break;
+                        case KeyCode.Return:
+                        case KeyCode.KeypadEnter:
+                            isReturnDown = true;
+                            break;
+                        case KeyCode.PageUp:
+                            ScrollPosition += Vector2.down * GetFullScrollSpeedMult(evt);
+                            break;
+                        case KeyCode.PageDown:
+                            ScrollPosition += Vector2.up * GetFullScrollSpeedMult(evt);
+                            break;
+                        case KeyCode.LeftArrow:
+                            ScrollPosition += Vector2.left * GetFullScrollSpeedMult(evt);
+                            break;
+                        case KeyCode.RightArrow:
+                            ScrollPosition += Vector2.right * GetFullScrollSpeedMult(evt);
+                            break;
+                        case KeyCode.UpArrow:
+                            CommandEventArgs argPrevious = NitroxConsole.Main.HistoryPrevious();
+                            ConsoleInput = argPrevious.Value;
+                            break;
+                        case KeyCode.DownArrow:
+                            CommandEventArgs argNext = NitroxConsole.Main.HistoryNext();
+                            ConsoleInput = argNext.Value;
+                            break;
+                        case KeyCode.Home:
+                            ScrollPosition = Vector2.zero;
+                            break;
+                        case KeyCode.End:
+                            ScrollPosition = new Vector2(0, consoleTextArea.y);
+                            break;
+                    }
+                }
+            }
+
+            // TODO: Rescaling on all resolutions.
+            //Vector3 scale = new Vector3(Screen.width / originalSize.x, Screen.height / originalSize.y, 1);
+            //Matrix4x4 matrix = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, scale);
+
+            GUISkinUtils.RenderWithSkin(GUISkinUtils.RegisterDerivedOnce("console", SetSkinStyle), Render);
+
+            if (GUI.GetNameOfFocusedControl() != CONTROL_CONSOLEINPUT)
+            {
+                GUI.FocusControl(CONTROL_CONSOLEINPUT);
+            }
+        }
+
+        private void Render()
+        {
+            using (new GUILayout.VerticalScope("Box", GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4f)))
+            {
+                using (GUILayout.ScrollViewScope scroll = new GUILayout.ScrollViewScope(ScrollPosition, "fillscroll"))
+                {
+                    ScrollPosition = scroll.scrollPosition;
+                    using (new GUILayout.VerticalScope("consoletextarea"))
+                    {
+                        foreach (string line in consoleText)
+                        {
+                            GUILayout.Label(line, "consoletext");
+                        }
+                    }
+
+                    // Get the total size of the text area inside the console scrollview.
+                    consoleTextArea = GUILayoutUtility.GetLastRect();
+                }
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    GUILayout.Label(">", "input-prefix");
+                    GUI.SetNextControlName(CONTROL_CONSOLEINPUT);
+                    ConsoleInput = GUILayout.TextField(ConsoleInput, "input");
+                }
+            }
+        }
+
+        private void SetSkinStyle(GUISkin skin)
+        {
+            skin.SetCustomStyle("fillscroll", "scrollView", style =>
+            {
+                style.stretchWidth = true;
+                style.stretchHeight = true;
+            });
+
+            skin.SetCustomStyle("consoletextarea", "box", style =>
+            {
+                style.stretchWidth = true;
+                style.stretchHeight = true;
+            });
+
+            skin.SetCustomStyle("consoletext", "label", style =>
+            {
+                style.stretchWidth = true;
+                style.margin = new RectOffset();
+                style.padding = new RectOffset();
+            });
+
+            skin.SetCustomStyle("input-prefix", "label", style =>
+            {
+                style.fontSize = 20;
+                style.normal.textColor = Color.cyan;
+                style.fixedWidth = 20;
+                style.margin.left = 20;
+            });
+
+            skin.SetCustomStyle("input", "textfield", style =>
+            {
+                style.fontSize = 20;
+                style.fontStyle = FontStyle.Bold;
+            });
+        }
+    }
+}

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -171,9 +171,11 @@
     <Compile Include="MonoBehaviours\Multiplayer.cs" />
     <Compile Include="MonoBehaviours\MultiplayerCyclops.cs" />
     <Compile Include="MonoBehaviours\MultiplayerExosuit.cs" />
+    <Compile Include="MonoBehaviours\MultiplayerManager.cs" />
     <Compile Include="MonoBehaviours\MultiplayerSeaMoth.cs" />
     <Compile Include="MonoBehaviours\MultiplayerVehicleControl.cs" />
     <Compile Include="MonoBehaviours\NitroxBootstrapper.cs" />
+    <Compile Include="MonoBehaviours\NitroxConsoleUi.cs" />
     <Compile Include="MonoBehaviours\NitroxDebugManager.cs" />
     <Compile Include="MonoBehaviours\Overrides\MultiplayerBuilder.cs" />
     <Compile Include="MonoBehaviours\PlayerMovement.cs" />

--- a/NitroxClient/Unity/Helper/GUISkinUtils.cs
+++ b/NitroxClient/Unity/Helper/GUISkinUtils.cs
@@ -6,6 +6,12 @@ using UnityEngine;
 
 namespace NitroxClient.Unity.Helper
 {
+    /// <summary>
+    /// Utilities for handling Unity's state-based IMGUI layout.
+    /// <remarks>
+    /// Possible future improvement: refactor to a 'NitroxGUI' that renders with a config object and resets Unity's GUI after render.
+    /// </remarks>
+    /// </summary>
     public static class GUISkinUtils
     {
         private static Dictionary<string, GUISkin> guiSkins = new Dictionary<string, GUISkin>();
@@ -99,6 +105,18 @@ namespace NitroxClient.Unity.Helper
             GUI.skin = skin;
             render();
             GUI.skin = prevSkin;
+        }
+
+        public static void RenderWithMatrix(Matrix4x4 matrix, Action render)
+        {
+            if (GUI.matrix == matrix)
+            {
+                return;
+            }
+            Matrix4x4 prevMatrix = GUI.matrix;
+            GUI.matrix = matrix;
+            render();
+            GUI.matrix = prevMatrix;
         }
 
         /// <summary>

--- a/NitroxModel/DataStructures/Optional.cs
+++ b/NitroxModel/DataStructures/Optional.cs
@@ -71,6 +71,27 @@ namespace NitroxModel.DataStructures.Util
 
             return "Optional[" + Get().ToString() + "]";
         }
+
+        public Optional<T> Then(Func<T, Optional<T>> continueFunc)
+        {
+            if (IsPresent())
+            {
+                return continueFunc(value);
+            }
+
+            return Empty();
+        }
+
+        public bool Then(Action<T> continueAction)
+        {
+            if (IsPresent())
+            {
+                continueAction(value);
+                return true;
+            }
+
+            return false;
+        }
     }
 
     [Serializable]

--- a/NitroxModel/DataStructures/Optional.cs
+++ b/NitroxModel/DataStructures/Optional.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NitroxModel.Helper;
 
 namespace NitroxModel.DataStructures.Util
 {
@@ -74,6 +75,8 @@ namespace NitroxModel.DataStructures.Util
 
         public Optional<T> Then(Func<T, Optional<T>> continueFunc)
         {
+            Validate.NotNull(continueFunc);
+
             if (IsPresent())
             {
                 return continueFunc(value);
@@ -84,6 +87,8 @@ namespace NitroxModel.DataStructures.Util
 
         public bool Then(Action<T> continueAction)
         {
+            Validate.NotNull(continueAction);
+
             if (IsPresent())
             {
                 continueAction(value);

--- a/NitroxModel/Helper/Validate.cs
+++ b/NitroxModel/Helper/Validate.cs
@@ -1,9 +1,9 @@
-﻿using NitroxModel.Logger;
-using System.Linq;
+﻿using System.Linq;
 using System.Diagnostics;
-using NitroxModel.DataStructures.Util;
 using System;
+using System.Collections;
 using System.Reflection;
+using NitroxModel.DataStructures.Util;
 
 namespace NitroxModel.Helper
 {
@@ -97,6 +97,54 @@ namespace NitroxModel.Helper
         {
             ParameterInfo[] parametersOfMethodBeforeValidate = new StackFrame(2).GetMethod().GetParameters();
             return Optional<string>.OfNullable(parametersOfMethodBeforeValidate.SingleOrDefault(pi => pi.ParameterType == typeof(TParam))?.Name);
+        }
+
+        public static void NotNullOrEmpty(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                Optional<string> paramName = GetParameterName<string>();
+                if (paramName.IsPresent())
+                {
+                    throw new ArgumentNullException(paramName.Get());
+                }
+                else
+                {
+                    throw new ArgumentNullException();
+                }
+            }
+        }
+
+        public static void NotNullOrWhitespace(string value)
+        {
+            if (string.IsNullOrEmpty(value) || value.All(c => c == ' '))
+            {
+                Optional<string> paramName = GetParameterName<string>();
+                if (paramName.IsPresent())
+                {
+                    throw new ArgumentNullException(paramName.Get());
+                }
+                else
+                {
+                    throw new ArgumentNullException();
+                }
+            }
+        }
+
+        public static void NotNullOrEmpty<T>(T value) where T : ICollection
+        {
+            if (value == null || value.Count > 0)
+            {
+                Optional<string> paramName = GetParameterName<T>();
+                if (paramName.IsPresent())
+                {
+                    throw new ArgumentNullException(paramName.Get());
+                }
+                else
+                {
+                    throw new ArgumentNullException();
+                }
+            }
         }
     }
 }

--- a/NitroxModel/NitroxConsole/CommandArgInput.cs
+++ b/NitroxModel/NitroxConsole/CommandArgInput.cs
@@ -1,0 +1,30 @@
+﻿namespace NitroxModel.NitroxConsole
+{
+    public class CommandArgInput
+    {
+        public string Name { get; }
+        public object Value { get; }
+        public Type ValueType { get; }
+
+        public CommandArgInput(string name, object value)
+        {
+            Name = name;
+            Value = value;
+
+            if (value is string)
+            {
+                ValueType = Type.STRING;
+            }
+            else
+            {
+                ValueType = Type.NUMBER;
+            }
+        }
+
+        public enum Type
+        {
+            NUMBER,
+            STRING
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/CommandDatabase.cs
+++ b/NitroxModel/NitroxConsole/CommandDatabase.cs
@@ -17,7 +17,7 @@ namespace NitroxModel.NitroxConsole
     /// </summary>
     public class CommandDatabase
     {
-        private readonly Dictionary<CommandIdentity, CommandsStore> Commands = new Dictionary<CommandIdentity, CommandsStore>();
+        private readonly Dictionary<CommandIdentity, CommandsStore> commands = new Dictionary<CommandIdentity, CommandsStore>();
         /// <summary>
         /// Keeps track of the entered commands.
         /// </summary>
@@ -41,12 +41,12 @@ namespace NitroxModel.NitroxConsole
 
         private void AddEntry(CommandEntry entry, bool silentlyFail = false)
         {
-            if (!Commands.ContainsKey(entry.Command.Identity))
+            if (!commands.ContainsKey(entry.Command.Identity))
             {
-                Commands.Add(entry.Command.Identity, new CommandsStore(entry.Command.Identity));
+                commands.Add(entry.Command.Identity, new CommandsStore(entry.Command.Identity));
             }
 
-            CommandsStore store = Commands[entry.Command.Identity];
+            CommandsStore store = commands[entry.Command.Identity];
             if (store.Contains(entry))
             {
                 if (!silentlyFail)
@@ -62,7 +62,7 @@ namespace NitroxModel.NitroxConsole
         public Optional<CommandsStore> GetStore(CommandIdentity identity)
         {
             CommandsStore store;
-            Commands.TryGetValue(identity, out store);
+            commands.TryGetValue(identity, out store);
             return Optional<CommandsStore>.OfNullable(store);
         }
 
@@ -257,8 +257,7 @@ namespace NitroxModel.NitroxConsole
 
             public override string ToString()
             {
-                string argString = Args.Any() ? Args.Select(a => a.Name).Aggregate((a1, a2) => a1 + ", " + a2) : "";
-                return $"{nameof(Command)}: {Command}{(argString != "" ? $", {nameof(Args)}: {argString}" : "")}";
+                return $"{nameof(Command)}: {Command}, {nameof(Args)}: {string.Join(", ", Args.Select(a => a.Name).ToArray())}";
             }
 
             internal static CommandEntry From(string category, string command, Action handler)

--- a/NitroxModel/NitroxConsole/CommandDatabase.cs
+++ b/NitroxModel/NitroxConsole/CommandDatabase.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using NitroxModel.NitroxConsole.Events;
+using NitroxModel.NitroxConsole.Typing;
+
+namespace NitroxModel.NitroxConsole
+{
+    /// <summary>
+    /// Stores commands and can invoke commands directly.
+    /// </summary>
+    public class CommandDatabase
+    {
+        private readonly Dictionary<CommandIdentity, CommandsStore> Commands = new Dictionary<CommandIdentity, CommandsStore>();
+        /// <summary>
+        /// Keeps track of the entered commands.
+        /// </summary>
+
+        public CommandEntry Add(Action<CommandEventArgs> handler)
+        {
+            CommandEntry entry = CommandEntry.From(handler);
+            AddEntry(entry);
+
+            return entry;
+        }
+
+        [Obsolete("Prefer using Add(handler) over adding commands directly.")]
+        internal CommandEntry Add(string category, string command, Action handler)
+        {
+            CommandEntry entry = CommandEntry.From(category, command, handler);
+            AddEntry(entry, true);
+            
+            return entry;
+        }
+
+        private void AddEntry(CommandEntry entry, bool silentlyFail = false)
+        {
+            if (!Commands.ContainsKey(entry.Command.Identity))
+            {
+                Commands.Add(entry.Command.Identity, new CommandsStore(entry.Command.Identity));
+            }
+
+            CommandsStore store = Commands[entry.Command.Identity];
+            if (store.Contains(entry))
+            {
+                if (!silentlyFail)
+                {
+                    throw new NotSupportedException($"Command handler already exists in database for command: {entry.Instance.GetType().FullName}.{entry.Method.Name}");
+                }
+
+                return;
+            }
+            store.Add(entry, silentlyFail);
+        }
+
+        public Optional<CommandsStore> GetStore(CommandIdentity identity)
+        {
+            CommandsStore store;
+            Commands.TryGetValue(identity, out store);
+            return Optional<CommandsStore>.OfNullable(store);
+        }
+
+        public bool TryInvokeHandler(CommandEventArgs e)
+        {
+            return GetStore(new CommandIdentity(e.Category, e.Command)).Then(s => s.GetHandler(e.Arguments).Then(ce => ce.EventHandler(this, e)));
+        }
+
+        public class CommandsStore
+        {
+            public CommandIdentity Identity { get; }
+            protected List<CommandEntry> Entries = new List<CommandEntry>();
+
+            public CommandsStore(CommandIdentity identity)
+            {
+                Validate.NotNull(identity);
+
+                Identity = identity;
+            }
+
+            protected internal void Add(CommandEntry entry, bool silentlyFail = false)
+            {
+                if (Entries.Contains(entry))
+                {
+                    if (!silentlyFail)
+                    {
+                        throw new NotSupportedException("Command entry already exists in store.");
+                    }
+
+                    return;
+                }
+
+                CommandEntry conflicting = Entries.FirstOrDefault(e => e.IsSameHandler(entry));
+                if (conflicting != null)
+                {
+                    if (!silentlyFail)
+                    {
+                        throw new NotSupportedException($"Another command entry handles the same command. Given: {entry}, Conflicting: {conflicting}");
+                    }
+
+                    return;
+                }
+
+                Entries.Add(entry);
+            }
+
+            /// <summary>
+            /// Get all the registered command entries in this store.
+            /// </summary>
+            /// <returns>Commands with the same <see cref="CommandIdentity"/>.</returns>
+            public IEnumerable<CommandEntry> GetEntries()
+            {
+                return Entries;
+            }
+
+            /// <summary>
+            /// Compares the given arguments with all the arguments in the store. Doesn't compare <see cref="CommandIdentity"/> because it's expected to be equal to the current store.
+            /// </summary>
+            /// <param name="given">Arguments to find a handler for.</param>
+            /// <returns>Registered command handler for the command arguments.</returns>
+            public Optional<CommandEntry> GetHandler(IEnumerable<CommandArgInput> given)
+            {
+                CommandEntry bestMatch = Entries.FirstOrDefault(entry => entry.Args.Where(a => a.Required).All(a => given.Any(g => a.HasName(g.Name))));
+                return Optional<CommandEntry>.OfNullable(bestMatch);
+            }
+
+            public bool Contains(CommandEntry entry)
+            {
+                if (entry == null)
+                {
+                    return false;
+                }
+
+                return Entries.Contains(entry);
+            }
+        }
+
+        /// <summary>
+        ///     Used by <see cref="CommandDatabase" /> to store a new registered command entry.
+        /// </summary>
+        public class CommandEntry : IEquatable<CommandEntry>
+        {
+            private CommandEntry(string category, string command, Action handler)
+            {
+                Args = new ReadOnlyCollection<NitroxCommandArgAttribute>(new List<NitroxCommandArgAttribute>());
+                Command = new NitroxCommandAttribute(category, command);
+                Instance = handler.Target;
+                Method = handler.Method;
+                InternalDelegate = args => handler();
+                EventHandler = (sender, e) => InternalDelegate(e);
+            }
+
+            private CommandEntry(NitroxCommandAttribute command, List<NitroxCommandArgAttribute> args, MethodInfo method, object instance = null)
+            {
+                Validate.NotNull(command);
+                Validate.NotNull(args);
+                Validate.NotNull(method);
+
+                // Validate that there aren't any conflicting argument names.
+                if (args.SelectMany(a => new[] {a.Name}.Concat(a.Aliases)).GroupBy(n => n).Any(g => g.Count() > 1))
+                {
+                    throw new DuplicateNameException(
+                        $"Commands must not have conflicting argument names or aliases. Command: {command.Identity}, Command's method: {method.DeclaringType?.FullName}.{method.Name}");
+                }
+
+                Instance = instance;
+                Command = command;
+                Method = method;
+                Args = new ReadOnlyCollection<NitroxCommandArgAttribute>(args);
+                InternalDelegate = (Action<CommandEventArgs>)Delegate.CreateDelegate(typeof(Action<CommandEventArgs>), Instance, Method);
+                EventHandler = (sender, e) => InternalDelegate(e);
+            }
+
+            /// <summary>
+            ///     Instance of a class that has the command handler.
+            /// </summary>
+            public object Instance { get; }
+
+            public NitroxCommandAttribute Command { get; }
+            public ReadOnlyCollection<NitroxCommandArgAttribute> Args { get; }
+            public MethodInfo Method { get; }
+            public EventHandler<CommandEventArgs> EventHandler { get; }
+            private Action<CommandEventArgs> InternalDelegate { get; }
+
+            public static CommandEntry From(Action<CommandEventArgs> method)
+            {
+                Validate.NotNull(method);
+                return From(method.Method, method.Target);
+            }
+
+            /// <summary>
+            /// Creates a command registration entry from a method with an optional instance for istance methods.
+            /// </summary>
+            /// <param name="instance"></param>
+            /// <param name="method"></param>
+            /// <returns></returns>
+            public static CommandEntry From(MethodInfo method, object instance = null)
+            {
+                Validate.NotNull(method);
+
+                NitroxCommandAttribute cmd = method.GetCustomAttributes(typeof(NitroxCommandAttribute), false)
+                    .OfType<NitroxCommandAttribute>().Single();
+                List<NitroxCommandArgAttribute> args = method.GetCustomAttributes(typeof(NitroxCommandArgAttribute), false)
+                    .OfType<NitroxCommandArgAttribute>().ToList();
+
+                return new CommandEntry(cmd, args, method, instance);
+            }
+
+            public bool IsSameHandler(CommandEntry other)
+            {
+                if (other == null)
+                {
+                    return false;
+                }
+
+                return Command.Identity == other.Command.Identity && Args.All(a => other.Args.Any(otherA => otherA.IsSameCommandArg(a)));
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as CommandEntry);
+            }
+
+            public bool Equals(CommandEntry other)
+            {
+                return other != null &&
+                       EqualityComparer<object>.Default.Equals(Instance, other.Instance) &&
+                       EqualityComparer<NitroxCommandAttribute>.Default.Equals(Command, other.Command) &&
+                       EqualityComparer<ReadOnlyCollection<NitroxCommandArgAttribute>>.Default.Equals(Args, other.Args) &&
+                       EqualityComparer<MethodInfo>.Default.Equals(Method, other.Method);
+            }
+
+            public override int GetHashCode()
+            {
+                int hashCode = 217259050;
+                hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(Instance);
+                hashCode = hashCode * -1521134295 + EqualityComparer<NitroxCommandAttribute>.Default.GetHashCode(Command);
+                hashCode = hashCode * -1521134295 + EqualityComparer<ReadOnlyCollection<NitroxCommandArgAttribute>>.Default.GetHashCode(Args);
+                hashCode = hashCode * -1521134295 + EqualityComparer<MethodInfo>.Default.GetHashCode(Method);
+                return hashCode;
+            }
+
+            public static bool operator ==(CommandEntry entry1, CommandEntry entry2)
+            {
+                return EqualityComparer<CommandEntry>.Default.Equals(entry1, entry2);
+            }
+
+            public static bool operator !=(CommandEntry entry1, CommandEntry entry2)
+            {
+                return !(entry1 == entry2);
+            }
+
+            public override string ToString()
+            {
+                string argString = Args.Any() ? Args.Select(a => a.Name).Aggregate((a1, a2) => a1 + ", " + a2) : "";
+                return $"{nameof(Command)}: {Command}{(argString != "" ? $", {nameof(Args)}: {argString}" : "")}";
+            }
+
+            internal static CommandEntry From(string category, string command, Action handler)
+            {
+                Validate.NotNullOrWhitespace(category);
+                Validate.NotNullOrWhitespace(command);
+                Validate.NotNull(handler);
+
+                return new CommandEntry(category, command, handler);
+            }
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/CommandIdentity.cs
+++ b/NitroxModel/NitroxConsole/CommandIdentity.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole
+{
+    public class CommandIdentity : IEquatable<CommandIdentity>
+    {
+        /// <summary>
+        /// Category that the command belongs to.
+        /// </summary>
+        public string Category { get; }
+        /// <summary>
+        /// Name of the command.
+        /// </summary>
+        public string Command { get; }
+
+        public CommandIdentity(string category, string command)
+        {
+            Validate.NotNullOrWhitespace(category);
+            Validate.NotNullOrWhitespace(command);
+
+            if (category.Any(char.IsUpper))
+            {
+                throw new NotSupportedException("The category of a command must be all lower-case.");
+            }
+
+            if (command.Any(char.IsUpper))
+            {
+                throw new NotSupportedException("Command name must be all lower-case.");
+            }
+
+            Category = category;
+            Command = command;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as CommandIdentity);
+        }
+
+        public bool Equals(CommandIdentity other)
+        {
+            return other != null &&
+                   Category == other.Category &&
+                   Command == other.Command;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1403680907;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Category);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Command);
+            return hashCode;
+        }
+
+        public static bool operator ==(CommandIdentity identity1, CommandIdentity identity2)
+        {
+            return EqualityComparer<CommandIdentity>.Default.Equals(identity1, identity2);
+        }
+
+        public static bool operator !=(CommandIdentity identity1, CommandIdentity identity2)
+        {
+            return !(identity1 == identity2);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Category)}: {Category}, {nameof(Command)}: {Command}";
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
+++ b/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole.Events
+{
+    /// <summary>
+    /// Decides whether a given string is a command or not.
+    /// </summary>
+    public class CommandCandidateEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Pattern to match 3 parts:
+        ///  - Command category
+        ///  - Command name
+        ///  - Command arguments
+        /// </summary>
+        /// <remarks>
+        /// https://regex101.com/r/J1E3ut/2
+        /// </remarks>
+        private static readonly Regex cmdRegex = new Regex(@"^\s*(?<cat>(?>[a-zA-Z][a-zA-Z0-9]*))?\s?(?<cmd>[a-zA-Z][a-zA-Z0-9]*)\s?(?<args>[\s\S]*)");
+
+        /// <summary>
+        /// Patern to match 1 part multiple times:
+        ///  - Command name + command value[string/number]
+        /// </summary>
+        /// <remarks>
+        /// https://regex101.com/r/IoD56p/3
+        /// </remarks>
+        private static readonly Regex argsRegex = new Regex(@"-(?<var>[a-z][a-z0-9]*)(?: (?!\s*\-)(?>(?<num>\d*\.?\d+)(?:\s|$)|['""]?(?<str>(?<!['""])\S+|[^'""]+(?=['""] *\-)|.*(?=['""]))['""]?))?");
+
+        /// <summary>
+        /// Optional category of the command. Defaults to 'nitrox'.
+        /// </summary>
+        public string Category { get; }
+        public string Command { get; }
+
+        /// <summary>
+        /// The full command including parts that are default and not given directly as text as with <see cref="Value"/>.
+        /// </summary>
+        public string VerboseValue { get; }
+
+        /// <summary>
+        /// The command as it was received.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Instance of an object that has the command handler.
+        /// </summary>
+        public object Instance { get; set; }
+
+        /// <summary>
+        /// The method that handles the command.
+        /// </summary>
+        public MethodInfo Method { get; }
+
+        /// <summary>
+        /// The message supplied when <see cref="IsValid()"/> is false.
+        /// </summary>
+        public string StateMessage { get; }
+
+        /// <summary>
+        /// The state for why the command was invalid.
+        /// </summary>
+        public CommandStates State { get; private set; }
+
+        /// <summary>
+        /// Arguments as they were parsed from input.
+        /// </summary>
+        public ReadOnlyCollection<CommandArgInput> Arguments { get; }
+
+        public CommandCandidateEventArgs(string value)
+        {
+            Validate.NotNullOrWhitespace(value);
+
+            List<CommandArgInput> argList = new List<CommandArgInput>();
+            Arguments = new ReadOnlyCollection<CommandArgInput>(argList);
+            
+            // Text to command validation.
+            Value = value;
+            Match cmdMatch = cmdRegex.Match(value);
+            if (!cmdMatch.Success)
+            {
+                // This is not a command..
+                State = CommandStates.FAILEDPARSING;
+                return;
+            }
+
+            MatchCollection argMatches = null;
+            if (cmdMatch.Groups["args"].Success)
+            {
+                argMatches = argsRegex.Matches(cmdMatch.Groups["args"].Value);
+                if (argMatches.OfType<Match>().GroupBy(m => m.Groups["var"].Value.ToLowerInvariant()).Any(g => g.Count() > 1))
+                {
+                    State = CommandStates.DUPLICATEARGUMENTS;
+                    StateMessage = "Duplicate argument names found in command.";
+                    return;
+                }
+            }
+            
+            string cat = cmdMatch.Groups["cat"].Value;
+            Category = cat == "" ? NitroxConsole.DEFAULT_CATEGORY : cat.ToLowerInvariant();
+            Command = cmdMatch.Groups["cmd"].Value.ToLowerInvariant();
+            if (string.IsNullOrEmpty(cat))
+            {
+                VerboseValue = $"{Category} {Value}";
+            }
+
+            if (argMatches == null)
+            {
+                argMatches = argsRegex.Matches(cmdMatch.Groups["args"].Value);
+            }
+            foreach (Match argMatch in argMatches)
+            {
+                if (argMatch.Groups["num"].Success)
+                {
+                    argList.Add(new CommandArgInput(argMatch.Groups["var"].Value.ToLowerInvariant(), argMatch.Groups["num"].Value));
+                }
+                else if (argMatch.Groups["str"].Success)
+                {
+                    argList.Add(new CommandArgInput(argMatch.Groups["var"].Value.ToLowerInvariant(), argMatch.Groups["str"].Value));
+                }
+            }
+
+            // Textual command to handler validation.
+            Optional<CommandDatabase.CommandsStore> store = NitroxConsole.Main.GetStore(Category, Command);
+            Optional<CommandDatabase.CommandEntry> entry;
+            if (store.IsEmpty() || (entry = store.Get().GetHandler(Arguments)).IsEmpty())
+            {
+                State = CommandStates.NOCOMMANDHANDLER;
+                StateMessage = "No command handler for command.";
+                return;
+            }
+
+            Instance = entry.Get().Instance;
+            Method = entry.Get().Method;
+
+            State = CommandStates.VALID;
+        }
+
+        public bool IsValid() => State == CommandStates.VALID;
+
+        public enum CommandStates
+        {
+            /// <summary>
+            /// Set when the command is valid.
+            /// </summary>
+            VALID,
+
+            /// <summary>
+            /// Set when the command didn't match the expected command pattern.
+            /// </summary>
+            FAILEDPARSING,
+
+            /// <summary>
+            /// Set when the arguments of the given command have duplicates in them.
+            /// </summary>
+            DUPLICATEARGUMENTS,
+
+            /// <summary>
+            /// Set when a command format was parsed successfully but no handler was found. 
+            /// </summary>
+            NOCOMMANDHANDLER
+        }
+    }
+}
+

--- a/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
+++ b/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
@@ -26,8 +26,9 @@ namespace NitroxModel.NitroxConsole.Events
         private static readonly Regex cmdRegex = new Regex(@"^\s*(?<cat>(?>[a-zA-Z][a-zA-Z0-9]*))?\s?(?<cmd>[a-zA-Z][a-zA-Z0-9]*)\s?(?<args>[\s\S]*)");
 
         /// <summary>
-        /// Pattern to match 1 part multiple times:
-        ///  - Command name + command value[string/number]
+        /// Pattern to match 2 parts multiple times:
+        ///  - Argument name 
+        ///  - Argument value[string/number]
         /// </summary>
         /// <remarks>
         /// https://regex101.com/r/IoD56p/3

--- a/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
+++ b/NitroxModel/NitroxConsole/Events/CommandCandidateEventArgs.cs
@@ -26,7 +26,7 @@ namespace NitroxModel.NitroxConsole.Events
         private static readonly Regex cmdRegex = new Regex(@"^\s*(?<cat>(?>[a-zA-Z][a-zA-Z0-9]*))?\s?(?<cmd>[a-zA-Z][a-zA-Z0-9]*)\s?(?<args>[\s\S]*)");
 
         /// <summary>
-        /// Patern to match 1 part multiple times:
+        /// Pattern to match 1 part multiple times:
         ///  - Command name + command value[string/number]
         /// </summary>
         /// <remarks>

--- a/NitroxModel/NitroxConsole/Events/CommandEventArgs.cs
+++ b/NitroxModel/NitroxConsole/Events/CommandEventArgs.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole.Events
+{
+    public class CommandEventArgs : EventArgs
+    {
+        private string handlerMessage;
+
+        /// <summary>
+        /// Optional category of the command. Defaults to 'nitrox'.
+        /// </summary>
+        public string Category { get; }
+        public string Command { get; }
+
+        /// <summary>
+        /// The full command including parts that are default and not given directly as text as with <see cref="Value"/>.
+        /// </summary>
+        public string VerboseValue { get; }
+
+        /// <summary>
+        /// The command as it was received.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Instance of a class that has the command handler or null if method is on a static class.
+        /// </summary>
+        public object Instance { get; }
+
+        /// <summary>
+        /// The method that handles the command.
+        /// </summary>
+        public MethodInfo Method { get; }
+
+        /// <summary>
+        /// Arguments as they were parsed from input. Use <see cref="Get{T}"/> for more convenience.
+        /// </summary>
+        public ReadOnlyCollection<CommandArgInput> Arguments { get; }
+
+        public bool HasError { get; private set; }
+
+        public string HandlerMessage
+        {
+            get { return handlerMessage ?? ""; }
+            set { handlerMessage = value; }
+        }
+
+        public CommandEventArgs(CommandCandidateEventArgs candidate)
+        {
+            Validate.NotNull(candidate);
+
+            if (!candidate.IsValid())
+            {
+                throw new ArgumentException("Cannot convert an invalid candidate command into a command.", nameof(candidate));
+            }
+
+            Category = candidate.Category;
+            Command = candidate.Command;
+            Value = candidate.Value;
+            VerboseValue = candidate.VerboseValue;
+            Instance = candidate.Instance;
+            Method = candidate.Method;
+            Arguments = candidate.Arguments;
+        }
+
+        public Optional<T> Get<T>(string argName)
+        {
+            Validate.NotNullOrWhitespace(argName);
+
+            Optional<CommandDatabase.CommandsStore> store = NitroxConsole.Main.GetStore(Category, Command);
+            if (store.IsEmpty())
+            {
+                return Optional<T>.Empty();
+            }
+
+            Optional<CommandDatabase.CommandEntry> handler = store.Get().GetHandler(Arguments);
+            if (handler.IsEmpty())
+            {
+                return Optional<T>.Empty();
+            }
+
+            ReadOnlyCollection<NitroxCommandArgAttribute> handlerArgs = handler.Get().Args;
+
+            NitroxCommandArgAttribute cmdArg = handlerArgs.FirstOrDefault(hA => hA.HasName(argName));
+            if (cmdArg == null)
+            {
+                return Optional<T>.Empty();
+            }
+
+            return Optional<T>.OfNullable((T)Arguments.FirstOrDefault(a => cmdArg.HasName(a.Name))?.Value);
+        }
+
+        public void Error(string message = null)
+        {
+            HasError = true;
+            HandlerMessage = string.IsNullOrEmpty(message) ? HandlerMessage : message;
+        }
+    }
+}
+

--- a/NitroxModel/NitroxConsole/Events/ConsoleInputEventArgs.cs
+++ b/NitroxModel/NitroxConsole/Events/ConsoleInputEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole.Events
+{
+    public class ConsoleInputEventArgs : EventArgs
+    {
+        public string Input { get; }
+
+        public ConsoleInputEventArgs(string input)
+        {
+            Validate.NotNull(input); // User text can't be null so this shouldn't happen.
+
+            Input = input;
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/NitroxCommandArgAttribute.cs
+++ b/NitroxModel/NitroxConsole/NitroxCommandArgAttribute.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class NitroxCommandArgAttribute : Attribute, IEquatable<NitroxCommandArgAttribute>
+    {
+        private string[] aliases;
+        private string description;
+
+        public string Name { get; private set; }
+        public CommandArgInput.Type Type { get; }
+        public bool Required { get; private set; }
+
+        /// <summary>
+        ///     Aliases of the argument. Usage: [CommandCategory] [CommandName] -[alias1|alias2|alias3..]
+        /// </summary>
+        public string[] Aliases
+        {
+            get { return aliases; }
+            protected set { aliases = value.Where(v => v != null).Select(v => v.Trim().ToLowerInvariant()).ToArray(); }
+        }
+
+        /// <summary>
+        ///     Description of what the argument means for its command.
+        /// </summary>
+        public string Description
+        {
+            get { return description ?? ""; }
+            protected set { description = value; }
+        }
+
+        public NitroxCommandArgAttribute(string name, CommandArgInput.Type type, bool required, params string[] aliases) : this(name, type, required, aliases, null)
+        {
+
+        }
+
+        public NitroxCommandArgAttribute(string name, CommandArgInput.Type type, params string[] aliases) : this(name, type, false, aliases, null)
+        {
+
+        }
+
+        public NitroxCommandArgAttribute(string name, CommandArgInput.Type type, bool required, string[] aliases, string description)
+        {
+            Validate.NotNullOrEmpty(name);
+            aliases = aliases ?? new string[0];
+
+            if (aliases.Select(a => a.ToLowerInvariant()).Distinct().Count() != aliases.Length)
+            {
+                throw new ArgumentException("Aliases must be unique among each other.", nameof(aliases));
+            }
+
+            if (aliases.Any(v => string.IsNullOrEmpty(v) || v.All(c => c == ' ')))
+            {
+                throw new ArgumentException("Item in aliases must not be null or empty.", nameof(aliases));
+            }
+
+            if (aliases.Any(v => v.Equals(name, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new ArgumentException("Aliases must not contain a value that equals the name.", nameof(aliases));
+            }
+
+            Name = name.ToLowerInvariant();
+            Type = type;
+            Aliases = aliases;
+            Description = description;
+            Required = required;
+        }
+
+        public bool HasName(string argName)
+        {
+            if (argName == Name)
+            {
+                return true;
+            }
+
+            if (Array.IndexOf(Aliases, argName) >= 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool IsSameCommandArg(NitroxCommandArgAttribute other)
+        {
+            return Name == other.Name && Type == other.Type && Required == other.Required;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as NitroxCommandArgAttribute);
+        }
+
+        public bool Equals(NitroxCommandArgAttribute other)
+        {
+            return other != null &&
+                   base.Equals(other) &&
+                   EqualityComparer<string[]>.Default.Equals(aliases, other.aliases) &&
+                   description == other.description &&
+                   Name == other.Name &&
+                   Type == other.Type &&
+                   Required == other.Required &&
+                   EqualityComparer<string[]>.Default.Equals(Aliases, other.Aliases) &&
+                   Description == other.Description;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1691396427;
+            hashCode = hashCode * -1521134295 + base.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string[]>.Default.GetHashCode(aliases);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(description);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
+            hashCode = hashCode * -1521134295 + Type.GetHashCode();
+            hashCode = hashCode * -1521134295 + Required.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string[]>.Default.GetHashCode(Aliases);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Description);
+            return hashCode;
+        }
+
+        public static bool operator ==(NitroxCommandArgAttribute attribute1, NitroxCommandArgAttribute attribute2)
+        {
+            return EqualityComparer<NitroxCommandArgAttribute>.Default.Equals(attribute1, attribute2);
+        }
+
+        public static bool operator !=(NitroxCommandArgAttribute attribute1, NitroxCommandArgAttribute attribute2)
+        {
+            return !(attribute1 == attribute2);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Name)}: {Name}, {nameof(Type)}: {Type}, {nameof(Required)}: {Required}, {nameof(Aliases)}: {Aliases}";
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/NitroxCommandAttribute.cs
+++ b/NitroxModel/NitroxConsole/NitroxCommandAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using NitroxModel.Helper;
+
+namespace NitroxModel.NitroxConsole
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class NitroxCommandAttribute : Attribute
+    {
+        public CommandIdentity Identity { get; }
+
+        public NitroxCommandAttribute(string command) : this(NitroxConsole.DEFAULT_CATEGORY, command)
+        {
+        }
+
+        public NitroxCommandAttribute(string category, string command) : this(new CommandIdentity(category, command))
+        {
+        }
+
+        public NitroxCommandAttribute(CommandIdentity identity)
+        {
+            Validate.NotNull(identity);
+
+            Identity = identity;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Identity)}: {Identity}";
+        }
+    }
+}

--- a/NitroxModel/NitroxConsole/NitroxConsole.cs
+++ b/NitroxModel/NitroxConsole/NitroxConsole.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+using NitroxModel.NitroxConsole.Events;
+using NitroxModel.NitroxConsole.Typing;
+
+namespace NitroxModel.NitroxConsole
+{
+    public sealed class NitroxConsole
+    {
+        private static NitroxConsole main;
+        internal const string DEFAULT_CATEGORY = "nitrox";
+
+        public static NitroxConsole Main
+        {
+            get { return main = main ?? new NitroxConsole(); }
+            set { main = value; }
+        }
+
+        public event EventHandler<ConsoleInputEventArgs> InputReceived;
+        public event EventHandler<CommandEventArgs> CommandReceived;
+        public event EventHandler<CommandEventArgs> CommandProcessed;
+        public event EventHandler<CommandCandidateEventArgs> InvalidCommandReceived;
+        private CommandDatabase Database { get; }
+        private CommandHistory History { get; }
+
+        private NitroxConsole()
+        {
+            Database = new CommandDatabase();
+            History = new CommandHistory();
+        }
+
+        public void Submit(string input)
+        {
+            Validate.NotNullOrWhitespace(input);
+
+            CommandCandidateEventArgs candidate = new CommandCandidateEventArgs(input);
+            if (!candidate.IsValid())
+            {
+                switch (candidate.State)
+                {
+                    case CommandCandidateEventArgs.CommandStates.FAILEDPARSING:
+                        // Because the command failed to parse as a command it's being regarded as normal text.
+                        OnInputReceived(new ConsoleInputEventArgs(input));
+                        return;
+                }
+
+                OnInvalidCommandReceived(candidate);
+                return;
+            }
+
+            CommandEventArgs command = new CommandEventArgs(candidate);
+            OnCommandReceived(command); // Invokes the command handlers.
+            OnCommandProcessed(command);
+        }
+
+        public void AddCommand(Action<CommandEventArgs> args)
+        {
+            Database.Add(args);
+        }
+
+        [Obsolete("Prefer using AddCommand(Action) over directly adding commands.")]
+        public void AddCommandDirect(string category, string command, Action handler)
+        {
+            Database.Add(category, command, handler);
+        }
+
+        public Optional<CommandDatabase.CommandsStore> GetStore(CommandIdentity identity)
+        {
+            Validate.NotNull(identity);
+
+            return Database.GetStore(identity);
+        }
+
+        public Optional<CommandDatabase.CommandsStore> GetStore(string category, string command)
+        {
+            return GetStore(new CommandIdentity(category, command));
+        }
+
+        public CommandEventArgs HistoryPrevious()
+        {
+            return History.Previous();
+        }
+
+        public CommandEventArgs HistoryNext()
+        {
+            return History.Next();
+        }
+
+        public Optional<CommandEventArgs> HistoryMoveToNow()
+        {
+            return History.Now();
+        }
+
+        public void HistoryMoveAfterNow()
+        {
+            History.AfterNow();
+        }
+
+        private void OnCommandProcessed(CommandEventArgs e)
+        {
+            CommandProcessed?.Invoke(this, e);
+        }
+
+        private void OnCommandReceived(CommandEventArgs e)
+        {
+            if (!Database.TryInvokeHandler(e))
+            {
+                throw new InvalidOperationException($"Handler for command '{e.VerboseValue}' was found during parse but not on command receive.");
+            }
+            History.Add(e);
+            CommandReceived?.Invoke(this, e);
+        }
+
+        private void OnInvalidCommandReceived(CommandCandidateEventArgs e)
+        {
+            Log.Debug($"Invalid console command: {e.Value}, Error: {e.State}{(!string.IsNullOrEmpty(e.StateMessage) ? $", Message: {e.StateMessage}" : "")}");
+            InvalidCommandReceived?.Invoke(this, e);
+        }
+
+        private void OnInputReceived(ConsoleInputEventArgs e)
+        {
+            Log.Debug($"Console input received: {e.Input}");
+            InputReceived?.Invoke(this, e);
+        }
+    }
+}
+

--- a/NitroxModel/NitroxConsole/Typing/CommandHistory.cs
+++ b/NitroxModel/NitroxConsole/Typing/CommandHistory.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using NitroxModel.NitroxConsole.Events;
+
+namespace NitroxModel.NitroxConsole.Typing
+{
+    public class CommandHistory
+    {
+        private const int MAX_SIZE = 16;
+        private int cursor;
+        private readonly List<CommandEventArgs> data = new List<CommandEventArgs>();
+
+        public void Add(CommandEventArgs e)
+        {
+            Validate.NotNull(e);
+
+            // Adding duplicates of last history is not needed..
+            if (data.Any() && e.Value == data[data.Count - 1].Value)
+            {
+                return;
+            }
+
+            data.Add(e);
+            CleanDataToMaxSize();
+
+            // Reset history to now because new history was just written.
+            AfterNow();
+        }
+
+        public CommandEventArgs Previous()
+        {
+            DecCursor();
+            return data[cursor];
+        }
+
+        public CommandEventArgs Next()
+        {
+            IncCursor();
+            return data[cursor];
+        }
+
+        public Optional<CommandEventArgs> Now()
+        {
+            cursor = 0;
+            if (data.Any())
+            {
+                return Optional<CommandEventArgs>.Of(data[cursor]);
+            }
+            return Optional<CommandEventArgs>.Empty();
+        }
+
+        public void AfterNow()
+        {
+            cursor = data.Count;
+        }
+
+        private void IncCursor()
+        {
+            cursor++;
+            if (cursor >= data.Count)
+            {
+                cursor = data.Count - 1;
+            }
+        }
+
+        private void DecCursor()
+        {
+            cursor--;
+            if (cursor < 0)
+            {
+                cursor = 0;
+            }
+        }
+
+        private void CleanDataToMaxSize()
+        {
+            while (data.Count > MAX_SIZE)
+            {
+                data.RemoveAt(0);
+            }
+        }
+    }
+}

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -47,6 +47,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataStructures\CommandData.cs" />
+    <Compile Include="Helper\EventHelper.cs" />
+    <Compile Include="NitroxConsole\CommandArgInput.cs" />
+    <Compile Include="NitroxConsole\NitroxCommandArgAttribute.cs" />
+    <Compile Include="NitroxConsole\NitroxCommandAttribute.cs" />
+    <Compile Include="NitroxConsole\Events\CommandCandidateEventArgs.cs" />
+    <Compile Include="NitroxConsole\Events\CommandEventArgs.cs" />
+    <Compile Include="NitroxConsole\CommandIdentity.cs" />
+    <Compile Include="NitroxConsole\NitroxConsole.cs" />
+    <Compile Include="NitroxConsole\CommandDatabase.cs" />
+    <Compile Include="NitroxConsole\Events\ConsoleInputEventArgs.cs" />
     <Compile Include="DataStructures\AbsoluteEntityCell.cs" />
     <Compile Include="DataStructures\GameLogic\Creatures\Actions\SerializableCreatureAction.cs" />
     <Compile Include="DataStructures\GameLogic\Entity.cs" />
@@ -70,6 +81,7 @@
     <Compile Include="Helper\SteamFinder.cs" />
     <Compile Include="Helper\Validate.cs" />
     <Compile Include="Logger\Log.cs" />
+    <Compile Include="NitroxConsole\Typing\CommandHistory.cs" />
     <Compile Include="Packets\AnimationChangeEvent.cs" />
     <Compile Include="Packets\Authenticate.cs" />
     <Compile Include="Packets\BroadcastEscapePods.cs" />
@@ -130,6 +142,7 @@
     <Compile Include="Tcp\Connection.cs" />
     <Compile Include="Tcp\MessageBuffer.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -47,8 +47,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DataStructures\CommandData.cs" />
-    <Compile Include="Helper\EventHelper.cs" />
     <Compile Include="NitroxConsole\CommandArgInput.cs" />
     <Compile Include="NitroxConsole\NitroxCommandArgAttribute.cs" />
     <Compile Include="NitroxConsole\NitroxCommandAttribute.cs" />

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -55,8 +55,6 @@ namespace NitroxPatcher
             Multiplayer.OnBeforeMultiplayerStart += Apply;
             Log.Info("Completed patching using " + Assembly.GetExecutingAssembly().FullName);
 
-            Log.Info("Enabling developer console.");
-            DevConsole.disableConsole = false;
             Application.runInBackground = true;
             Log.Info($"Unity run in background set to {Application.runInBackground.ToString().ToUpperInvariant()}.");
 

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -56,6 +57,7 @@
     <Compile Include="Patches\BaseGhost_Finish_Patch.cs" />
     <Compile Include="Patches\BuilderTool_HandleInput_Patch.cs" />
     <Compile Include="Patches\Builder_TryPlace_Patch.cs" />
+    <Compile Include="Patches\Persistent\DevConsole_RegisterConsoleCommand_Patch.cs" />
     <Compile Include="Patches\StoryGoal_Execute_Patch.cs" />
     <Compile Include="Patches\Constructable_Construct_Patch.cs" />
     <Compile Include="Patches\Constructable_Deconstruct_Patch.cs" />

--- a/NitroxPatcher/Patches/Persistent/DevConsole_RegisterConsoleCommand_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/DevConsole_RegisterConsoleCommand_Patch.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Harmony;
+using NitroxModel.Logger;
+using NitroxModel.NitroxConsole;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Persistent
+{
+    public class DevConsole_RegisterConsoleCommand_Patch : NitroxPatch
+    {
+        public static readonly Type TARGET_CLASS = typeof(DevConsole);
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("RegisterConsoleCommand", BindingFlags.Public | BindingFlags.Static);
+
+        public static void Prefix(Component originator, string command, bool caseSensitiveArgs, bool combineArgs)
+        {
+#pragma warning disable 618
+            NitroxConsole.Main.AddCommandDirect("subnautica", command, () => DevConsole.SendConsoleCommand(command));
+#pragma warning restore 618
+        }
+
+        public override void Patch(HarmonyInstance harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxServer/Communication/TcpServer.cs
+++ b/NitroxServer/Communication/TcpServer.cs
@@ -27,7 +27,7 @@ namespace NitroxServer.Communication
             Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.Bind(localEndPoint);
             socket.Listen(4000);
-            socket.BeginAccept(new AsyncCallback(ClientAccepted), socket);
+            socket.BeginAccept(ClientAccepted, socket);
         }
 
         private void ClientAccepted(IAsyncResult ar)
@@ -37,9 +37,9 @@ namespace NitroxServer.Communication
             Socket socket = (Socket)ar.AsyncState;
 
             Connection connection = new Connection(socket.EndAccept(ar)); // TODO: Will this throw an error if timed correctly?
-            connection.BeginReceive(new AsyncCallback(DataReceived));
+            connection.BeginReceive(DataReceived);
 
-            socket.BeginAccept(new AsyncCallback(ClientAccepted), socket);
+            socket.BeginAccept(ClientAccepted, socket);
         }
 
         private void DataReceived(IAsyncResult ar)


### PR DESCRIPTION
## The main changes:
- Refactored Multiplayer init code into the Multiplayer.OnEnable/OnDisable methods.
- Added a NitroxConsole.
- Fixed that mplayer command didn't work.

## NitroxConsole
Press \` key (just like with DevConsole) to open the NitroxConsole.

### Command syntax
The NitroxConsole uses a git style command system where parameters can either be just names like `-f` or have values like `-name this_is_my_name`. A string can have spaces as long as it is surrounded by the `'` character like `find -player 'That strange player's name'`. 

Parameter values are matched as either `string` or `number` allowing for ints or floats.

mplayer command became: `mplayer -u NAMEHERE -i 127.0.0.1` (-i is optional)
`disconnect` is still `disconnect`.
`warpto` became `warpto -o ID`. -o for -other.

### The command categories
NitroxConsole defaults to 'nitrox' category of commands. To run subnautica commands enter it like so: `subnautica fps`. Giving no category (like `fps`) will run the command as `nitrox fps`. I plan to later let users change the category from the console UI as a dropdown.

### Adding commands
To add new commands define a method similar to the following. Note the attributes and the required parameter:
![image](https://user-images.githubusercontent.com/1107063/36067730-818adbc0-0ec3-11e8-8e96-2455d9c7c9f2.png)

**A command doesn't get registered automatically** and needs to be added with the `AddCommand` function. I opted for this because I want to later on disable commands on the fly based the game's state:
`NitroxConsole.Main.AddCommand(OnConsoleCommand);`

### How does it work?
After something is entered into the console: NitroxConsoleUI -> NitroxConsole.Submit() -> new CommandCandidateEventArgs(input) -> new CommandEventArgs(candidate) -> CommandReceived applicable handler invoked.

## Final thoughts
Even though this change is relatively transparent I hope the console will get used more often now that it is more powerful.

Future plans for improvement: adding auto-complete/command search.