### PR TITLE
Set explosion to 3.1 days, quickpatch to _disable_ client side aurora story timers

### DIFF
--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Patches\LargeWorldStreamer_Deinitialize.cs" />
     <Compile Include="Patches\Player_SetCurrentSub_Patch.cs" />
     <Compile Include="Patches\Radio_OnRepair_Patch.cs" />
+    <Compile Include="Patches\CrashedShipExploder_SetExplodeTime_Patch.cs" />
     <Compile Include="Patches\VehicleDockingBay_DockVehicle_Patch.cs" />
     <Compile Include="Patches\Vehicle_OnHandClick_Patch.cs" />
     <Compile Include="Patches\PilotingChair_OnPlayerDeath_Patch.cs" />

--- a/NitroxPatcher/Patches/CrashedShipExploder_SetExplodeTime_Patch.cs
+++ b/NitroxPatcher/Patches/CrashedShipExploder_SetExplodeTime_Patch.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using Harmony;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.Core;
+using NitroxModel.Packets;
+using Story;
+
+namespace NitroxPatcher.Patches
+{
+    public class CrashedShipExploder_SetExplodeTime_Patch : NitroxPatch
+    {
+        public static readonly Type TARGET_CLASS = typeof(CrashedShipExploder);
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SetExplodeTime", BindingFlags.NonPublic | BindingFlags.Instance);
+
+
+        //TODO instead of disabling UPdate, which we need for actually eploding the ship
+        //because we actually send a packet to trigger the explosion and this packet sets the timeMonitor of crashedShipExploder to -25f
+        //(see StoryEventHandler ExplodeAurora)
+        //when the whole exploding routine starts, we shuold do something else
+        //e.g. disable local timeToStartWarning and/or timeToStartCountdown or sync it with servers'
+
+        //set timeToStartCountdown and timeToStartWarning to an bigger value than what the server will have
+        //so that the server explodes it first and overrides this value. See StoryEventHandler.ExplodeAurora
+        public static void Postfix(CrashedShipExploder __instance)
+        {
+            __instance.timeToStartCountdown = 5 * 1200f * 1000f;
+            __instance.timeToStartWarning = __instance.timeToStartCountdown - 1f;
+        }
+
+        public override void Patch(HarmonyInstance harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -18,7 +18,7 @@ namespace NitroxServer.GameLogic
         {
             // eventually this should be on a better timer so it can be saved, paused, etc
             Log.Debug("Event Triggerer started!");
-            double auroraTimer = RandomNumber(2.3d, 4d) * 1200d * 1000d; //Time.deltaTime returns seconds so we need to multiply 1000
+            double auroraTimer = 3.1 * 1200d * 1000d; //Time.deltaTime returns seconds so we need to multiply 1000
             CreateTimer(auroraTimer * 0.2d, StoryEventType.PDA, "Story_AuroraWarning1");
             CreateTimer(auroraTimer * 0.5d, StoryEventType.PDA, "Story_AuroraWarning2");
             CreateTimer(auroraTimer * 0.8d, StoryEventType.PDA, "Story_AuroraWarning3");


### PR DESCRIPTION

The client CrashedShipExploder uses a timeMonitor that is Updated at Update. I've set a Patch that sets the timers to a greater number than the server does so that the later triggers it first and overrites those values.

A better approach is to actually disable the timeMonitor time update or the CrashedShipExploder Update altogether and re-activate it the moment the server requests the aurora explosion.

this PR should solve #499 #626 #678 