### PR TITLE
Fix player sinking and relative rotation

### DIFF
--- a/NitroxClient/GameLogic/MovementHelper.cs
+++ b/NitroxClient/GameLogic/MovementHelper.cs
@@ -43,11 +43,9 @@ namespace NitroxClient.GameLogic
                 // This should be a one-off teleport.
                 gameObject.transform.position = remotePosition;
             }
-            // overcorrections can cause jitter when standing still.
-            else if (distance > 0.001f)
+            else
             {
-                float maxAdjustment = (float)Math.Log10(distance) * 4f;
-                remoteVelocity += MathUtil.ClampMagnitude(velocityToMakeUpDifference - remoteVelocity, maxAdjustment, -maxAdjustment);
+                remoteVelocity = velocityToMakeUpDifference;
             }
 
             return remoteVelocity;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -93,13 +93,13 @@ namespace NitroxClient.GameLogic
             SetVehicle(null);
             SetPilotingChair(null);
             // If in a subroot the position will be relative to the subroot
-            if (SubRoot  != null && !SubRoot.isBase)
+            if (SubRoot != null && !SubRoot.isBase)
             {
                 Quaternion vehicleAngle = SubRoot.transform.rotation;
                 position = vehicleAngle * position;
                 position = position + SubRoot.transform.position;
-                
-                
+                bodyRotation = vehicleAngle * bodyRotation;
+                aimingRotation = vehicleAngle * aimingRotation;
             }
             RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
             RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovement.BROADCAST_INTERVAL);
@@ -226,7 +226,7 @@ namespace NitroxClient.GameLogic
         private void UpdateEquipmentVisibility()
         {
             ReadOnlyCollection<TechType> currentEquipment = new ReadOnlyCollection<TechType>(equipment.ToList());
-            
+
             playerModelManager.UpdateEquipmentVisibility(PlayerModel, currentEquipment);
         }
     }

--- a/NitroxClient/MonoBehaviours/PlayerMovement.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovement.cs
@@ -1,13 +1,11 @@
 ﻿using NitroxClient.GameLogic;
-using NitroxClient.GameLogic.Helper;
 using NitroxModel.Core;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel_Subnautica.Helper;
-using NitroxModel.Logger;
 using UnityEngine;
-using NitroxModel.DataStructures;
 
 namespace NitroxClient.MonoBehaviours
 {
@@ -45,12 +43,13 @@ namespace NitroxClient.MonoBehaviours
                 SubRoot subRoot = Player.main.GetCurrentSub();
                 // If in a subroot the position will be relative to the subroot
                 if (subRoot != null && !subRoot.isBase)
-                { 
+                {
                     // Rotate relative player position relative to the subroot (else there are problems with respawning)
-                    Quaternion vehicleAngle = subRoot.transform.rotation;                    
+                    Quaternion undoVehicleAngle = subRoot.transform.rotation.GetInverse();
                     currentPosition = currentPosition - subRoot.transform.position;
-                    currentPosition = vehicleAngle.GetInverse() * currentPosition;
-
+                    currentPosition = undoVehicleAngle * currentPosition;
+                    bodyRotation = undoVehicleAngle * bodyRotation;
+                    aimingRotation = undoVehicleAngle * aimingRotation;
                 }
 
                 localPlayer.UpdateLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation, vehicle);
@@ -138,16 +137,16 @@ namespace NitroxClient.MonoBehaviours
                 return Optional<VehicleMovementData>.Empty();
             }
 
-            VehicleMovementData model = VehicleMovementFactory.GetVehicleMovementData(  techType, 
-                                                                                        id, 
-                                                                                        position, 
-                                                                                        rotation, 
-                                                                                        velocity, 
-                                                                                        angularVelocity, 
-                                                                                        steeringWheelYaw, 
-                                                                                        steeringWheelPitch, 
-                                                                                        appliedThrottle, 
-                                                                                        leftArmPosition, 
+            VehicleMovementData model = VehicleMovementFactory.GetVehicleMovementData(techType,
+                                                                                        id,
+                                                                                        position,
+                                                                                        rotation,
+                                                                                        velocity,
+                                                                                        angularVelocity,
+                                                                                        steeringWheelYaw,
+                                                                                        steeringWheelPitch,
+                                                                                        appliedThrottle,
+                                                                                        leftArmPosition,
                                                                                         rightArmPosition);
             return Optional<VehicleMovementData>.Of(model);
         }


### PR DESCRIPTION
Fixes https://github.com/SubnauticaNitrox/Nitrox/issues/128
Fixes https://github.com/SubnauticaNitrox/Nitrox/issues/794

Address Y-offset issues by removing the broken "interpolation"/"smoothing".
Also, make rotation relative to the subroot (just like positioning). This is to keep the player properly oriented when the subroot moves without (timely) receiving position updates from other players in this subroot.

### Next up
We need to make a light-weight "RigidBody" controller, since it's only used to integrate velocities after all. The current implementation will keep interpolating the velocity causing players to fly away when no packets are received. The new implementation should apply some kind of smoothing towards the end and hold the player stationary when no packets are received for a prolonged amount of time.
Thereafter smoothing for remote controlled Cyclopses needs to be addressed. Players in this cyclops seem to stutter since the game probably doesn't account for the cyclops moving "on it's own" (without the player fixed in the piloting seat). This can cause a player to fall out when standing close to the wall or inside the helm.