### PR TITLE
Add basic error handling to ClientOnDownloadStringCompleted in IpLogger.cs

### DIFF
--- a/NitroxServer/IpLogger.cs
+++ b/NitroxServer/IpLogger.cs
@@ -75,14 +75,19 @@ namespace NitroxServer
 
             using (WebClient client = new WebClient())
             {
-                client.DownloadStringCompleted += ClientOnDownloadStringCompleted;
+                client.DownloadStringCompleted += ExternalIpStringDownloadCompleted;
                 client.DownloadStringAsync(new Uri("http://ipv4bot.whatismyipaddress.com/")); // from https://stackoverflow.com/questions/3253701/get-public-external-ip-address answer by user_v
             }
         }
 
-        private static void ClientOnDownloadStringCompleted(object sender, DownloadStringCompletedEventArgs e)
+        private static void ExternalIpStringDownloadCompleted(object sender, DownloadStringCompletedEventArgs e)
         {
-            Log.Info("If using port forwarding, use this IP: " + e.Result);
+            if (!e.Cancelled && e.Error == null)
+            {
+                Log.Info($"If using port forwarding, use this IP: {e.Result}");
+            }
+
+            Log.Warn("Could not get your external IP. You are on your own...");
         }
     }
 }


### PR DESCRIPTION
The Serverprocess did crash because the API used for getting the external IP is blocked on my network. 
Obviously the page could be offline and not reachable, so error handling is a must.