### PR TITLE
Add basic fire extinguisher syncing

### DIFF
--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -74,6 +74,7 @@ namespace NitroxClient
             containerBuilder.RegisterType<SeamothModulesEvent>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<EscapePodManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<Debugger>().InstancePerLifetimeScope();
+            containerBuilder.RegisterType<FireManager>().InstancePerLifetimeScope();
         }
 
         private void RegisterPacketProcessors(ContainerBuilder containerBuilder)

--- a/NitroxClient/Communication/Packets/Processors/FireDouseProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FireDouseProcessor.cs
@@ -1,0 +1,57 @@
+﻿using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors
+{
+    public class FireDouseProcessor : ClientPacketProcessor<FireDouse>
+    {
+        private readonly IPacketSender packetSender;
+
+        public FireDouseProcessor(IPacketSender packetSender)
+        {
+            this.packetSender = packetSender;
+        }
+
+        public override void Process(FireDouse packet)
+        {
+            Optional<Fire> fire = getNearestFire(packet.FirePosition);
+            if (fire.IsPresent())
+            {
+                fire.Get().Douse(packet.DouseAmount);
+                if (packet.Extinguished)
+                {
+                    fire.Get().ReflectionCall("Extinguished");
+                }
+            }
+        }
+
+        private Optional<Fire> getNearestFire(Vector3 position)
+        {
+            Collider[] colliders = Physics.OverlapSphere(position, 1f);
+            Optional<Fire> closestFire = Optional<Fire>.Empty();
+            float closestFireDistance = -1;
+            foreach(Collider col in colliders)
+            {
+                Fire fire = col.gameObject.GetComponent<Fire>();
+                if (fire)
+                {
+                    float dist = (position - fire.transform.position).sqrMagnitude;
+                    if(closestFireDistance == -1 || dist < closestFireDistance)
+                    {
+                        closestFireDistance = dist;
+                        closestFire = Optional<Fire>.Of(fire);
+                    }
+                }
+            }
+            return closestFire;
+        }
+    }
+}

--- a/NitroxClient/GameLogic/FireManager.cs
+++ b/NitroxClient/GameLogic/FireManager.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Timers;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic
+{
+    public class FireManager
+    {
+        private const float THRESHOLD = 3f; // Limits the rate at which packets are sent
+ 
+        Dictionary<Fire, float> queue = new Dictionary<Fire, float>();
+        
+        private readonly IPacketSender packetSender;
+
+        public FireManager(IPacketSender packetSender)
+        {
+            this.packetSender = packetSender;
+        }
+
+        public void UpdateFire(Fire fire, float douseDelta)
+        {
+            float douseAmount = 0;
+            queue.TryGetValue(fire, out douseAmount);
+            float newDouse = douseAmount + douseDelta;
+            bool extinguished = (bool)fire.ReflectionGet("isExtinguished");
+
+            if(newDouse >= THRESHOLD || extinguished)
+            {
+                packetSender.Send(new FireDouse(fire.transform.position, newDouse, extinguished));
+                queue.Remove(fire);
+            }
+            else
+            {
+                queue[fire] = newDouse;
+            }
+        }
+    }
+}

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Communication\Abstract\IPacketSender.cs" />
     <Compile Include="Communication\Packets\Processors\EscapePodRepairProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EscapePodRadioRepairProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\FireDouseProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\SubRootChangedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\SceneDebuggerChangeProcessor.cs" />
     <Compile Include="Communication\DeferringPacketReceiver.cs" />
@@ -154,6 +155,7 @@
     <Compile Include="Debuggers\BaseDebugger.cs" />
     <Compile Include="Debuggers\NetworkDebugger.cs" />
     <Compile Include="Debuggers\SceneDebugger.cs" />
+    <Compile Include="GameLogic\FireManager.cs" />
     <Compile Include="MonoBehaviours\DiscordRP\DiscordController.cs" />
     <Compile Include="MonoBehaviours\DiscordRP\DiscordRpc.cs" />
     <Compile Include="GameLogic\AI.cs" />

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Packets\BedEnter.cs" />
     <Compile Include="Packets\EscapePodRadioRepair.cs" />
     <Compile Include="Packets\EscapePodRepair.cs" />
+    <Compile Include="Packets\FireDouse.cs" />
     <Compile Include="Packets\SubRootChanged.cs" />
     <Compile Include="Packets\PlayerKicked.cs" />
     <Compile Include="Packets\VehicleChildUpdate.cs" />

--- a/NitroxModel/Packets/FireDouse.cs
+++ b/NitroxModel/Packets/FireDouse.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnityEngine;
+
+namespace NitroxModel.Packets
+{
+    [Serializable]
+    public class FireDouse : Packet
+    {
+        public Vector3 FirePosition { get; }
+        public float DouseAmount { get; }
+        public bool Extinguished { get; }
+
+        public FireDouse(Vector3 firePosition, float douseAmount, bool extinguished)
+        {
+            FirePosition = firePosition;
+            DouseAmount = douseAmount;
+            Extinguished = extinguished;
+        }
+
+        public override string ToString()
+        {
+            return "[FireDouse - FirePosition: " + FirePosition + " DouseAmount: " + DouseAmount + " Extinguished: " + Extinguished + "]";
+        }
+    }
+}

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Patches\DayNightCycle_OnConsoleCommand_night_Patch.cs" />
     <Compile Include="Patches\DevConsole_Update_Patch.cs" />
     <Compile Include="Patches\EscapePod_OnRepair_Patch.cs" />
+    <Compile Include="Patches\FireExtinguisher_UseExtinguisher_Patch.cs" />
     <Compile Include="Patches\IngameMenu_QuitGame_Patch.cs" />
     <Compile Include="Patches\Inventory_OnApplicationQuit_Patch.cs" />
     <Compile Include="Patches\Persistent\PAXTerrainController_LoadAsync_Patch.cs" />

--- a/NitroxPatcher/Patches/FireExtinguisher_UseExtinguisher_Patch.cs
+++ b/NitroxPatcher/Patches/FireExtinguisher_UseExtinguisher_Patch.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+using Harmony;
+using NitroxClient.GameLogic;
+using NitroxModel.Core;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches
+{
+    public class FireExtinguisher_UseExtinguisher_Patch : NitroxPatch
+    {
+        public static readonly Type TARGET_CLASS = typeof(FireExtinguisher);
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("UseExtinguisher", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static void Postfix(FireExtinguisher __instance, float douseAmount, float expendAmount)
+        {
+            Fire fire = (Fire)__instance.ReflectionGet("fireTarget");
+            if (fire)
+            {
+                NitroxServiceLocator.LocateService<FireManager>().UpdateFire(fire, douseAmount);
+            }
+        }
+
+        public override void Patch(HarmonyInstance harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}


### PR DESCRIPTION
Basic fire douse/extinguish syncing to nearby players w/ packet rate limiting. 

This surely can be improved over time:
- Player must have the fire streamed in in order to see the effects
- Fire position is used instead of GUID as they're not synced (as far as I know). Fires don't move so this should be fine for most cases, especially those spawned as part of the map. Tested on Aurora.

Updating this to a GUID-based fire resolution would be trivial if that sort of system were in place.