### PR TITLE
Reload of player food/water

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
@@ -70,6 +70,8 @@ namespace NitroxClient.GameLogic.InitialSync
                 {
                     Player.main.oxygenMgr.AddOxygen(statsData.Oxygen);
                     Player.main.liveMixin.health = statsData.Health;
+                    Player.main.GetComponent<Survival>().food = statsData.Food;
+                    Player.main.GetComponent<Survival>().water = statsData.Water;
                     Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
                     if (statsData.InfectionAmount > 0f)
                     {


### PR DESCRIPTION
Sets the players food and water when the player reconnects to the server

Fixes #978 