### PR TITLE
Patched CheckLoseTooth with hard-coded hardness values

### DIFF
--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Patches\Player_OnDestroy_Patch.cs" />
     <Compile Include="Patches\Player_Update_Patch.cs" />
     <Compile Include="Patches\uGUI_SignInput_OnDeselect_Patch.cs" />
+    <Compile Include="Patches\Stalker_CheckLoseTooth_Patch.cs" />
     <Compile Include="Patches\StoryGoal_Execute_Patch.cs" />
     <Compile Include="Patches\SubNameInput_OnColorChange_Patch.cs" />
     <Compile Include="Patches\SubNameInput_OnNameChange_Patch.cs" />

--- a/NitroxPatcher/Patches/Stalker_CheckLoseTooth_Patch.cs
+++ b/NitroxPatcher/Patches/Stalker_CheckLoseTooth_Patch.cs
@@ -1,0 +1,47 @@
+﻿using Harmony;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Helper;
+using NitroxModel.Core;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches
+{
+    public class Stalker_CheckLoseTooth_Patch : NitroxPatch
+    {
+        public static readonly Type TARGET_CLASS = typeof(Stalker);
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("CheckLoseTooth", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static bool Prefix(Stalker __instance, GameObject target)
+        {
+            float hardness = 0f;
+            TechType techType = CraftData.GetTechType(target);
+            LiveMixin liveMixin = target.GetComponent<LiveMixin>();
+            
+            if (techType == TechType.ScrapMetal || techType == TechType.Titanium
+             || techType == TechType.Seamoth || techType == TechType.Exosuit)
+            {
+                hardness = 0.3f; //15% probability
+            }
+            else if(liveMixin != null && liveMixin.IsAlive())
+            {
+                hardness = 0.1f; //5% probability
+            }
+
+            if (UnityEngine.Random.value < hardness && UnityEngine.Random.value < 0.5f)
+            {
+                __instance.ReflectionCall("LoseTooth");
+            }
+            return false;
+        }
+
+        public override void Patch(HarmonyInstance harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Stalker_CheckLoseTooth_Patch.cs
+++ b/NitroxPatcher/Patches/Stalker_CheckLoseTooth_Patch.cs
@@ -1,10 +1,5 @@
 ﻿using Harmony;
-using NitroxClient.GameLogic;
-using NitroxClient.GameLogic.Helper;
-using NitroxModel.Core;
-using NitroxModel.DataStructures;
 using NitroxModel.Helper;
-using NitroxModel.Logger;
 using System;
 using System.Reflection;
 using UnityEngine;


### PR DESCRIPTION
As-is, titanium, scrap, seamoth and prawn suit drop at 15%, live things drop at 5%. 