### PR TITLE
Update IpLogger.cs to better handle IPv6 detection

### DIFF
--- a/NitroxServer/IpLogger.cs
+++ b/NitroxServer/IpLogger.cs
@@ -59,6 +59,22 @@ namespace NitroxServer
                     using (WebClient client = new WebClient())
                     {
                         string externalIP = client.DownloadString("http://bot.whatismyipaddress.com"); // from https://stackoverflow.com/questions/3253701/get-public-external-ip-address answer by user_v
+                        if (externalIP.Contains(":"))
+                        {
+                          // If the externalIP we retrieved from bot.whatismyipaddress.com has colons in it, it's an IPV6 address.
+                          // If so, use backup source which more reliably retrieves the IPV4 address. This behavior can be
+                          // observed when connecting via Comcast, which supports allocation of both IPV4 and IPV6 addresses
+                          // simultaneously.
+                          // Basic idea came from: https://stackoverflow.com/a/7838551/1136388
+                          string ipPage = client.DownloadString("http://checkip.dyndns.org");
+                          int startIP = ipPage.IndexOf(": ") + 1;
+                          int endIP = ipPage.IndexOf("<", startIP);
+
+                          if (endIP - startIP > 0 && endIP > 0)
+                          {
+                            externalIP = ipPage.Substring(startIP, endIP - startIP);
+                          }
+                        }
                         Log.Info("If using port forwarding, use this IP: " + externalIP);
                     }
                 }


### PR DESCRIPTION
Update IPLogger.cs to better handle IPv6 and use redundant IP checking service

Some ISP's (like Comcast) allocate IPv4 and IPv6 IP Addresses, which can cause some IP Checking services to inconsistently post different IP address. The original ip address service being used, bot.whatismyipaddress.com was retrieving IPv6 Addresses for Comcast, but checkip.dyndns.org was correctly retrieving the IPv4 IP Address.

As can be seen on the following image, the IP Address retrieved was in IPV6 form, which is unhelpful (and I confirmed manually, Nitrox currently doesn't support IPv6 Routing):
![ipv6 on comcast isp with bot whatismyipaddress com](https://user-images.githubusercontent.com/6578056/50263905-575ada00-03d5-11e9-9d35-781a61e39902.PNG)

With the correction I made, the correct IPv4 address is being retrieved, by detecting that the first attempt at pulling a correctly formatted IPv4 address actually retrieved an IPv6 address, as seen in action here:
![ipv4 with fix](https://user-images.githubusercontent.com/6578056/50263969-a99bfb00-03d5-11e9-9898-8501bbf927a3.PNG)

Here's a third IP Checking utility which displays both my public and private IP addresses:
![ip address lookup with both ipv4 and ipv6](https://user-images.githubusercontent.com/6578056/50263982-bfa9bb80-03d5-11e9-94eb-435c559d94af.PNG)


It may not be a bad idea to replace the entire first IP check and just use the 2nd check, or maybe use an alternate URL, with better HTML-scraping logic to differentiate between IPv4 and IPv6, but I'm just posting this initial modification as a starting point to consider making further changes in the future.