### PR TITLE
Add ability to enable/disable nitrox

### DIFF
--- a/NitroxInstallerActions/Patches/NitroxEntryPatch.cs
+++ b/NitroxInstallerActions/Patches/NitroxEntryPatch.cs
@@ -14,12 +14,12 @@ namespace InstallerActions.Patches
         public const string GAME_ASSEMBLY_MODIFIED_NAME = "Assembly-CSharp-Nitrox.dll";
 
         private const string NITROX_ENTRY_TYPE_NAME = "Main";
-        private const string NITROX_ENTRY_METHOD_NAME = "Execute";
+        private const string NITROX_ENTRY_METHOD_NAME = "ExecuteIfEnabled";
 
         private const string GAME_INPUT_TYPE_NAME = "GameInput";
         private const string GAME_INPUT_METHOD_NAME = "Awake";
 
-        private const string NITROX_EXECUTE_INSTRUCTION = "System.Void NitroxPatcher.Main::Execute()";
+        private const string NITROX_EXECUTE_INSTRUCTION = "System.Void NitroxPatcher.Main::ExecuteIfEnabled()";
 
         private readonly string subnauticaBasePath;
 

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -12,6 +12,7 @@ using NitroxModel.Logger;
 using NitroxPatcher.Patches;
 using NitroxReloader;
 using UnityEngine;
+using System.IO;
 
 namespace NitroxPatcher
 {
@@ -20,7 +21,22 @@ namespace NitroxPatcher
         private static NitroxPatch[] patches;
         private static readonly HarmonyInstance harmony = HarmonyInstance.Create("com.nitroxmod.harmony");
         private static bool isApplied;
-
+        public static void ExecuteIfEnabled()
+        {
+            if (File.Exists(@".\nitrox.enabled"))
+            {
+                string fileContents = File.ReadAllText(@".\nitrox.enabled").ToLower();
+                if (fileContents == "true")
+                {
+                    Execute();
+                }
+            }
+            else
+            {
+                File.WriteAllText(@".\nitrox.enabled", "true");
+                Execute();
+            }
+        }
         public static void Execute()
         {
             Log.SetLevel(Log.LogLevel.ConsoleInfo | Log.LogLevel.ConsoleDebug | Log.LogLevel.InGameMessages | Log.LogLevel.FileLog);


### PR DESCRIPTION
This allows users to disable nitrox without having to uninstall it. A file is created in the Subnautica directory called nitrox.enabled, and NitroxPatcher.Main.Execute() is only called if this file contains "true". Useful for occasions where nitrox might affect singleplayer experience, such as in #557 