### PR TITLE
fix FileParser to suport filename prefix

### DIFF
--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -37,18 +37,18 @@ namespace NitroxServer.Serialization
         {
             List<EntitySpawnPoint> spawnPoints = new List<EntitySpawnPoint>();
 
-            ParseFile(batchId, "", "loot-slots", spawnPoints);
-            ParseFile(batchId, "", "creature-slots", spawnPoints);
-            ParseFile(batchId, "Generated", "slots", spawnPoints);  // Very expensive to load
-            ParseFile(batchId, "", "loot", spawnPoints);
-            ParseFile(batchId, "", "creatures", spawnPoints);
-            ParseFile(batchId, "", "other", spawnPoints);
-            ParseFile(batchId, "CellsCache", "baked-", spawnPoints);
+            ParseFile(batchId, "", "", "-loot-slots", spawnPoints);
+            ParseFile(batchId, "", "", "-creature-slots", spawnPoints);
+            ParseFile(batchId, "Generated", "", "-slots", spawnPoints);  // Very expensive to load
+            ParseFile(batchId, "", "", "-loot", spawnPoints);
+            ParseFile(batchId, "", "", "-creatures", spawnPoints);
+            ParseFile(batchId, "", "", "-other", spawnPoints);
+            ParseFile(batchId, "CellsCache", "baked-", "", spawnPoints);
 
             return spawnPoints;
         }
 
-        public void ParseFile(Int3 batchId, string pathPrefix, string suffix, List<EntitySpawnPoint> spawnPoints)
+        public void ParseFile(Int3 batchId, string pathPrefix, string prefix, string suffix, List<EntitySpawnPoint> spawnPoints)
         {
             List<string> errors = new List<string>();
             Optional<string> subnauticaPath = GameInstallationFinder.Instance.FindGame(errors);
@@ -60,11 +60,11 @@ namespace NitroxServer.Serialization
             }
 
             string path = Path.Combine(subnauticaPath.Get(), "SNUnmanagedData", "Build18");
-            string fileName = Path.Combine(path, pathPrefix, "batch-cells-" + batchId.x + "-" + batchId.y + "-" + batchId.z + "-" + suffix + ".bin");
+            string fileName = Path.Combine(path, pathPrefix, prefix + "batch-cells-" + batchId.x + "-" + batchId.y + "-" + batchId.z + suffix + ".bin");
 
             if (!File.Exists(fileName))
             {
-                // Log.Debug("File not exists: " + fileName)
+                //Log.Debug("File does not exist: " + fileName);
                 return;
             }
 


### PR DESCRIPTION
The ParseFiles silently failed to find `batch-cells-1-16-8baked-.bin` . Modified so that it correctly creates `baked-batch-cells-*-*-*.bin`.

However, the parsing of baked- throws an exception.

```
[Nitrox] I: Parsing c:/program files (x86)/steam\steamapps\common\Subnautica\SNUnmanagedData\Build18\CellsCache\baked-batch-cells-12-18-11.bin
[Nitrox] I: Exception while processing packet:
[CellVisibilityChanged 
	| Added: 
		[AbsoluteEntityCell Position: 0,32,-352 BatchId: 12,19,10 CellId: 4,1,3 Level: 3 ]
		[...]
		[AbsoluteEntityCell Position: -160,-128,-352 BatchId: 11,18,10 CellId: 4,1,3 Level: 2 ]
	| Removed: 
		[AbsoluteEntityCell Position: -32,-128,-256 BatchId: 12,18,11 CellId: 3,1,1 Level: 1 ]
		[...]
		[AbsoluteEntityCell Position: -64,-128,-288 BatchId: 12,18,11 CellId: 2,1,0 Level: 1 ]
	| PlayerId: 1] ProtoBufNet.ProtoException: Invalid wire-type; this usually means you have over-written a file without truncating or setting the length; see http://stackoverflow.com/q/2152978/2335
```
