### PR TITLE
Common assembly info

### DIFF
--- a/AssemblyInfoCommon.cs
+++ b/AssemblyInfoCommon.cs
@@ -6,22 +6,22 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("NitroxServer-Subnautica")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-// COMMON: [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("NitroxServer-Subnautica")]
-// COMMON: [assembly: AssemblyCopyright("")]
-// COMMON: [assembly: AssemblyTrademark("")]
-// COMMON: [assembly: AssemblyCulture("")]
+// UNIQUE: [assembly: AssemblyTitle("")]
+// UNIQUE: [assembly: AssemblyDescription("")]
+// UNIQUE: [assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+// UNIQUE: [assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-// COMMON: [assembly: ComVisible(false)]
+[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("eff1d7a5-efd6-413a-8d5f-dc2408e4c9b7")]
+// UNIQUE: [assembly: Guid("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
-// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -228,6 +228,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="ClientAutoFacRegistrar.cs" />
     <Compile Include="Communication\PacketReceiver.cs" />
     <Compile Include="Communication\Packets\Processors\RadioPlayPendingMessageProcessor.cs" />

--- a/NitroxClient/Properties/AssemblyInfo.cs
+++ b/NitroxClient/Properties/AssemblyInfo.cs
@@ -2,22 +2,23 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Client")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Client")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ed5034bd-66b5-4596-94b7-66a28d3eff49")]
@@ -31,7 +32,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+// [assembly: AssemblyVersion("1.0.*")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
 
 [assembly: InternalsVisibleTo("NitroxTest")]

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -74,6 +74,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Events\ServerStartEventArgs.cs" />
     <Compile Include="LauncherLogic.cs" />
     <Compile Include="Patching\NitroxEntryPatch.cs" />

--- a/NitroxLauncher/Properties/AssemblyInfo.cs
+++ b/NitroxLauncher/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
+
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -10,29 +9,21 @@ using System.Windows;
 [assembly: AssemblyTitle("NitroxLauncher")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NitroxLauncher")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("228948e3-b68e-47ad-abe2-2972ecf36b06")]
 
-
-//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
-
-
-[assembly: ThemeInfo(
-    ResourceDictionaryLocation.None, 
-    ResourceDictionaryLocation.SourceAssembly 
-)]
-
-
-
+// Version information for an assembly consists of the following four values:
 //
 //      Major Version
 //      Minor Version
@@ -42,5 +33,12 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,
+    ResourceDictionaryLocation.SourceAssembly
+)]

--- a/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
+++ b/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
@@ -219,6 +219,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="DataStructures\GameLogic\Buildings\Rotation\Metadata\CorridorRotationMetadata.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Rotation\Metadata\MapRoomRotationMetadata.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Rotation\SubnauticaRotationMetadataFactory.cs" />

--- a/NitroxModel-Subnautica/Properties/AssemblyInfo.cs
+++ b/NitroxModel-Subnautica/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+
 using System.Runtime.InteropServices;
+
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -8,16 +9,16 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NitroxModel-Subnautica")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NitroxModel-Subnautica")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0a377218-6b36-4522-89a3-a39cfc999209")]
@@ -32,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -223,6 +223,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Core\IAutoFacRegistrar.cs" />
     <Compile Include="Core\NitroxServiceLocator.cs" />
     <Compile Include="DataStructures\GameLogic\Entities\UwePrefab.cs" />

--- a/NitroxModel/Properties/AssemblyInfo.cs
+++ b/NitroxModel/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection;
+
 using System.Runtime.InteropServices;
+
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -7,16 +9,16 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Networking")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Networking")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b16f4de7-21ad-4fef-955b-0a5a365fa4e3")]
@@ -30,5 +32,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+// [assembly: AssemblyVersion("1.0.*")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -222,6 +222,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Main.cs" />
     <Compile Include="Modules\NitroxPatchesModule.cs" />
     <Compile Include="Patches\Dynamic\CrashHome_Spawn_Patch.cs" />

--- a/NitroxPatcher/Properties/AssemblyInfo.cs
+++ b/NitroxPatcher/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+
 using System.Runtime.InteropServices;
+
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -8,16 +9,16 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NitroxPatcher")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NitroxPatcher")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("be983e25-24cc-4fc8-9017-61eec43dd618")]
@@ -31,5 +32,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// [assembly: AssemblyVersion("1.0.*")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -231,6 +231,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Communication\Packets\Processors\ConstructorBeginCraftingProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\CyclopsChangeEngineModeProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\CyclopsChangeShieldModeProcessor.cs" />

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -252,6 +252,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibConnection.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibServer.cs" />
     <Compile Include="Communication\NetworkingLayer\NitroxConnection.cs" />

--- a/NitroxServer/Properties/AssemblyInfo.cs
+++ b/NitroxServer/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+
 using System.Runtime.InteropServices;
+
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -8,16 +9,16 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SubServer")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SubServer")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0fc864b0-694e-4fca-b78c-8ef98bc6f262")]
@@ -32,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -248,6 +248,9 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Client\Communication\DeferredPacketReceiverTest.cs" />
     <Compile Include="Client\Communication\MultiplayerSessionTests\ConnectionStateTests\ConnectionNegotiatedStateTests\SessionJoinedStateTests.cs" />
     <Compile Include="Client\Communication\MultiplayerSessionTests\ConnectionStateTests\ConnectionNegotiatedStateTests\SessionReservationRejectedStateTests.cs" />

--- a/NitroxTest/Properties/AssemblyInfo.cs
+++ b/NitroxTest/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+
 using System.Runtime.InteropServices;
+
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -8,16 +9,16 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NitroxTest")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+// COMMON: [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NitroxTest")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+// COMMON: [assembly: AssemblyCopyright("")]
+// COMMON: [assembly: AssemblyTrademark("")]
+// COMMON: [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+// COMMON: [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7787384e-3b08-4d6f-9c0e-a9e3701ba9f1")]
@@ -32,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// COMMON: [assembly: AssemblyVersion("X.X.X.X")]
+// COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]


### PR DESCRIPTION
This change supports rolling the version number for all projects in a single file. This is useful for multi-assembly solutions where each has a common version number as well as other attributes (e.g. copyright, etc).

"AssemblyInfoCommon.cs" is placed at the root of the solution. It is then linked (Add as link) into each project and collocated with the AssemblyInfo.cs (at .\Properties). AssemblyInfoCommon.cs holds the common values while each AssemblyInfo.cs retains the unique ones. I aligned each AssemblyInfo.cs so comparison is easy. I placed comment markers for the common lines in the unique files and the unique lines in the common file.

Notes:

- I left a few attributes that are unused (e.g. Description) in each AssemblyInfo.cs as they should be unique despite them not being populated (yet?).

- NitroxLauncher's AssemblyInfo.cs was missing a guid, so I generated one. I think it's moot, but for the sake of consistency...yeah OCD much? If someone can confirm none are needed (as they seem to relate to COM which is disabled for all), I can pull 'em.

- There are a few dead lines (already commented out). I wasn't sure why they were there, but left them in case that was something in work or for reference