### PR TITLE
Fix issue with discord-rpc.dll version is missing / cannot be determined

### DIFF
--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -35,8 +35,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dnlib">
-      <HintPath>..\packages\dnlib.1.6.1\lib\dnlib.dll</HintPath>
+    <Reference Include="dnlib, Version=3.1.0.0, Culture=neutral, PublicKeyToken=50e96378b6e77999, processorArchitecture=MSIL">
+      <HintPath>..\packages\dnlib.3.1.0\lib\net461\dnlib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -85,6 +85,7 @@
     <None Include="app.manifest">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/NitroxLauncher/packages.config
+++ b/NitroxLauncher/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="dnlib" version="3.1.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I really like the new Launcher, but i had some issues with it: There was always an BadImageFormat Exception with the **discord-rpc.dll**. It seems that this dll is missing some version info, so AssemblyName.GetAssemblyName will fail here when trying to get the version.

This PR adds a workaround for that.