### PR TITLE
Sending server commands for day/night on DevConsole

### DIFF
--- a/NitroxModel/Packets/ServerCommand.cs
+++ b/NitroxModel/Packets/ServerCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NitroxModel.Logger;
 
 namespace NitroxModel.Packets
 {
@@ -10,6 +11,11 @@ namespace NitroxModel.Packets
         public ServerCommand(string[] args)
         {
             CmdArgs = args;
+        }
+
+        public ServerCommand(string cmd)
+        {
+            CmdArgs = cmd.Split(' ');
         }
     }
 }

--- a/NitroxPatcher/Patches/DayNightCycle_OnConsoleCommand_day_Patch.cs
+++ b/NitroxPatcher/Patches/DayNightCycle_OnConsoleCommand_day_Patch.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Harmony;
 using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.Core;
+using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches
 {
@@ -11,6 +14,8 @@ namespace NitroxPatcher.Patches
 
         public static bool Prefix()
         {
+            IPacketSender packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
+            packetSender.Send(new ServerCommand("day"));
             return false;
         }
 

--- a/NitroxPatcher/Patches/DayNightCycle_OnConsoleCommand_night_Patch.cs
+++ b/NitroxPatcher/Patches/DayNightCycle_OnConsoleCommand_night_Patch.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Harmony;
 using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.Core;
+using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches
 {
@@ -11,6 +14,8 @@ namespace NitroxPatcher.Patches
 
         public static bool Prefix()
         {
+            IPacketSender packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
+            packetSender.Send(new ServerCommand("night"));
             return false;
         }
 


### PR DESCRIPTION
As requested in #645 the day/night commands from the DevConsole now send the ServerCommand packet.