### PR TITLE
Added error if Nitrox Launcher is started from temp directory

### DIFF
--- a/NitroxLauncher/App.xaml.cs
+++ b/NitroxLauncher/App.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -21,6 +24,14 @@ namespace NitroxLauncher
                 DefaultValue = FindResource(typeof(Page))
             });
             
+            // Error if running from a temporary directory because Nitrox Launcher won't be able to write files directly to zip/rar
+            // Tools like WinRAR do this to support running EXE files while it's still zipped.
+            if (Directory.GetCurrentDirectory().StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show("Nitrox launcher should not be executed from a temporary directory. Install Nitrox launcher properly by extracting and moving it to a dedicated location on your PC.", "Invalid working directory", MessageBoxButton.OK, MessageBoxImage.Error);
+                Environment.Exit(1);
+            }
+
             base.OnStartup(e);
         }
 

--- a/NitroxLauncher/App.xaml.cs
+++ b/NitroxLauncher/App.xaml.cs
@@ -28,7 +28,7 @@ namespace NitroxLauncher
             // Tools like WinRAR do this to support running EXE files while it's still zipped.
             if (Directory.GetCurrentDirectory().StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase))
             {
-                MessageBox.Show("Nitrox launcher should not be executed from a temporary directory. Install Nitrox launcher properly by extracting and moving it to a dedicated location on your PC.", "Invalid working directory", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("Nitrox launcher should not be executed from a temporary directory. Install Nitrox launcher properly by extracting ALL files and moving these to a dedicated location on your PC.", "Invalid working directory", MessageBoxButton.OK, MessageBoxImage.Error);
                 Environment.Exit(1);
             }
 

--- a/NitroxServer/IpLogger.cs
+++ b/NitroxServer/IpLogger.cs
@@ -86,7 +86,7 @@ namespace NitroxServer
             using (WebClient client = new WebClient())
             {
                 client.DownloadStringCompleted += ExternalIpStringDownloadCompleted;
-                client.DownloadStringAsync(new Uri("http://ipv4bot.whatismyipaddress.com/")); // from https://stackoverflow.com/questions/3253701/get-public-external-ip-address answer by user_v
+                client.DownloadStringAsync(new Uri("https://ipv4bot.whatismyipaddress.com/")); // from https://stackoverflow.com/questions/3253701/get-public-external-ip-address answer by user_v
             }
         }
 


### PR DESCRIPTION
Should reduce issues in help channel on discord down the line by running Nitrox Launcher from zip without extracting it first.