### PR TITLE
Added "==" and "!=" operator to NitroxId. (Fixes repairability of escape pod)

### DIFF
--- a/NitroxModel/DataStructures/NitroxId.cs
+++ b/NitroxModel/DataStructures/NitroxId.cs
@@ -52,6 +52,24 @@ namespace NitroxModel.DataStructures
                    guid.Equals(id.guid);
         }
 
+        public static bool operator ==(NitroxId id1, NitroxId id2)
+        {
+            if (Object.ReferenceEquals(id1, null))
+            {
+                if (Object.ReferenceEquals(id2, null))
+                {
+                    return true;
+                }
+                return false;
+            }
+            return id1.Equals(id2);
+        }
+
+        public static bool operator !=(NitroxId id1, NitroxId id2)
+        {
+            return !(id1 == id2);
+        }
+
         public override int GetHashCode()
         {
             return -1324198676 + EqualityComparer<Guid>.Default.GetHashCode(guid);

--- a/NitroxServer/GameLogic/EscapePodManager.cs
+++ b/NitroxServer/GameLogic/EscapePodManager.cs
@@ -73,7 +73,7 @@ namespace NitroxServer.GameLogic
         {
             lock(escapePodData.EscapePods)
             {
-                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.Id == id);
+                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.Id.Equals(id));
                 escapePod.Damaged = false;
             }
         }
@@ -82,7 +82,7 @@ namespace NitroxServer.GameLogic
         {
             lock (escapePodData.EscapePods)
             {
-                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.RadioId == id);
+                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.RadioId.Equals(id));
                 escapePod.RadioDamaged = false;
             }
         }

--- a/NitroxServer/GameLogic/EscapePodManager.cs
+++ b/NitroxServer/GameLogic/EscapePodManager.cs
@@ -73,7 +73,7 @@ namespace NitroxServer.GameLogic
         {
             lock(escapePodData.EscapePods)
             {
-                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.Id.Equals(id));
+                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.Id == id);
                 escapePod.Damaged = false;
             }
         }
@@ -82,7 +82,7 @@ namespace NitroxServer.GameLogic
         {
             lock (escapePodData.EscapePods)
             {
-                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.RadioId.Equals(id));
+                EscapePodModel escapePod = escapePodData.EscapePods.Find(ep => ep.RadioId == id);
                 escapePod.RadioDamaged = false;
             }
         }


### PR DESCRIPTION
This patch makes the secondary systems and the radio of the escape pod repairable again.
The == operator doesn't seem to work for comparing the NitroxIds so I changed it to .Equals() to make the repairing work.