### PR TITLE
Replaced lidgren with litenetlib for connection lost issues

### DIFF
--- a/NitroxClient/Communication/UdpClient.cs
+++ b/NitroxClient/Communication/UdpClient.cs
@@ -1,21 +1,25 @@
-﻿using Lidgren.Network;
-using NitroxClient.Communication.Abstract;
+﻿using NitroxClient.Communication.Abstract;
 using NitroxClient.MonoBehaviours.Gui.InGame;
 using NitroxModel.Logger;
 using NitroxModel.Packets;
-using System.IO;
 using System.Threading;
+using LiteNetLib;
+using LiteNetLib.Utils;
+using NitroxClient.Communication.MultiplayerSession.ConnectionState;
 
 namespace NitroxClient.Communication
 {
     public class UdpClient : IClient
     {
         private readonly DeferringPacketReceiver packetReceiver;
-        private NetClient client;
         private AutoResetEvent connectedEvent = new AutoResetEvent(false);
 
+        private const string CONNECTION_KEY = "nitrox";
+        private NetManager client;
+        private NetPacketProcessor netPacketProcessor = new NetPacketProcessor();
+
         public bool IsConnected { get; set; } = false;
-        
+
         public UdpClient(DeferringPacketReceiver packetManager)
         {
             Log.Info("Initializing UdpClient...");
@@ -25,75 +29,59 @@ namespace NitroxClient.Communication
         public void Start(string ipAddress, int serverPort)
         {
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
-            
-            NetPeerConfiguration config = new NetPeerConfiguration("Nitrox");
-            config.AutoFlushSendQueue = true;
-            client = new NetClient(config);
-            client.RegisterReceivedCallback(new SendOrPostCallback(ReceivedMessage));
+
+            netPacketProcessor.SubscribeReusable<WrapperPacket, NetPeer>(OnPacketReceived);
+
+            EventBasedNetListener listener = new EventBasedNetListener();
+            listener.PeerConnectedEvent += Connected;
+            listener.PeerDisconnectedEvent += Disconnected;
+            listener.NetworkReceiveEvent += ReceivedNetworkData;
+
+            client = new NetManager(listener);
+            client.UpdateTime = 15;
+            client.UnsyncedEvents = true; //experimental feature, may need to replace with calls to client.PollEvents();
             client.Start();
-            client.Connect(ipAddress, serverPort);
+            client.Connect(ipAddress, serverPort, "nitrox");
+
             connectedEvent.WaitOne(2000);
             connectedEvent.Reset();
         }
 
-        public void ReceivedMessage(object peer)
+        private void ReceivedNetworkData(NetPeer peer, NetDataReader reader, DeliveryMethod deliveryMethod)
         {
-            NetIncomingMessage im;
-            while ((im = client.ReadMessage()) != null)
-            {
-                switch (im.MessageType)
-                {
-                    case NetIncomingMessageType.DebugMessage:
-                    case NetIncomingMessageType.ErrorMessage:
-                    case NetIncomingMessageType.WarningMessage:
-                    case NetIncomingMessageType.VerboseDebugMessage:
-                        string text = im.ReadString();
-                        Log.Info("Network message: " + text);
-                        break;
-                    case NetIncomingMessageType.StatusChanged:
-                        NetConnectionStatus status = (NetConnectionStatus)im.ReadByte();
-                        IsConnected = status == NetConnectionStatus.Connected;
-
-                        if(IsConnected)
-                        {
-                            connectedEvent.Set();
-                        }
-                        else if (LostConnectionModal.Instance)
-                        {
-                            LostConnectionModal.Instance.Show();
-                        }
-
-                        Log.Info("IsConnected status: " + IsConnected);
-                        break;
-                    case NetIncomingMessageType.Data:
-                        if (im.Data.Length > 0)
-                        {
-                            Packet packet = Packet.Deserialize(im.Data);
-                            packetReceiver.PacketReceived(packet);
-                        }
-                        break;
-                    default:
-                        Log.Info("Unhandled lidgren message type: " + im.MessageType + " " + im.LengthBytes + " bytes " + im.DeliveryMethod + "|" + im.SequenceChannel);
-                        break;
-                }
-                client.Recycle(im);
-            }
+            netPacketProcessor.ReadAllPackets(reader, peer);
         }
-        
+
+        private void OnPacketReceived(WrapperPacket wrapperPacket, NetPeer peer)
+        {
+            Packet packet = Packet.Deserialize(wrapperPacket.packetData);
+            packetReceiver.PacketReceived(packet);
+        }
+
+        private void Connected(NetPeer peer)
+        {
+            connectedEvent.Set();
+            IsConnected = true;
+            Log.Info("Connected to server");
+        }
+
+        private void Disconnected(NetPeer peer, DisconnectInfo disconnectInfo)
+        {
+            LostConnectionModal.Instance.Show();
+            IsConnected = false;
+            Log.Info("Disconnected from server");
+        }
+
         public void Send(Packet packet)
         {
-            byte[] bytes = packet.Serialize();
-
-            NetOutgoingMessage om = client.CreateMessage();
-            om.Write(bytes);
-
-            client.SendMessage(om, packet.DeliveryMethod, (int)packet.UdpChannel);
-            client.FlushSendQueue();
+            client.SendToAll(netPacketProcessor.Write(packet.toWrapperPacket()), packet.DeliveryMethod);
+            client.Flush();
         }
 
         public void Stop()
         {
-            client.Disconnect("");
+            IsConnected = false;
+            client.Stop();
         }
     }
 }

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -42,6 +42,10 @@
     <Reference Include="Autofac.Configuration, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.2.6.3.862\lib\NET35\Autofac.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\LiteNetLib.0.8.2-beta\lib\net35\LiteNetLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(SubnauticaManaged)\UnityEngine.dll</HintPath>
     </Reference>
@@ -268,10 +272,6 @@
     <Compile Include="Unity\Smoothing\SmoothVector.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\lidgren-network-gen3\Lidgren.Network\Lidgren.Network.csproj">
-      <Project>{69BEE16A-B6E7-4642-8081-3928B32455DF}</Project>
-      <Name>Lidgren.Network</Name>
-    </ProjectReference>
     <ProjectReference Include="..\NitroxModel\NitroxModel.csproj">
       <Project>{b16f4de7-21ad-4fef-955b-0a5a365fa4e3}</Project>
       <Name>NitroxModel</Name>

--- a/NitroxClient/packages.config
+++ b/NitroxClient/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.3.862" targetFramework="net35" />
+  <package id="LiteNetLib" version="0.8.2-beta" targetFramework="net35" />
 </packages>

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -42,6 +42,10 @@
     <Reference Include="Autofac.Configuration, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.2.6.3.862\lib\NET35\Autofac.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\LiteNetLib.0.8.2-beta\lib\net35\LiteNetLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net35-full\log4net.dll</HintPath>
       <Private>True</Private>
@@ -189,16 +193,11 @@
     <Compile Include="Packets\VehicleColorChange.cs" />
     <Compile Include="Packets\VehicleMovement.cs" />
     <Compile Include="Packets\VehicleNameChange.cs" />
+    <Compile Include="Packets\WrapperPacket.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\lidgren-network-gen3\Lidgren.Network\Lidgren.Network.csproj">
-      <Project>{69bee16a-b6e7-4642-8081-3928b32455df}</Project>
-      <Name>Lidgren.Network</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="path.txt">

--- a/NitroxModel/Packets/Movement.cs
+++ b/NitroxModel/Packets/Movement.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using UnityEngine;
-using Lidgren.Network;
+using LiteNetLib;
 
 namespace NitroxModel.Packets
 {
@@ -20,7 +20,7 @@ namespace NitroxModel.Packets
             Velocity = velocity;
             BodyRotation = bodyRotation;
             AimingRotation = aimingRotation;
-            DeliveryMethod = NetDeliveryMethod.UnreliableSequenced;
+            DeliveryMethod = DeliveryMethod.Sequenced;
             UdpChannel = UdpChannelId.PLAYER_MOVEMENT;
         }
 

--- a/NitroxModel/Packets/Packet.cs
+++ b/NitroxModel/Packets/Packet.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using LiteNetLib;
 using NitroxModel.DataStructures.Surrogates;
 using NitroxModel.Logger;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.DataStructures.GameLogic;
-using Lidgren.Network;
 using LZ4;
 
 namespace NitroxModel.Packets
@@ -19,7 +19,7 @@ namespace NitroxModel.Packets
         private static readonly SurrogateSelector surrogateSelector;
         private static readonly StreamingContext streamingContext;
         private static readonly BinaryFormatter Serializer;
-        
+
         static Packet()
         {
             surrogateSelector = new SurrogateSelector();
@@ -47,7 +47,7 @@ namespace NitroxModel.Packets
             Serializer = new BinaryFormatter(surrogateSelector, streamingContext);
         }
 
-        public NetDeliveryMethod DeliveryMethod { get; protected set; } = NetDeliveryMethod.ReliableOrdered;
+        public DeliveryMethod DeliveryMethod { get; protected set; } = DeliveryMethod.ReliableOrdered;
         public UdpChannelId UdpChannel { get; protected set; } = UdpChannelId.DEFAULT;
 
         public enum UdpChannelId
@@ -99,6 +99,11 @@ namespace NitroxModel.Packets
         public virtual Optional<AbsoluteEntityCell> GetDeferredCell()
         {
             return Optional<AbsoluteEntityCell>.Empty();
+        }
+
+        public WrapperPacket toWrapperPacket()
+        {
+            return new WrapperPacket(Serialize());
         }
     }
 }

--- a/NitroxModel/Packets/PlayerStats.cs
+++ b/NitroxModel/Packets/PlayerStats.cs
@@ -1,5 +1,5 @@
-﻿using Lidgren.Network;
-using System;
+﻿using System;
+using LiteNetLib;
 
 namespace NitroxModel.Packets
 {
@@ -21,7 +21,7 @@ namespace NitroxModel.Packets
             Health = health;
             Food = food;
             Water = water;
-            DeliveryMethod = NetDeliveryMethod.UnreliableSequenced;
+            DeliveryMethod = DeliveryMethod.Sequenced;
             UdpChannel = UdpChannelId.PLAYER_STATS;
         }
 

--- a/NitroxModel/Packets/VehicleMovement.cs
+++ b/NitroxModel/Packets/VehicleMovement.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using LiteNetLib;
 using NitroxModel.DataStructures.GameLogic;
-using Lidgren.Network;
 
 namespace NitroxModel.Packets
 {
@@ -12,7 +12,7 @@ namespace NitroxModel.Packets
         public VehicleMovement(ushort playerId, VehicleMovementData vehicle) : base(playerId, vehicle.Position, vehicle.Velocity, vehicle.Rotation, vehicle.Rotation)
         {
             Vehicle = vehicle;
-            DeliveryMethod = NetDeliveryMethod.UnreliableSequenced;
+            DeliveryMethod = DeliveryMethod.Sequenced;
             UdpChannel = UdpChannelId.VEHICLE_MOVEMENT;
         }
 

--- a/NitroxModel/Packets/WrapperPacket.cs
+++ b/NitroxModel/Packets/WrapperPacket.cs
@@ -1,0 +1,16 @@
+namespace NitroxModel.Packets
+{
+    public class WrapperPacket
+    {
+        public byte[] packetData { get; set; }
+
+        public WrapperPacket()
+        {
+        }
+
+        public WrapperPacket(byte[] packetData)
+        {
+            this.packetData = packetData;
+        }
+    }
+}

--- a/NitroxModel/packages.config
+++ b/NitroxModel/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.3.862" targetFramework="net35" />
+  <package id="LiteNetLib" version="0.8.2-beta" targetFramework="net35" />
   <package id="log4net" version="2.0.8" targetFramework="net35" />
 </packages>

--- a/NitroxServer/Communication/Connection.cs
+++ b/NitroxServer/Communication/Connection.cs
@@ -1,30 +1,27 @@
-﻿using NitroxModel.Logger;
+﻿using LiteNetLib;
+using LiteNetLib.Utils;
+using NitroxModel.Logger;
 using NitroxModel.Packets;
 using NitroxModel.Packets.Processors.Abstract;
-using Lidgren.Network;
 
 namespace NitroxServer.Communication
 {
     public class Connection : IProcessorContext
     {
-        private readonly NetServer server;
-        private readonly NetConnection connection;
+        private readonly NetPeer peer;
+        private readonly NetPacketProcessor netPacketProcessor = new NetPacketProcessor();
 
-        public Connection(NetServer server, NetConnection connection)
+        public Connection(NetPeer peer)
         {
-            this.server = server;
-            this.connection = connection;
+            this.peer = peer;
         }
-        
+
         public void SendPacket(Packet packet)
         {
-            if (connection.Status == NetConnectionStatus.Connected)
+            if (peer.ConnectionState == ConnectionState.Connected)
             {
-                byte[] packetData = packet.Serialize();
-                NetOutgoingMessage om = server.CreateMessage();
-                om.Write(packetData);
-
-                connection.SendMessage(om, packet.DeliveryMethod, (int)packet.UdpChannel);
+                peer.Send(netPacketProcessor.Write(packet.toWrapperPacket()), packet.DeliveryMethod);
+                peer.Flush();
             }
             else
             {

--- a/NitroxServer/Communication/UdpServer.cs
+++ b/NitroxServer/Communication/UdpServer.cs
@@ -3,17 +3,14 @@ using NitroxModel.Logger;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets;
 using NitroxServer.GameLogic;
-using Lidgren.Network;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
-using System.IO;
+using LiteNetLib;
+using LiteNetLib.Utils;
 using NitroxServer.GameLogic.Entities;
 using NitroxModel.DataStructures;
 using NitroxServer.ConfigParser;
-using NitroxServer.Communication.Packets.Processors.Abstract;
-using NitroxModel.Packets.Processors.Abstract;
-using NitroxModel.Core;
-using NitroxServer.Communication.Packets.Processors;
 
 namespace NitroxServer.Communication
 {
@@ -21,12 +18,17 @@ namespace NitroxServer.Communication
     {
         private bool isStopped = true;
 
+        private const int MAX_CLIENTS = ushort.MaxValue;
+        private const string CONNECTION_KEY = "nitrox";
+        private const int SERVER_PORT = 11000;
+
         private readonly PacketHandler packetHandler;
         private readonly EntitySimulation entitySimulation;
         private readonly Dictionary<long, Connection> connectionsByRemoteIdentifier = new Dictionary<long, Connection>();
         private readonly PlayerManager playerManager;
-        private readonly NetServer server;
-        private readonly Thread thread;
+        private readonly NetManager server;
+        private readonly EventBasedNetListener listener;
+        private readonly NetPacketProcessor netPacketProcessor = new NetPacketProcessor();
         private int portNumber, maxConn;
 
         public UdpServer(PacketHandler packetHandler, PlayerManager playerManager, EntitySimulation entitySimulation, ServerConfig serverConfig)
@@ -38,69 +40,103 @@ namespace NitroxServer.Communication
             portNumber = serverConfig.ServerPort;
             maxConn = serverConfig.MaxConnections;
 
-            NetPeerConfiguration config = BuildNetworkConfig();
-            server = new NetServer(config);
-            thread = new Thread(Listen);
+            netPacketProcessor.SubscribeReusable<WrapperPacket, NetPeer>(OnPacketReceived);
+
+            listener = new EventBasedNetListener();
+            server = new NetManager(listener);
         }
 
         public void Start()
         {
-            server.Start();
-            thread.Start();
-            
-            
+            listener.PeerConnectedEvent += PeerConnected;
+            listener.PeerDisconnectedEvent += PeerDisconnected;
+            listener.NetworkReceiveEvent += NetworkDataReceived;
+            listener.NetworkReceiveUnconnectedEvent += OnNetworkReceiveUnconnected;
+            listener.ConnectionRequestEvent += OnConnectionRequest;
+
+            server.DiscoveryEnabled = true;
+            server.UnconnectedMessagesEnabled = true;
+            server.UpdateTime = 15;
+            server.UnsyncedEvents = true;
+            server.Start(SERVER_PORT);
+
             isStopped = false;
+        }
+
+        private void PeerConnected(NetPeer peer)
+        {
+            Connection connection = new Connection(peer);
+
+            lock (connectionsByRemoteIdentifier)
+            {
+                connectionsByRemoteIdentifier[peer.Id] = connection;
+            }
+        }
+
+        private void PeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)
+        {
+            Connection connection = GetConnection(peer.Id);
+            Player player = playerManager.GetPlayer(connection);
+
+            if (player != null)
+            {
+                playerManager.PlayerDisconnected(connection);
+
+                Disconnect disconnect = new Disconnect(player.Id);
+                playerManager.SendPacketToAllPlayers(disconnect);
+
+                List<SimulatedEntity> revokedGuids = entitySimulation.CalculateSimulationChangesFromPlayerDisconnect(player);
+
+                if (revokedGuids.Count > 0)
+                {
+                    SimulationOwnershipChange ownershipChange = new SimulationOwnershipChange(revokedGuids);
+                    playerManager.SendPacketToAllPlayers(ownershipChange);
+                }
+            }
+        }
+
+        private void NetworkDataReceived(NetPeer peer, NetDataReader reader, DeliveryMethod deliveryMethod)
+        {
+            netPacketProcessor.ReadAllPackets(reader, peer);
+        }
+
+        private void OnPacketReceived(WrapperPacket wrapperPacket, NetPeer peer)
+        {
+            Connection connection = GetConnection(peer.Id);
+            Packet packet = Packet.Deserialize(wrapperPacket.packetData);
+
+            try
+            {
+                packetHandler.Process(packet, connection);
+            }
+            catch (Exception ex)
+            {
+                Log.Info("Exception while processing packet: " + packet + " " + ex);
+            }
+        }
+
+        public void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetDataReader reader, UnconnectedMessageType messageType)
+        {
+            int i = 0;
+        }
+
+        public void OnConnectionRequest(ConnectionRequest request)
+        {
+            if (server.PeersCount < MAX_CLIENTS)
+            {
+                request.AcceptIfKey("nitrox");
+            }
+            else
+            {
+                request.Reject();
+            }
         }
 
         public void Stop()
         {
             isStopped = true;
 
-            server.Shutdown("Shutting down server...");
-            thread.Join(30000);
-        }
-        
-        private void Listen()
-        {
-            while (!isStopped)
-            {
-                // Pause reading thread and wait for messages.
-                server.MessageReceivedEvent.WaitOne();
-
-                NetIncomingMessage im;
-                while ((im = server.ReadMessage()) != null)
-                {
-                    switch (im.MessageType)
-                    {
-                        case NetIncomingMessageType.DebugMessage:
-                        case NetIncomingMessageType.ErrorMessage:
-                        case NetIncomingMessageType.WarningMessage:
-                        case NetIncomingMessageType.VerboseDebugMessage:
-                            string message = im.ReadString();
-                            Log.Info("Networking: " + message);
-                            break;
-                        case NetIncomingMessageType.StatusChanged:
-                            NetConnectionStatus status = (NetConnectionStatus)im.ReadByte();
-
-                            string reason = im.ReadString();
-                            Log.Info("Identifier " + im.SenderConnection.RemoteUniqueIdentifier + " " + status + ": " + reason);
-
-                            ConnectionStatusChanged(status, im.SenderConnection);
-                            break;
-                        case NetIncomingMessageType.Data:
-                            if (im.Data.Length > 0)
-                            {
-                                Connection connection = GetConnection(im.SenderConnection.RemoteUniqueIdentifier);
-                                ProcessIncomingData(connection, im.Data);
-                            }
-                            break;
-                        default:
-                            Log.Info("Unhandled type: " + im.MessageType + " " + im.LengthBytes + " bytes " + im.DeliveryMethod + "|" + im.SequenceChannel);
-                            break;
-                    }
-                    server.Recycle(im);
-                }
-            }
+            server.Stop();
         }
 
         private void ProcessIncomingData(Connection connection, byte[] data)
@@ -114,40 +150,6 @@ namespace NitroxServer.Communication
             catch (Exception ex)
             {
                 Log.Info("Exception while processing packet: " + packet + " " + ex);
-            }            
-        }
-
-        private void ConnectionStatusChanged(NetConnectionStatus status, NetConnection networkConnection)
-        {
-            if (status == NetConnectionStatus.Connected)
-            {
-                Connection connection = new Connection(server, networkConnection);
-
-                lock (connectionsByRemoteIdentifier)
-                {
-                    connectionsByRemoteIdentifier[networkConnection.RemoteUniqueIdentifier] = connection;
-                }
-            }
-            else if (status == NetConnectionStatus.Disconnected)
-            {
-                Connection connection = GetConnection(networkConnection.RemoteUniqueIdentifier);
-                Player player = playerManager.GetPlayer(connection);
-
-                if (player != null)
-                {
-                    playerManager.PlayerDisconnected(connection);
-
-                    Disconnect disconnect = new Disconnect(player.Id);
-                    playerManager.SendPacketToAllPlayers(disconnect);
-
-                    List<SimulatedEntity> ownershipChanges = entitySimulation.CalculateSimulationChangesFromPlayerDisconnect(player);
-
-                    if (ownershipChanges.Count > 0)
-                    {
-                        SimulationOwnershipChange ownershipChange = new SimulationOwnershipChange(ownershipChanges);
-                        playerManager.SendPacketToAllPlayers(ownershipChange);
-                    }
-                }
             }
         }
 
@@ -161,16 +163,6 @@ namespace NitroxServer.Communication
             }
 
             return connection;
-        }
-
-        private NetPeerConfiguration BuildNetworkConfig()
-        {
-            NetPeerConfiguration config = new NetPeerConfiguration("Nitrox");
-            config.Port = portNumber;
-            config.MaximumConnections = maxConn;
-            config.AutoFlushSendQueue = true;
-
-            return config;
         }
     }
 }

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -52,6 +52,10 @@
     <Reference Include="Autofac.Configuration, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\LiteNetLib.0.8.2-beta\lib\net35\LiteNetLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="LitJson">
       <HintPath>$(SubnauticaManaged)\LitJson.dll</HintPath>
     </Reference>
@@ -185,10 +189,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\lidgren-network-gen3\Lidgren.Network\Lidgren.Network.csproj">
-      <Project>{69BEE16A-B6E7-4642-8081-3928B32455DF}</Project>
-      <Name>Lidgren.Network</Name>
-    </ProjectReference>
     <ProjectReference Include="..\NitroxModel\NitroxModel.csproj">
       <Project>{b16f4de7-21ad-4fef-955b-0a5a365fa4e3}</Project>
       <Name>NitroxModel</Name>

--- a/NitroxServer/packages.config
+++ b/NitroxServer/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.3.862" targetFramework="net40" />
+  <package id="LiteNetLib" version="0.8.2-beta" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Replaced lidgren as the networking library with litenetlib as an attempt to resolve the connection lost issue some people encounter, that were not based on port forwarding issues.
After some hours of testing, no random disconnects occurred in our testing environment, when before they occurred approximately every 0.5-5 minutes.
For absolute clarification, if this is the reason for the random disconnects, further testing with the community is required. 

On the technical side:
The code is loosely based on the networking branch.
I had to create a WrapperPacket for the litenetlib serializer because I did not want to refactor the whole packet handling. For better performance (maybe?) it would be possible to refactor the packet handling.