### PR TITLE
Add default Constructor for serialization for ItemEquipment

### DIFF
--- a/NitroxModel/DataStructures/GameLogic/InteractiveChildObjectIdentifier.cs
+++ b/NitroxModel/DataStructures/GameLogic/InteractiveChildObjectIdentifier.cs
@@ -8,6 +8,11 @@ namespace NitroxModel.DataStructures.GameLogic
         public string Guid { get; }
         public string GameObjectNamePath { get; }
 
+        public InteractiveChildObjectIdentifier()
+        {
+            // Default Constructor for serialization
+        }
+
         public InteractiveChildObjectIdentifier(string guid, string gameObjectNamePath)
         {
             Guid = guid;

--- a/NitroxModel/DataStructures/GameLogic/ItemEquipment.cs
+++ b/NitroxModel/DataStructures/GameLogic/ItemEquipment.cs
@@ -13,6 +13,11 @@ namespace NitroxModel.DataStructures.GameLogic
         [ProtoMember(2)]
         public TechType TechType { get; }
 
+        public EquippedItemData()
+        {
+            // Default Constructor for serialization
+        }
+
         public EquippedItemData(string containerGuid, string guid, byte[] serializedData, string slot, TechType techType) : base(containerGuid, guid, serializedData)
         {
             Slot = slot;


### PR DESCRIPTION
Otherwise loading a save game where the player has equipped items will fail with:

``` [21:09:26 INFO]: Could not load world: ProtoBufNet.ProtoException: No parameterless constructor found for NitroxModel.DataStructures.GameLogic.EquippedItemData ```