### PR TITLE
Disable intro sequences in multiplayer

### DIFF
--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -42,6 +42,11 @@ namespace NitroxClient.MonoBehaviours
             }
         }
 
+        public bool IsMultiplayer()
+        {
+            return multiplayerSession.Client.IsConnected;
+        }
+
         public void ProcessPackets()
         {
             Queue<Packet> packets = packetReceiver.GetReceivedPackets();

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -70,6 +70,7 @@ namespace NitroxClient.MonoBehaviours
             InitializeLocalPlayerState();
             multiplayerSession.JoinSession();
             InitMonoBehaviours();
+            Utils.SetContinueMode(true);
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
         }
 

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Patches\Equipment_RemoveItem_Patch.cs" />
     <Compile Include="Patches\EscapePod_Awake_Patch.cs" />
     <Compile Include="Patches\Fabricator_OnCraftingBegin_Patch.cs" />
-	<Compile Include="Patches\FreezeTime_Begin_Patch.cs" />
+    <Compile Include="Patches\FreezeTime_Begin_Patch.cs" />
     <Compile Include="Patches\GameSettings_SerializeInputSettings_Patch.cs" />
     <Compile Include="Patches\ItemsContainer_NotifyAddItem_Patch.cs" />
     <Compile Include="Patches\ItemsContainer_NotifyRemoveItem_Patch.cs" />
@@ -88,6 +88,7 @@
     <Compile Include="Patches\NitroxPatch.cs" />
     <Compile Include="Patches\Openable_PlayOpenAnimation_Patch.cs" />
     <Compile Include="Patches\Persistent\CellManager_GetPrefabForSlot_Patch.cs" />
+    <Compile Include="Patches\Persistent\EscapePodFirstUseCinematicsController_Initialize_Patch.cs" />
     <Compile Include="Patches\Persistent\GameInput_Initialize_Patch.cs" />
     <Compile Include="Patches\Persistent\GameInput_SetupDefaultKeyboardBindings_Patch.cs" />
     <Compile Include="Patches\Pickupable_Drop_Patch.cs" />

--- a/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+using Harmony;
+using NitroxClient.MonoBehaviours;
+
+namespace NitroxPatcher.Patches.Persistent
+{
+    class EscapePodFirstUseCinematicsController_Initialize_Patch : NitroxPatch
+    {
+        public static readonly Type TARGET_CLASS = typeof(EscapePodFirstUseCinematicsController);
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static bool Prefix(EscapePodFirstUseCinematicsController __instance)
+        {
+            __instance.bottomCinematicTarget.gameObject.SetActive(true);
+            __instance.topCinematicTarget.gameObject.SetActive(true);
+
+            __instance.bottomFirstUseCinematicTarget.gameObject.SetActive(false);
+            __instance.topFirstUseCinematicTarget.gameObject.SetActive(false);
+
+            return !Multiplayer.Main.IsMultiplayer();
+        }
+
+        public override void Patch(HarmonyInstance harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}


### PR DESCRIPTION
Implements #122 

Introductory sequence is disabled in multiplayer, and first time escape pod exit cutscenes don't play in multiplayer either (and the creatures aren't spawned).

Intro and pod cutscenes play as normal in singleplayer.