### PR TITLE
Changed default server start option to 'console window'

### DIFF
--- a/NitroxLauncher/ServerPage.xaml
+++ b/NitroxLauncher/ServerPage.xaml
@@ -330,8 +330,8 @@
                                     <StaticResource ResourceKey="Roboto"/>
                                 </ComboBox.FontFamily>
 
-                                <ComboBoxItem FontFamily="{StaticResource Roboto}" x:Name="CBInner" Foreground="White" HorizontalAlignment="Stretch" FontSize="16" Content="Launcher window" ToolTip="Server will run in the launcher."/>
-                                <ComboBoxItem FontFamily="{StaticResource Roboto}" x:Name="CBWindow" Foreground="White" HorizontalAlignment="Stretch" FontSize="16" Content="Command line window" ToolTip="Server will run in a seperate window (CMD)" />
+                                <ComboBoxItem FontFamily="{StaticResource Roboto}" x:Name="CBWindow" Foreground="White" HorizontalAlignment="Stretch" FontSize="16" Content="Command line window" ToolTip="Server will run in a seperate window (CMD)" Tag="external"/>
+                                <ComboBoxItem FontFamily="{StaticResource Roboto}" x:Name="CBInner" Foreground="White" HorizontalAlignment="Stretch" FontSize="16" Content="Launcher window" ToolTip="Server will run in the launcher." Tag="embedded" />
                             </ComboBox>
                             <!--<TextBlock Foreground="White" HorizontalAlignment="Left" FontSize="16" Margin="12,12,0,0">Only base game available</TextBlock>-->
                         </Border>

--- a/NitroxLauncher/ServerPage.xaml.cs
+++ b/NitroxLauncher/ServerPage.xaml.cs
@@ -40,7 +40,9 @@ namespace NitroxLauncher
         private void OnSelectionChange(object sender, SelectionChangedEventArgs e)
         {
             ComboBox box = (ComboBox)sender;
-            embeddedServer = box.SelectedIndex == 0;
+            ComboBoxItem item = (ComboBoxItem)box.SelectedValue;
+            
+            embeddedServer = item.Tag.ToString() == "embedded";
         }
     }
 }


### PR DESCRIPTION
The embedded server page in the NitroxLauncher needs more work. The way it displays text is very bad on performance. Until this is fixed I recommend just launching the cmd by default.