### PR TITLE
Fixed movement not syncing properly

### DIFF
--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -17,6 +17,7 @@ namespace NitroxClient.GameLogic
         public Rigidbody RigidBody { get; }
         public ArmsController ArmsController { get; }
         public AnimationController AnimationController { get; }
+        public MovementSyncer MovementSyncer { get; }
 
         public string PlayerId => PlayerContext.PlayerId;
         public string PlayerName => PlayerContext.PlayerName;
@@ -30,6 +31,8 @@ namespace NitroxClient.GameLogic
         {
             Body = playerBody;
             PlayerContext = playerContext;
+
+            MovementSyncer = Body.AddComponent<MovementSyncer>();
 
             RigidBody = Body.AddComponent<Rigidbody>();
             RigidBody.useGravity = false;
@@ -78,8 +81,11 @@ namespace NitroxClient.GameLogic
             SetPilotingChair(null);
             SetSubRoot(subRoot);
 
-            RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
-            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovement.BROADCAST_INTERVAL);
+            //RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
+            //RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovement.BROADCAST_INTERVAL);
+
+            AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
+            MovementSyncer?.SetNewLocation(position, bodyRotation);
 
             AnimationController.AimingRotation = aimingRotation;
             AnimationController.UpdatePlayerAnimations = true;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -84,7 +84,7 @@ namespace NitroxClient.GameLogic
             //RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
             //RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovement.BROADCAST_INTERVAL);
 
-            AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
+            AnimationController.Velocity = velocity;
             MovementSyncer?.SetNewLocation(position, bodyRotation);
 
             AnimationController.AimingRotation = aimingRotation;

--- a/NitroxClient/MonoBehaviours/MovementSyncer.cs
+++ b/NitroxClient/MonoBehaviours/MovementSyncer.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours
+{
+    public class MovementSyncer : MonoBehaviour
+    {
+        public Vector3 NextPosition { get; private set; }
+        public Quaternion NextRotation { get; private set; }
+
+        public void SetNewLocation(Vector3 newPos, Quaternion newRot)
+        {
+            NextPosition = newPos;
+            NextRotation = newRot;
+        }
+
+        public void Update()
+        {
+            transform.position = Vector3.Lerp(transform.position, NextPosition, PlayerMovement.BROADCAST_INTERVAL);
+            transform.rotation = Quaternion.Lerp(transform.rotation, NextRotation, PlayerMovement.BROADCAST_INTERVAL);
+        }
+    }
+}

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -202,6 +202,7 @@
     <Compile Include="MonoBehaviours\Gui\MainMenu\MainMenuMods.cs" />
     <Compile Include="MonoBehaviours\Gui\MainMenu\MainMenuMultiplayerPanel.cs" />
     <Compile Include="MonoBehaviours\Gui\MainMenu\MainMenuNotification.cs" />
+    <Compile Include="MonoBehaviours\MovementSyncer.cs" />
     <Compile Include="MonoBehaviours\Multiplayer.cs" />
     <Compile Include="MonoBehaviours\MultiplayerCyclops.cs" />
     <Compile Include="MonoBehaviours\MultiplayerExosuit.cs" />


### PR DESCRIPTION
Nitrox syncs movement based on velocity, this causes lots of issues with player positions not being the same on all clients. With this, instead of relying on the velocity, the player positions are extrapolated from what the server sends us, making sure that all clients' players' have the same position.