### PR TITLE
Fix for exception when throwing item

### DIFF
--- a/NitroxServer/GameLogic/Entities/EntityData.cs
+++ b/NitroxServer/GameLogic/Entities/EntityData.cs
@@ -67,7 +67,10 @@ namespace NitroxServer.GameLogic.Entities
             {
                 lock (globalRootEntitiesByGuid)
                 {
-                    globalRootEntitiesByGuid.Add(entity.Guid, entity);
+                    if (!globalRootEntitiesByGuid.ContainsKey(entity.Guid))
+                    {
+                        globalRootEntitiesByGuid.Add(entity.Guid, entity);
+                    }
                 }
             }
             else


### PR DESCRIPTION
fix catch exception when throwing an item ( key already exists in dict) no need to re add.

Needs to be tested across clients.