### PR TITLE
Graceful server shutdown

### DIFF
--- a/NitroxServer/Communication/UdpServer.cs
+++ b/NitroxServer/Communication/UdpServer.cs
@@ -14,6 +14,8 @@ namespace NitroxServer.Communication
 {
     public class UdpServer
     {
+        private bool isStopped = true;
+
         private readonly PacketHandler packetHandler;
         private readonly PlayerManager playerManager;
         private readonly EntitySimulation entitySimulation;
@@ -36,6 +38,19 @@ namespace NitroxServer.Communication
 
             Thread thread = new Thread(Listen);
             thread.Start();
+
+            isStopped = false;
+        }
+
+        public void Stop()
+        {
+            isStopped = false;
+
+            thread.Stop();
+
+            //Close all connections here or let them timeout?
+
+            server.Stop();
         }
         
         private void Listen()

--- a/NitroxServer/Communication/UdpServer.cs
+++ b/NitroxServer/Communication/UdpServer.cs
@@ -44,18 +44,14 @@ namespace NitroxServer.Communication
 
         public void Stop()
         {
-            isStopped = false;
+            isStopped = true;
 
-            thread.Stop();
-
-            //Close all connections here or let them timeout?
-
-            server.Stop();
+            server.Shutdown("Shutting down server...");
         }
         
         private void Listen()
         {
-            while (true)
+            while (!isStopped)
             {
                 // Pause reading thread and wait for messages.
                 server.MessageReceivedEvent.WaitOne();

--- a/NitroxServer/Communication/UdpServer.cs
+++ b/NitroxServer/Communication/UdpServer.cs
@@ -21,6 +21,7 @@ namespace NitroxServer.Communication
         private readonly EntitySimulation entitySimulation;
         private readonly Dictionary<long, Connection> connectionsByRemoteIdentifier = new Dictionary<long, Connection>(); 
         private readonly NetServer server;
+        private readonly Thread thread;
 
         public UdpServer(PacketHandler packetHandler, PlayerManager playerManager, EntitySimulation entitySimulation)
         {
@@ -30,13 +31,12 @@ namespace NitroxServer.Communication
 
             NetPeerConfiguration config = BuildNetworkConfig();
             server = new NetServer(config);
+            thread = new Thread(Listen);
         }
 
         public void Start()
         {
             server.Start();
-
-            Thread thread = new Thread(Listen);
             thread.Start();
 
             isStopped = false;
@@ -47,6 +47,7 @@ namespace NitroxServer.Communication
             isStopped = true;
 
             server.Shutdown("Shutting down server...");
+            thread.Join(30000);
         }
         
         private void Listen()

--- a/NitroxServer/MainWindow.xaml
+++ b/NitroxServer/MainWindow.xaml
@@ -1,10 +1,10 @@
 ﻿<Window x:Class="NitroxServer.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Nitrox Server" Height="350" Width="525" Loaded="Window_Loaded">
+        Title="Nitrox Server" Height="350" Width="525" Loaded="Window_Loaded" Closing="Window_Closing">
     <Grid>
+
         <TabControl HorizontalAlignment="Stretch"  Margin="0,0,0,0" VerticalAlignment="Stretch" >
-           
             <TabItem Header="Log">
                 <Grid Background="#FFE5E5E5">
                     <TextBox HorizontalAlignment="Stretch" TextWrapping="Wrap" Name="LogTextBox" VerticalAlignment="Stretch" Foreground="White" Background="Black" HorizontalScrollBarVisibility="Auto" FontFamily="Console"/>

--- a/NitroxServer/MainWindow.xaml.cs
+++ b/NitroxServer/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -48,7 +49,7 @@ namespace NitroxServer
             }
         }
 
-        private void Window_Closing(object sender, RoutedEventArgs e)
+        private void Window_Closing(object sender, CancelEventArgs e)
         {
            _server.Stop();
         }

--- a/NitroxServer/MainWindow.xaml.cs
+++ b/NitroxServer/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace NitroxServer
     /// </summary>
     public partial class MainWindow : Window
     {
+        private Server _server;
         public static MainWindow Instance;
 
         public MainWindow()
@@ -38,13 +39,18 @@ namespace NitroxServer
 
             try
             {
-                Server _Server = new Server();
-                _Server.Start();
+                _server = new Server();
+                _server.Start();
             }
             catch (Exception ex)
             {
                 Log.Error(ex.ToString());
             }
+        }
+
+        private void Window_Closing(object sender, RoutedEventArgs e)
+        {
+           _server.Stop();
         }
 
         public void WriteLog(string data)

--- a/NitroxServer/MainWindow.xaml.cs
+++ b/NitroxServer/MainWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace NitroxServer
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
-            Task.Factory.StartNew(()=> _server.Stop()); //No something locks the UI and everything freezes, thus a task for now.
+            Task.Factory.StartNew(()=> _server.Stop()); //Something locks the UI and everything freezes, thus a task for now.
         }
 
         public void WriteLog(string data)

--- a/NitroxServer/MainWindow.xaml.cs
+++ b/NitroxServer/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -51,7 +52,7 @@ namespace NitroxServer
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
-           _server.Stop();
+            Task.Factory.StartNew(()=> _server.Stop()); //No something locks the UI and everything freezes, thus a task for now.
         }
 
         public void WriteLog(string data)

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -12,6 +12,7 @@ namespace NitroxServer
         private readonly UdpServer udpServer;
         private readonly WorldPersistence worldPersistence;
         private readonly PacketHandler packetHandler;
+        private readonly Timer saveTimer;
 
         public static Server Instance;
 
@@ -26,7 +27,16 @@ namespace NitroxServer
             worldPersistence = new WorldPersistence();
             world = worldPersistence.Load();
             packetHandler = new PacketHandler(world);
-            udpServer = new UdpServer(packetHandler, world.PlayerManager, world.EntitySimulation);            
+            udpServer = new UdpServer(packetHandler, world.PlayerManager, world.EntitySimulation);
+
+            //Maybe add settings for the interval?
+            saveTimer = new Timer();
+            saveTimer.Interval = 60000;
+            saveTimer.AutoReset = true;
+            saveTimer.Elapsed += delegate
+            {
+                Save();
+            };
         }
 
         public void Start()
@@ -38,22 +48,21 @@ namespace NitroxServer
 
         public void Stop()
         {
-            worldPersistence.Save(world);
+            Log.Info("Nitrox Server Stopping...");
+            DisablePeriodicSaving();
+            Save();
             udpServer.Stop();
             Log.Info("Nitrox Server Stopped");
         }
         
         private void EnablePeriodicSaving()
         {
-            Timer timer = new Timer();
-            timer.Elapsed += delegate
-            {
-                worldPersistence.Save(world);
-            };
-            timer.Interval = 60000;
-            timer.Enabled = true;
-            timer.AutoReset = true;
-            timer.Start();
+            saveTimer.Start();
+        }
+
+        private void DisablePeriodicSaving()
+        {
+            saveTimer.Stop();
         }
     }
 }

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -35,6 +35,13 @@ namespace NitroxServer
             Log.Info("Nitrox Server Started");
             EnablePeriodicSaving();
         }
+
+        public void Stop()
+        {
+            worldPersistence.Save(world);
+            udpServer.Stop();
+            Log.Info("Nitrox Server Stopped");
+        }
         
         private void EnablePeriodicSaving()
         {


### PR DESCRIPTION
I added a closing event on the main window to call the shutdown of the NetworkPeer and stop the listen thread. This solves the issue of the server still running when the window is closed.