### PR TITLE
Bug with server spawned objects not being movable

### DIFF
--- a/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
@@ -28,7 +28,12 @@ namespace NitroxClient.GameLogic.Spawning
             gameObject.transform.localRotation = entity.Rotation;
             GuidHelper.SetNewGuid(gameObject, entity.Guid);
             gameObject.SetActive(true);
-            gameObject.AddComponent<Rigidbody>();
+            // Makes movable objects movable... we can probably do this before the server sends the spawner packet?
+            if(gameObject.GetComponent<Rigidbody>() ==  null)
+            {
+                gameObject.AddComponent<Rigidbody>();
+            }
+
             LargeWorldEntity.Register(gameObject);
             CrafterLogic.NotifyCraftEnd(gameObject, entity.TechType);
 

--- a/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
@@ -28,6 +28,7 @@ namespace NitroxClient.GameLogic.Spawning
             gameObject.transform.localRotation = entity.Rotation;
             GuidHelper.SetNewGuid(gameObject, entity.Guid);
             gameObject.SetActive(true);
+            gameObject.AddComponent<Rigidbody>();
             LargeWorldEntity.Register(gameObject);
             CrafterLogic.NotifyCraftEnd(gameObject, entity.TechType);
 


### PR DESCRIPTION
This allows movable objects spawned by the server to be moved so players can progress further through the story ie boxes blocking the aurora entries.

Only movable objects can be moved... I'm not sure if this affects anything else game related i did some limited testing and seems to be fine.