### PR TITLE
Use warnings instead of errors for style violations.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,34 +45,34 @@ csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
 # Avoid `this.` when not necessary
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_property = false:error
-dotnet_style_qualification_for_method = false:error
-dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
 
 # Use language keywords instead of framework type names for type references
-dotnet_style_predefined_type_for_locals_parameters_members = true:error
-dotnet_style_predefined_type_for_member_access = true:error
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
 
 # Expression-level preferences
-dotnet_style_object_initializer = false:error
-dotnet_style_collection_initializer = true:error
+dotnet_style_object_initializer = false:warning
+dotnet_style_collection_initializer = true:warning
 dotnet_style_coalesce_expression = true:suggestion # Prefer a ?? b
-dotnet_style_null_propagation = false:error # Do not prefer foo?.bar
+dotnet_style_null_propagation = false:warning # Do not prefer foo?.bar
 
 # Implicit and explicity styles (disallow use of `var` - types have to be specified explicitly)
-csharp_style_var_for_built_in_types = false:error
-csharp_style_var_when_type_is_apparent = false:error
-csharp_style_var_elsewhere = false:error
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = false:warning
+csharp_style_var_elsewhere = false:warning
 
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:none
 
 # Null checking preferences
-csharp_style_conditional_delegate_call = false:error # Do not prefer foo?.Invoke(bar); over if (foo != null) { foo(bar); }, with all it's newlines.
+csharp_style_conditional_delegate_call = false:warning # Do not prefer foo?.Invoke(bar); over if (foo != null) { foo(bar); }, with all it's newlines.
 
 # Code block preferences
-csharp_prefer_braces = true:error # Wrap everything in braces.
+csharp_prefer_braces = true:warning # Wrap everything in braces.
 
 # Put `using System.` on top
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
After a while of using and evaluating it turns out the errors for style violations cause more confusion than they do good while debugging. All errors have been reduced to warnings, especially since the Harmony subproject violates a bunch of them. This may however make them harder to spot - I have not yet found a way to exclude Harmony from checking, except for compiling the project once and unloading it (this may however cause developers to miss potential updates in the future, as it stays unloaded on subsequent solution loads).

The "new" but highly skilled contributors do use/like C# features such as `var` and `?.` - I think we may want to (read: should) reconsider the current policy.

#### Sidenote
Visual Studio may properly read from this file. I checked my own `Tools > Options... > style` and all warnings are configured properly, though I still get errors on violations. If anyone has a solution (like clearing a cache somewhere), please hit me up.