### PR TITLE
Added a null check to SteamGameRegistryFinder

### DIFF
--- a/NitroxModel/Discovery/InstallationFinders/SteamGameRegistryFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/SteamGameRegistryFinder.cs
@@ -13,8 +13,14 @@ namespace NitroxModel.Discovery.InstallationFinders
 
         public Optional<string> FindGame(List<string> errors)
         {
-            string appsPath = Path.Combine((string)ReadRegistrySafe("Software\\Valve\\Steam", "SteamPath"), "steamapps");
+            string steamPath = (string)ReadRegistrySafe("Software\\Valve\\Steam", "SteamPath");
+            if (string.IsNullOrEmpty(steamPath))
+            {
+                errors.Add("It appears you don't have Steam installed.");
+                return Optional<string>.Empty();
+            }
 
+            string appsPath = Path.Combine(steamPath, "steamapps");
             if (File.Exists(Path.Combine(appsPath, $"appmanifest_{SUBNAUTICA_APP_ID}.acf")))
             {
                 return Optional<string>.Of(Path.Combine(Path.Combine(appsPath, "common"), SUBNAUTICA_GAME_NAME));


### PR DESCRIPTION
On linux and mono, the Steam registry lookup would return null which would crash the process.

```
[Nitrox] E: System.ArgumentNullException: Value cannot be null.
Parameter name: path1
  at System.IO.Path.Combine (System.String path1, System.String path2) [0x00003] in <3d1438d9da1e4fe0b915f807d1ba56bd>:0
  at NitroxModel.Discovery.InstallationFinders.SteamGameRegistryFinder.FindGame (System.Collections.Generic.List`1[T] errors) [0x0000f] in <484753777b4b4c1ea501fed6c0b21452>:0
```

This proposal ensures that this does not happen and that in the case that the Steam registry can not be found for whatever reason, the application continues to look for the game files from other sources.

I tested this and the server works on linux after this change, however there are still some unrelated issues (clients are unable to connect), but the server at least doesn't crash now.