### PR TITLE
Adding functions to silently log missing files.

### DIFF
--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -31,7 +31,6 @@ namespace NitroxServer.Serialization
             /**
            * Implemented check to see if index.txt in our Build18 folder exists.
            * If it does, warnings for this check are then silenced on the console, and instead, missing files are dumped to a missing.txt file
-           * For this purpose and as a precautionary measure, path.txt is used.
            * Warnings can be turned back on by the presence of a nosilence.txt file. Could be later implemented as an option. */
             if (WarnSilence)
             {
@@ -41,12 +40,21 @@ namespace NitroxServer.Serialization
             {
                 return;
             }
-            string pathTXTFile = Path.Combine(Path.GetFullPath("."), "path.txt");
-            Log.Info("Using " + pathTXTFile + " as path to path.txt");
-            string PathToSub = File.ReadAllText(pathTXTFile);
+            string PathToSub;
+            List<string> errors = new List<string>();
+            Optional<string> subnauticaPath = GameInstallationFinder.Instance.FindGame(errors);
+            if (subnauticaPath.IsEmpty())
+            {
+                string pathTXTFile = Path.Combine(Path.GetFullPath("."), "path.txt");
+                Log.Info("Using " + pathTXTFile + " as path to path.txt");
+                PathToSub = File.ReadAllText(pathTXTFile);
+            } else
+            {
+                PathToSub = subnauticaPath.Get();
+            }
             if (PathToSub.Length <= 1)
             {
-                Log.Warn("Empty Path.txt file! Can not continue executing method!");
+                Log.Warn("Empty Path.txt file or universal finder can't find game directory! Can not continue executing method!");
                 return;
             }
             string fileName = Path.Combine(PathToSub, "SNUnmanagedData\\Build18\\index.txt");
@@ -113,6 +121,7 @@ namespace NitroxServer.Serialization
 
         public void ParseFile(Int3 batchId, string pathPrefix, string suffix, List<EntitySpawnPoint> spawnPoints)
         {
+            CheckForIndexAndSilenceWarnings();
             List<string> errors = new List<string>();
             Optional<string> subnauticaPath = GameInstallationFinder.Instance.FindGame(errors);
 


### PR DESCRIPTION
The commit message i written for the commit on my fork of the git repo is slightly off. So i will try again here:

- Added 2 new functions. CheckForIndexAndSilenceWarnings() which checks for index.txt using path.txt and LogMissingFileName() which is a helper function for logging to missing.txt
- Added calls for these functions into ParseFile(). These calls only trigger when "WarnSilence" is set to true and a file that was attempted to be parsed does not exist. 

Main reason why i did this: On my run through of compiling the mod and testing if it works, i noticed that the console fills up with errors, but most or all of the mobs spawned correctly. This is just for cleaning up for that case. But this also should narrow down if someone has a corrupted path for the mod, as if the path was not set correctly when compiling the mod yet it still compiled correctly, the check should error out when checking for index.txt
By the way, i know that using a file to "set a variable" is a shortcut, but i have not delve into the source code more thoroughly. Planning to do that at a later time. This patch's main purpose is to silence unnecessary warnings while also still leaving some evidence of what went wrong.

Side note: Don't be alarmed if it shows that i replaced everything in the new version of the file, i uploaded the file manually instead of doing the whole "git commit" and "git push" routine. 