### PR TITLE
Quick Fix for Below Zero

### DIFF
--- a/NitroxModel/Discovery/GameInstallationFinder.cs
+++ b/NitroxModel/Discovery/GameInstallationFinder.cs
@@ -14,8 +14,8 @@ namespace NitroxModel.Discovery
     {
         private readonly IFindGameInstallation[] finders = {
             new ConfigFileGameFinder(),
+            new EpicGamesInstallationFinder(),
             new SteamGameRegistryFinder(),
-            new EpicGamesInstallationFinder()
         };
         
         /// <summary>

--- a/NitroxModel/Discovery/InstallationFinders/EpicGamesInstallationFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EpicGamesInstallationFinder.cs
@@ -25,7 +25,7 @@ namespace NitroxModel.Discovery.InstallationFinders
             {
                 string fileText = File.ReadAllText(file);
                 Match match = installLocationRegex.Match(fileText);
-                if (fileText.Contains("Subnautica") && match.Success)
+                if (match.Success && match.Value.Contains("Subnautica") && !match.Value.Contains("Below"))
                 {
                     Log.Debug($"Found Subnautica install path in '{Path.GetFullPath(file)}'. Full pattern match: '{match.Value}'");
                     return Optional<string>.Of(match.Groups[1].Value);


### PR DESCRIPTION
> Subnautica below zero is sometimes detected as the install path for classic Subnautia. Need to improve installation detection to exclude below zero. See the GameFinder classes in Nitrox

After our quick conversation on Discord, I keep going in trying to understand where the bug could came from. And for Epic Games it could exist one issue where the manifest file of subnautica zero is the first to be read then the Regex will catch it and our check will let Below Zero passing throught 👎 

**Old code :**
```
Match match = installLocationRegex.Match(fileText)
if (fileText.Contains("Subnautica") && match.Success) {
    Log.Debug($"Found Subnautica install path in '{Path.GetFullPath(file)}'. Full pattern match: '{match.Value}'");
    return Optional<string>.Of(match.Groups[1].Value);
}
```