### PR TITLE
Fixed player initial spawn from random to inside escapepod

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -23,10 +23,11 @@ namespace NitroxClient.GameLogic.InitialSync
             Vector3 position = packet.PlayerSpawnData;
             Optional<NitroxId> subRootId = packet.PlayerSubRootId;
 
-            if (!(position.x == 0 && position.y == 0 && position.z == 0))
+            if (position.x == 0 && position.y == 0 && position.z == 0)
             {
-                Player.main.SetPosition(position);
+                position = Player.mainObject.transform.position;
             }
+            Player.main.SetPosition(position);
 
             if (subRootId.IsPresent())
             {


### PR DESCRIPTION
Not ideal pretty sure that there is some cause but can't find anything in the code or assemblies that seems to have any effect.

Feel free to throw it out.