### PR TITLE
Stabilized Network Communication

### DIFF
--- a/NitroxClient/Communication/NetworkingLayer/Lidgren/LidgrenClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/Lidgren/LidgrenClient.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections.Generic;
 using System.Threading;
 using Lidgren.Network;
 using NitroxClient.Communication.Abstract;
@@ -16,6 +17,13 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
         private NetClient client;
         private AutoResetEvent connectedEvent = new AutoResetEvent(false);
         private readonly DeferringPacketReceiver packetReceiver;
+
+        private long incomingSequence = 0;
+        private long outgoingSequence = 0;
+        private int packetSentCacheCount = 100;
+        private List<Packet> packetSentCache = new List<Packet>();
+        private List<Packet> packetPreReceivedCache = new List<Packet>();
+        private Packet latestSkippedPackageCausedOfResendRequests = null;
 
         public LidgrenClient()
         {
@@ -40,6 +48,36 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
 
         public void Send(Packet packet)
         {
+            outgoingSequence++;
+            packet.Sequence = outgoingSequence;
+            packetSentCache.Add(packet);
+            if (packetSentCache.Count > packetSentCacheCount)
+            {
+                packetSentCache.RemoveAt(0);
+            }
+            SendPreparedPacket(packet);
+        }
+
+        private void ResendPackage(long sequence)
+        {
+            if (packetSentCache.Exists(packet => packet.Sequence == sequence))
+            {
+                Packet packetToResend = packetSentCache.Find(packet => packet.Sequence == sequence);
+                SendPreparedPacket(packetToResend);
+            }
+            else
+            {
+                SendPreparedPacket(new PacketResendRequest(sequence * -1));
+            }
+        }
+
+        private void RequestResendPackage(int sequence)
+        {
+            SendPreparedPacket(new PacketResendRequest(sequence));
+        }
+
+        private void SendPreparedPacket(Packet packet)
+        {
             byte[] bytes = packet.Serialize();
 
             NetOutgoingMessage om = client.CreateMessage();
@@ -53,8 +91,13 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
         {
             client.UnregisterReceivedCallback(ReceivedMessage);
             client.Disconnect("");
+            packetSentCache.Clear();
+            packetPreReceivedCache.Clear();
+            latestSkippedPackageCausedOfResendRequests = null;
+            incomingSequence = 0;
+            outgoingSequence = 0;
         }
-
+    
         public void ReceivedMessage(object peer)
         {
             NetIncomingMessage im;
@@ -77,7 +120,7 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
                         {
                             connectedEvent.Set();
                         }
-                        else if (LostConnectionModal.Instance)
+                        else if (LostConnectionModal.Instance != null)
                         {
                             LostConnectionModal.Instance.Show();
                         }
@@ -88,7 +131,70 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
                         if (im.Data.Length > 0)
                         {
                             Packet packet = Packet.Deserialize(im.Data);
-                            packetReceiver.PacketReceived(packet);
+
+                            if (packet is PacketResendRequest)
+                            {
+                                if (((PacketResendRequest)packet).Sequence >= 0)
+                                {
+                                    ResendPackage(((PacketResendRequest)packet).Sequence);
+                                }
+                                else
+                                {
+                                    //Incoming PacketResendRequest was a Notification from Sender that the RequestedPackage 
+                                    //was not found in SentCache of Sender.
+                                    long _sequenceToRemove = ((PacketResendRequest)packet).Sequence * -1;
+
+#if TRACE && PACKET
+                                    NitroxModel.Logger.Log.Info("Connection: Received info for unresendable Package: " + _sequenceToRemove + '/' + incomingSequence + ' ' + packet.GetType().ToString());
+#endif
+
+                                    if (_sequenceToRemove <= incomingSequence)
+                                    {
+                                        //already processed, incoming is a duplicate of an old resend request
+                                    }
+                                    else
+                                    {
+                                        //ErrorHandling from this point on in later Version
+                                        //For now, skip requesting resends for this sequence number > desynct state from here on 
+                                        
+                                        //only skip for one package if this is the next in the order, for all higher ones let it untouched
+                                        if (incomingSequence + 1 == _sequenceToRemove)
+                                        {
+                                            incomingSequence++;
+                                        }
+
+                                        //try to go on with all other preCached received Packages
+                                        if (latestSkippedPackageCausedOfResendRequests != null)
+                                        {
+                                            List<Packet> packetsToProcess = SyncReceiveOrder(latestSkippedPackageCausedOfResendRequests);
+                                            foreach (Packet packetToProcess in packetsToProcess)
+                                            {
+#if TRACE && PACKET
+                                                NitroxModel.Logger.Log.Info("Processing after Skip: Packet: " + packetToProcess.Sequence + '/' + incomingSequence + ' ' + packetToProcess.GetType().ToString());
+#endif
+                                                packetReceiver.PacketReceived(packetToProcess);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+#if TRACE && PACKET
+                                NitroxModel.Logger.Log.Info("Connection: Received Packet: " + packet.Sequence + '/'+ incomingSequence + ' ' + packet.GetType().ToString());
+#endif
+
+                                List<Packet> packetsToProcess = SyncReceiveOrder(packet);
+
+                                foreach (Packet packetToProcess in packetsToProcess)
+                                {
+#if TRACE && PACKET
+                                    NitroxModel.Logger.Log.Info("Processing: Packet: " + packetToProcess.Sequence + '/' + incomingSequence + ' ' + packetToProcess.GetType().ToString());
+#endif
+                                    packetReceiver.PacketReceived(packetToProcess);
+                                }
+                            }
+
                         }
 
                         break;
@@ -99,6 +205,117 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
 
                 client.Recycle(im);
             }
+        }
+
+        private List<Packet> SyncReceiveOrder(Packet packet)
+        {
+            List<Packet> _result = new List<Packet>();
+            
+            if(packet.Sequence == incomingSequence + 1)
+            {
+                //case packet is in right order and next expected to be received, all previous packages have been processed
+
+                //check if it is a resented Packet and we know newer Packets ahead
+                if (latestSkippedPackageCausedOfResendRequests != null)
+                {
+                    packetPreReceivedCache.Add(packet);
+                    _result = SyncReceiveOrder(latestSkippedPackageCausedOfResendRequests);
+                    return _result;
+                }
+                else
+                {
+                    _result.Add(packet);
+                    incomingSequence = packet.Sequence;
+                    return _result;
+                }
+            }
+            if(packet.Sequence > incomingSequence + 1)
+            {
+                //case packet is further than expected
+                //check all PreCached Packages if order can be restored
+                List<long> _missingPackages = new List<long>();
+                for(long i=incomingSequence+1; i<packet.Sequence;i++)
+                {
+                    _missingPackages.Add(i);
+                }
+                foreach (Packet _cached in packetPreReceivedCache)
+                {
+                    if(_missingPackages.Contains(_cached.Sequence))
+                    {
+                        _missingPackages.Remove(_cached.Sequence);
+                    }
+                }
+
+                if (_missingPackages.Count == 0)
+                {
+                    //everything is fine, we know all packages
+                    for (long i = incomingSequence + 1; i < packet.Sequence; i++)
+                    {
+                        Packet _packageToProcess = packetPreReceivedCache.Find(e => e.Sequence == i);
+                        packetPreReceivedCache.Remove(_packageToProcess);
+                        _result.Add(_packageToProcess);
+                    }
+                    _result.Add(packet);
+                    incomingSequence = packet.Sequence;
+                    latestSkippedPackageCausedOfResendRequests = null;
+                }
+                else
+                {
+                    //packages in pre Order are missed
+                    //make resend request
+                    foreach (int i in _missingPackages)
+                    {
+                        RequestResendPackage(i);
+                    }
+                    //check if we already know the current package
+                    if (!packetPreReceivedCache.Exists(e => e.Sequence == packet.Sequence))
+                    {
+                        packetPreReceivedCache.Add(packet);
+                    }
+                    //check if we have to mark this package as the latest, or if this one is one of the missing between
+                    if (latestSkippedPackageCausedOfResendRequests != null)
+                    {
+                        if (packet.Sequence > latestSkippedPackageCausedOfResendRequests.Sequence)
+                        {
+                            latestSkippedPackageCausedOfResendRequests = packet;
+                        }
+                    }
+                    else
+                    {
+                        latestSkippedPackageCausedOfResendRequests = packet;
+                    }
+
+                    //check if we can progress partially in the sequence
+                    long latestSequenceInOrder = incomingSequence;
+                    for (long i = incomingSequence + 1; i < packet.Sequence; i++)
+                    {
+                        if(packetPreReceivedCache.Exists(e => e.Sequence == i))
+                        {
+                            latestSequenceInOrder = i;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    for (long i = incomingSequence + 1; i <= latestSequenceInOrder; i++)
+                    {
+                        Packet _packageToProcess = packetPreReceivedCache.Find(e => e.Sequence == i);
+                        packetPreReceivedCache.Remove(_packageToProcess);
+                        _result.Add(_packageToProcess);
+                    }
+                    incomingSequence = latestSequenceInOrder;
+                    return _result;
+
+                }
+
+
+            }
+            if (packet.Sequence < incomingSequence+1)
+            {
+                //old duplicate that has already been processed
+            }
+            return _result;
         }
     }
 }

--- a/NitroxClient/Communication/NetworkingLayer/Lidgren/LidgrenClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/Lidgren/LidgrenClient.cs
@@ -153,15 +153,12 @@ namespace NitroxClient.Communication.NetworkingLayer.Lidgren
                     case NetIncomingMessageType.Data:
                         if (im.Data.Length > 0)
                         {
-                            Packet packet = null;
-                            
 #if TRACE && PACKET
                             NitroxModel.Logger.Log.Info(DateTime.Now.Ticks + " Connection: Received Data: " + im.LengthBytes + " " + im.PositionInBytes + " " + im.Data);
 #endif
                             byte[] data = new byte[im.LengthBytes];
-                            im.ReadBytes(data, im.PositionInBytes, im.LengthBytes);                            
-                            packet = Packet.Deserialize(data);
-
+                            im.ReadBytes(data, im.PositionInBytes, im.LengthBytes);
+                            Packet packet = Packet.Deserialize(data);
 #if TRACE && PACKET
                             NitroxModel.Logger.Log.Info(DateTime.Now.Ticks + " Connection: Received Packet: " + packet.Sequence + '/' + incomingSequence + ' ' + packet.GetType().ToString());
 #endif

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Packets\MultiplayerSessionReservationRequest.cs" />
     <Compile Include="Packets\OpenableStateChanged.cs" />
     <Compile Include="Packets\Packet.cs" />
+    <Compile Include="Packets\PacketResendRequest.cs" />
     <Compile Include="Packets\PDAEncyclopediaEntryAdd.cs" />
     <Compile Include="Packets\PDAEncyclopediaEntryRemove.cs" />
     <Compile Include="Packets\PDAEncyclopediaEntryUpdate.cs" />

--- a/NitroxModel/Packets/Packet.cs
+++ b/NitroxModel/Packets/Packet.cs
@@ -19,7 +19,7 @@ namespace NitroxModel.Packets
     {
         private static readonly SurrogateSelector surrogateSelector;
         private static readonly StreamingContext streamingContext;
-        private static readonly BinaryFormatter Serializer;
+        private static readonly BinaryFormatter serializer;
         
         static Packet()
         {
@@ -45,11 +45,12 @@ namespace NitroxModel.Packets
             }
 
             // For completeness, we could pass a StreamingContextStates.CrossComputer.
-            Serializer = new BinaryFormatter(surrogateSelector, streamingContext);
+            serializer = new BinaryFormatter(surrogateSelector, streamingContext);
         }
 
         public NitroxDeliveryMethod.DeliveryMethod DeliveryMethod { get; protected set; } = NitroxDeliveryMethod.DeliveryMethod.ReliableOrdered;
         public UdpChannelId UdpChannel { get; protected set; } = UdpChannelId.DEFAULT;
+        public long Sequence { get; set; } = 0;
 
         public enum UdpChannelId
         {
@@ -66,7 +67,7 @@ namespace NitroxModel.Packets
             using (MemoryStream ms = new MemoryStream())
             using (LZ4Stream lz4Stream = new LZ4Stream(ms, LZ4StreamMode.Compress))
             {
-                Serializer.Serialize(lz4Stream, this);
+                serializer.Serialize(lz4Stream, this);
                 packetData = ms.ToArray();
             }
 
@@ -78,7 +79,7 @@ namespace NitroxModel.Packets
             using (Stream stream = new MemoryStream(data))
             using (LZ4Stream lz4Stream = new LZ4Stream(stream, LZ4StreamMode.Decompress))
             {
-                return (Packet)Serializer.Deserialize(lz4Stream);
+                return (Packet)serializer.Deserialize(lz4Stream);
             }
         }
 
@@ -89,7 +90,7 @@ namespace NitroxModel.Packets
             // System.Runtime.Serialization.Formatters.Binary.BinaryCommon.CheckSerializable
 
             ISurrogateSelector selector;
-            return (Serializer.SurrogateSelector.GetSurrogate(type, Packet.Serializer.Context, out selector) != null);
+            return (serializer.SurrogateSelector.GetSurrogate(type, Packet.serializer.Context, out selector) != null);
         }
 
         // Deferred cells are a replacement for the old DeferredPacket class.  The idea

--- a/NitroxModel/Packets/PacketResendRequest.cs
+++ b/NitroxModel/Packets/PacketResendRequest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using UnityEngine;
+
+namespace NitroxModel.Packets
+{
+    [Serializable]
+    public class PacketResendRequest : Packet
+    {
+        //public int Sequence { get; }
+
+        public PacketResendRequest(long sequence)
+        {
+            Sequence = sequence;
+        }
+
+        public override string ToString()
+        {
+            return "[PacketResendRequest Sequence:" + Sequence + "]";
+        }
+    }
+}

--- a/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenConnection.cs
+++ b/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenConnection.cs
@@ -12,7 +12,7 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
         private readonly NetConnection connection;
         private long incomingSequence = 0;
         private long outgoingSequence = 0;
-        private int packetSentCacheCount = 100;
+        private int packetSentCacheCount = 1000;
         private List<Packet> packetSentCache = new List<Packet>();
         private List<Packet> packetPreReceivedCache = new List<Packet>();
         private Packet latestSkippedPackageCausedOfResendRequests = null;
@@ -54,8 +54,8 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                 }
                 else
                 {
-                    //Incoming PacketResendRequest was a Notification from Sender that the RequestedPackage was not found
-                    //in SentCache of Sender.
+                    //incoming PacketResendRequest was a notification from sender  
+                    //that the requested packet was not found in SentCache of sender
                     long _sequenceToRemove = ((PacketResendRequest)packet).Sequence * -1;
 
 #if TRACE && PACKET
@@ -68,8 +68,8 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                     }
                     else
                     {
-                        //ErrorHandling from this point on in later Version
-                        //For now, skip requesting resends for this sequence number > desynct state from here on 
+                        //error handling from this point on in later version
+                        //for now, skip requesting resends for this sequence number > desynct state from here on 
 
                         //only skip for one package if this is the next in the order, for all higher ones let it untouched
                         if (incomingSequence + 1 == _sequenceToRemove)
@@ -77,7 +77,7 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                             incomingSequence++;
                         }
 
-                        //try to go on with all other preCached received Packages
+                        //try to go on with all other precached received packages
                         if (latestSkippedPackageCausedOfResendRequests != null)
                         {
                             List<Packet> packetsToProcess = SyncReceiveOrder(latestSkippedPackageCausedOfResendRequests);
@@ -110,37 +110,56 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
             }
 
             return _result;
-
         }
-
-
-
+                     
 
         private void ResendPackage(long sequence)
         {
             if(packetSentCache.Exists(packet => packet.Sequence == sequence))
             {
                 Packet packetToResend = packetSentCache.Find(packet => packet.Sequence == sequence);
+#if TRACE && PACKET
+                NitroxModel.Logger.Log.Info("Connection: Resending Package: " + sequence + ' ' + packetToResend.GetType().ToString());
+#endif
                 SendPreparedPacket(packetToResend);
             }
             else
             {
+#if TRACE && PACKET
+                NitroxModel.Logger.Log.Info("Connection: Sending Package not in Cache notification: " + sequence);
+#endif
                 SendPreparedPacket(new PacketResendRequest(sequence * -1));
             }
         }
 
         private void RequestResendPackage(int sequence)
         {
+#if TRACE && PACKET
+            NitroxModel.Logger.Log.Info("Connection: Sending Resend request: " + sequence);
+#endif
             SendPreparedPacket(new PacketResendRequest(sequence));
         }
 
         private void SendPreparedPacket(Packet packet)
         {
+#if TRACE && PACKET
+            NitroxModel.Logger.Log.Info("Connection: Sending new prepared Package: " + packet.Sequence + ' ' + packet.GetType().ToString());
+#endif
+#if TRACE && PACKET
+            NitroxModel.Logger.Log.Info("Connection: Sending prepared package: Method: " + packet.DeliveryMethod + " Channel: " + (int)packet.UdpChannel);
+#endif
             byte[] packetData = packet.Serialize();
             NetOutgoingMessage om = server.CreateMessage();
             om.Write(packetData);
+           
+#if TRACE && PACKET
+            NitroxModel.Logger.Log.Info("Connection: Message Data Length: " + om.Data.Length);
+#endif
+            NetSendResult result = connection.SendMessage(om, NitroxDeliveryMethod.ToLidgren(packet.DeliveryMethod), (int)packet.UdpChannel);
+#if TRACE && PACKET
+            NitroxModel.Logger.Log.Info("Connection: Message Send Result: " + result);
+#endif
 
-            connection.SendMessage(om, NitroxDeliveryMethod.ToLidgren(packet.DeliveryMethod), (int)packet.UdpChannel);
         }
 
 
@@ -152,7 +171,7 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
             {
                 //case packet is in right order and next expected to be received, all previous packages have been processed
 
-                //check if it is a resented Packet and we know newer Packets ahead
+                //check if it is a resented packet and we know newer packets ahead
                 if (latestSkippedPackageCausedOfResendRequests != null)
                 {
                     packetPreReceivedCache.Add(packet);
@@ -166,15 +185,19 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                     return _result;
                 }
             }
+
             if (packet.Sequence > incomingSequence + 1)
             {
+
                 //case packet is further than expected
-                //check all PreCached Packages if order can be restored
+                //check all precached packets if order can be restored
                 List<long> _missingPackages = new List<long>();
+
                 for (long i = incomingSequence + 1; i < packet.Sequence; i++)
                 {
                     _missingPackages.Add(i);
                 }
+
                 foreach (Packet _cached in packetPreReceivedCache)
                 {
                     if (_missingPackages.Contains(_cached.Sequence))
@@ -185,6 +208,7 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
 
                 if (_missingPackages.Count == 0)
                 {
+
                     //everything is fine, we know all packages
                     for (long i = incomingSequence + 1; i < packet.Sequence; i++)
                     {
@@ -192,23 +216,38 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                         packetPreReceivedCache.Remove(_packageToProcess);
                         _result.Add(_packageToProcess);
                     }
+
                     _result.Add(packet);
+
                     incomingSequence = packet.Sequence;
-                    latestSkippedPackageCausedOfResendRequests = null;
+
+                    //check if packet is the most newest or only the end of a partial sequence
+                    if (latestSkippedPackageCausedOfResendRequests != null && latestSkippedPackageCausedOfResendRequests == packet)
+                    {
+                        latestSkippedPackageCausedOfResendRequests = null;                        
+                    }
+
+                    //clean up cache
+                    if (packetPreReceivedCache.Exists(e => e.Sequence < packet.Sequence))
+                    {
+                        packetPreReceivedCache.RemoveAll(e => e.Sequence < packet.Sequence);
+                    }
                 }
                 else
                 {
-                    //packages in pre Order are missed
+                    //case packets in pre order are missed
                     //make resend request
                     foreach (int i in _missingPackages)
                     {
                         RequestResendPackage(i);
                     }
+
                     //check if we already know the current package
                     if (!packetPreReceivedCache.Exists(e => e.Sequence == packet.Sequence))
                     {
                         packetPreReceivedCache.Add(packet);
                     }
+
                     //check if we have to mark this package as the latest, or if this one is one of the missing between
                     if (latestSkippedPackageCausedOfResendRequests != null)
                     {
@@ -224,6 +263,7 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
 
                     //check if we can progress partially in the sequence
                     long latestSequenceInOrder = incomingSequence;
+
                     for (long i = incomingSequence + 1; i < packet.Sequence; i++)
                     {
                         if (packetPreReceivedCache.Exists(e => e.Sequence == i))
@@ -235,23 +275,31 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                             break;
                         }
                     }
+
                     for (long i = incomingSequence + 1; i <= latestSequenceInOrder; i++)
                     {
                         Packet _packageToProcess = packetPreReceivedCache.Find(e => e.Sequence == i);
                         packetPreReceivedCache.Remove(_packageToProcess);
                         _result.Add(_packageToProcess);
                     }
+
                     incomingSequence = latestSequenceInOrder;
+                  
+                    if (packetPreReceivedCache.Exists(e => e.Sequence < latestSequenceInOrder))
+                    {
+                        packetPreReceivedCache.RemoveAll(e => e.Sequence < latestSequenceInOrder);
+                    }
                     return _result;
 
                 }
-
-
+                
             }
+
             if (packet.Sequence < incomingSequence + 1)
             {
                 //old duplicate that has already been processed
             }
+
             return _result;
         }
 

--- a/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenConnection.cs
+++ b/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenConnection.cs
@@ -1,8 +1,8 @@
+﻿using System.Collections.Generic;
 using Lidgren.Network;
 using NitroxModel.Logger;
 using NitroxModel.Networking;
 using NitroxModel.Packets;
-using NitroxModel.Packets.Processors.Abstract;
 
 namespace NitroxServer.Communication.NetworkingLayer.Lidgren
 {
@@ -10,6 +10,12 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
     {
         private readonly NetServer server;
         private readonly NetConnection connection;
+        private long incomingSequence = 0;
+        private long outgoingSequence = 0;
+        private int packetSentCacheCount = 100;
+        private List<Packet> packetSentCache = new List<Packet>();
+        private List<Packet> packetPreReceivedCache = new List<Packet>();
+        private Packet latestSkippedPackageCausedOfResendRequests = null;
 
         public LidgrenConnection(NetServer server, NetConnection connection)
         {
@@ -21,16 +27,233 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
         {
             if (connection.Status == NetConnectionStatus.Connected)
             {
-                byte[] packetData = packet.Serialize();
-                NetOutgoingMessage om = server.CreateMessage();
-                om.Write(packetData);
-
-                connection.SendMessage(om, NitroxDeliveryMethod.ToLidgren(packet.DeliveryMethod), (int)packet.UdpChannel);
+                outgoingSequence++;
+                packet.Sequence = outgoingSequence;
+                packetSentCache.Add(packet);
+                if(packetSentCache.Count > packetSentCacheCount)
+                {
+                    packetSentCache.RemoveAt(0);
+                }
+                SendPreparedPacket(packet);
             }
             else
             {
                 Log.Info("Cannot send packet to a closed connection.");
             }
         }
+
+        public List<Packet> ManageNewPacket(Packet packet)
+        {
+            List<Packet> _result = new List<Packet>();
+
+            if (packet is PacketResendRequest)
+            {
+                if (((PacketResendRequest)packet).Sequence >= 0)
+                {
+                    ResendPackage(((PacketResendRequest)packet).Sequence);
+                }
+                else
+                {
+                    //Incoming PacketResendRequest was a Notification from Sender that the RequestedPackage was not found
+                    //in SentCache of Sender.
+                    long _sequenceToRemove = ((PacketResendRequest)packet).Sequence * -1;
+
+#if TRACE && PACKET
+                    NitroxModel.Logger.Log.Info("Connection: Received info for unresendable Package: " + _sequenceToRemove + '/' + incomingSequence + ' ' + packet.GetType().ToString());
+#endif
+
+                    if (_sequenceToRemove <= incomingSequence)
+                    {
+                        //already processed, incoming is a duplicate of an old resend request
+                    }
+                    else
+                    {
+                        //ErrorHandling from this point on in later Version
+                        //For now, skip requesting resends for this sequence number > desynct state from here on 
+
+                        //only skip for one package if this is the next in the order, for all higher ones let it untouched
+                        if (incomingSequence + 1 == _sequenceToRemove)
+                        {
+                            incomingSequence++;
+                        }
+
+                        //try to go on with all other preCached received Packages
+                        if (latestSkippedPackageCausedOfResendRequests != null)
+                        {
+                            List<Packet> packetsToProcess = SyncReceiveOrder(latestSkippedPackageCausedOfResendRequests);
+                            foreach (Packet packetToProcess in packetsToProcess)
+                            {
+#if TRACE && PACKET
+                                NitroxModel.Logger.Log.Info("Processing after Skip: Packet: " + packetToProcess.Sequence + '/' + incomingSequence + ' ' + packetToProcess.GetType().ToString());
+#endif
+                                _result.Add(packetToProcess);
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+#if TRACE && PACKET
+                NitroxModel.Logger.Log.Info("Connection: Received Packet: " + packet.Sequence + '/' + incomingSequence + ' ' + packet.GetType().ToString());
+#endif
+
+                List<Packet> packetsToProcess = SyncReceiveOrder(packet);
+
+                foreach (Packet packetToProcess in packetsToProcess)
+                {
+#if TRACE && PACKET
+                    NitroxModel.Logger.Log.Info("Processing: Packet: " + packetToProcess.Sequence + '/' + incomingSequence + ' ' + packetToProcess.GetType().ToString());
+#endif
+                    _result.Add(packetToProcess);
+                }
+            }
+
+            return _result;
+
+        }
+
+
+
+
+        private void ResendPackage(long sequence)
+        {
+            if(packetSentCache.Exists(packet => packet.Sequence == sequence))
+            {
+                Packet packetToResend = packetSentCache.Find(packet => packet.Sequence == sequence);
+                SendPreparedPacket(packetToResend);
+            }
+            else
+            {
+                SendPreparedPacket(new PacketResendRequest(sequence * -1));
+            }
+        }
+
+        private void RequestResendPackage(int sequence)
+        {
+            SendPreparedPacket(new PacketResendRequest(sequence));
+        }
+
+        private void SendPreparedPacket(Packet packet)
+        {
+            byte[] packetData = packet.Serialize();
+            NetOutgoingMessage om = server.CreateMessage();
+            om.Write(packetData);
+
+            connection.SendMessage(om, NitroxDeliveryMethod.ToLidgren(packet.DeliveryMethod), (int)packet.UdpChannel);
+        }
+
+
+        private List<Packet> SyncReceiveOrder(Packet packet)
+        {
+            List<Packet> _result = new List<Packet>();
+
+            if (packet.Sequence == incomingSequence + 1)
+            {
+                //case packet is in right order and next expected to be received, all previous packages have been processed
+
+                //check if it is a resented Packet and we know newer Packets ahead
+                if (latestSkippedPackageCausedOfResendRequests != null)
+                {
+                    packetPreReceivedCache.Add(packet);
+                    _result = SyncReceiveOrder(latestSkippedPackageCausedOfResendRequests);
+                    return _result;
+                }
+                else
+                {
+                    _result.Add(packet);
+                    incomingSequence = packet.Sequence;
+                    return _result;
+                }
+            }
+            if (packet.Sequence > incomingSequence + 1)
+            {
+                //case packet is further than expected
+                //check all PreCached Packages if order can be restored
+                List<long> _missingPackages = new List<long>();
+                for (long i = incomingSequence + 1; i < packet.Sequence; i++)
+                {
+                    _missingPackages.Add(i);
+                }
+                foreach (Packet _cached in packetPreReceivedCache)
+                {
+                    if (_missingPackages.Contains(_cached.Sequence))
+                    {
+                        _missingPackages.Remove(_cached.Sequence);
+                    }
+                }
+
+                if (_missingPackages.Count == 0)
+                {
+                    //everything is fine, we know all packages
+                    for (long i = incomingSequence + 1; i < packet.Sequence; i++)
+                    {
+                        Packet _packageToProcess = packetPreReceivedCache.Find(e => e.Sequence == i);
+                        packetPreReceivedCache.Remove(_packageToProcess);
+                        _result.Add(_packageToProcess);
+                    }
+                    _result.Add(packet);
+                    incomingSequence = packet.Sequence;
+                    latestSkippedPackageCausedOfResendRequests = null;
+                }
+                else
+                {
+                    //packages in pre Order are missed
+                    //make resend request
+                    foreach (int i in _missingPackages)
+                    {
+                        RequestResendPackage(i);
+                    }
+                    //check if we already know the current package
+                    if (!packetPreReceivedCache.Exists(e => e.Sequence == packet.Sequence))
+                    {
+                        packetPreReceivedCache.Add(packet);
+                    }
+                    //check if we have to mark this package as the latest, or if this one is one of the missing between
+                    if (latestSkippedPackageCausedOfResendRequests != null)
+                    {
+                        if (packet.Sequence > latestSkippedPackageCausedOfResendRequests.Sequence)
+                        {
+                            latestSkippedPackageCausedOfResendRequests = packet;
+                        }
+                    }
+                    else
+                    {
+                        latestSkippedPackageCausedOfResendRequests = packet;
+                    }
+
+                    //check if we can progress partially in the sequence
+                    long latestSequenceInOrder = incomingSequence;
+                    for (long i = incomingSequence + 1; i < packet.Sequence; i++)
+                    {
+                        if (packetPreReceivedCache.Exists(e => e.Sequence == i))
+                        {
+                            latestSequenceInOrder = i;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    for (long i = incomingSequence + 1; i <= latestSequenceInOrder; i++)
+                    {
+                        Packet _packageToProcess = packetPreReceivedCache.Find(e => e.Sequence == i);
+                        packetPreReceivedCache.Remove(_packageToProcess);
+                        _result.Add(_packageToProcess);
+                    }
+                    incomingSequence = latestSequenceInOrder;
+                    return _result;
+
+                }
+
+
+            }
+            if (packet.Sequence < incomingSequence + 1)
+            {
+                //old duplicate that has already been processed
+            }
+            return _result;
+        }
+
     }
 }

--- a/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/Lidgren/LidgrenServer.cs
@@ -1,8 +1,6 @@
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using Lidgren.Network;
-using NitroxModel.DataStructures;
 using NitroxModel.Logger;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets;
@@ -73,7 +71,21 @@ namespace NitroxServer.Communication.NetworkingLayer.Lidgren
                             {
                                 NitroxConnection connection = GetConnection(im.SenderConnection.RemoteUniqueIdentifier);
                                 Packet packet = Packet.Deserialize(im.Data);
-                                ProcessIncomingData(connection, packet);
+
+                                if (connection is LidgrenConnection)
+                                {
+                                    List<Packet> packetsToProcess = ((LidgrenConnection)connection).ManageNewPacket(packet);
+
+                                    foreach (Packet packetToProcess in packetsToProcess)
+                                    {
+                                        ProcessIncomingData(connection, packetToProcess);
+                                    }
+                                }
+                                else
+                                {
+                                    ProcessIncomingData(connection, packet);
+                                }
+                                    
                             }
                             break;
                         default:


### PR DESCRIPTION
Ready for Review

~~!Attention: This needs more rework. After further investigating and long term tests, i've noticed, that after about 10 minutes, connections begin to make weird things. Seems to be related to Lindgren.SendBuffer. I try to solve this and extend this pull request.
I let this pull request Open, because this solutions works already fine. And can be used by those who are testing against other issues (cyclops, etc).~~

Objective: 
- eliminate desync issues caused by packet loss
- eliminate issues caused by processing incoming packets in the wrong order

Changes:
- introduced a packet sequence for every connection between host and clients
- processing packets in the order that they were send and not in the order they were received
- request resend of packets that are missed in sequence
- packet cache for sent packets to be able to resend missing packets
- changed lindgren message read for safe usage
- increased SendBuffer