### PR TITLE
Removed Harmony module from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Harmony"]
-	path = Harmony
-	url = ../../SubnauticaNitrox/Harmony.git
 [submodule "NitroxUnity"]
 	path = NitroxUnity
 	url = https://github.com/SubnauticaNitrox/NitroxUnity


### PR DESCRIPTION
Removed Harmony submodule as no longer needed due to using the nuget package now.