### PR TITLE
Adjusted mono path to new location

### DIFF
--- a/NitroxLauncher/LauncherLogic.cs
+++ b/NitroxLauncher/LauncherLogic.cs
@@ -275,7 +275,7 @@ namespace NitroxLauncher
         {
             string libDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "lib");
             string launcherMonoPath = Path.Combine(libDirectory, "Mono");
-            string subnauticaMonoPath = Path.Combine(subnauticaPath, "Mono");
+            string subnauticaMonoPath = Path.Combine(subnauticaPath, "MonoBleedingEdge");
 
             List<string> ignoreNoBinaries = new List<string>();
             CopyAllAssemblies(launcherMonoPath, subnauticaMonoPath, ignoreNoBinaries);

--- a/NitroxLauncher/LauncherLogic.cs
+++ b/NitroxLauncher/LauncherLogic.cs
@@ -275,7 +275,7 @@ namespace NitroxLauncher
         {
             string libDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "lib");
             string launcherMonoPath = Path.Combine(libDirectory, "Mono");
-            string subnauticaMonoPath = Path.Combine(subnauticaPath, "Subnautica_Data", "Mono");
+            string subnauticaMonoPath = Path.Combine(subnauticaPath, "Mono");
 
             List<string> ignoreNoBinaries = new List<string>();
             CopyAllAssemblies(launcherMonoPath, subnauticaMonoPath, ignoreNoBinaries);


### PR DESCRIPTION
Adjusted mono syncing mono assemblys combined path. 

Due to location of mono folder changing to root subnautica folder from Subnautica_Data folder

Fixes #848 #862 