### PR TITLE
Remove unwanted RunAsAdminMode in launcher

### DIFF
--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -209,7 +209,6 @@
                     </Button>
                 </StackPanel>
                 <StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="32,555,0,-60" Height="39" Width="196">
-                    <TextBlock Margin="0,0,0,8" FontSize="10" Foreground="#C03535" Name="AdminMode">(Running as ADMIN)</TextBlock>
                     <TextBlock Margin="0,0,0,8" FontSize="10" Foreground="#7FFFFFFF">NITROX RELEASE</TextBlock>
                     <TextBlock Margin="0,0,3,0" x:Name="NitroxVersionLabel" Foreground="White" Text="{Binding Version}" />
                 </StackPanel>

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -68,11 +68,6 @@ namespace NitroxLauncher
                 };
             };
 
-            if (AppHelper.IsAppRunningInAdmin())
-            {
-                AdminMode.Visibility = Visibility.Visible;
-            }
-
             logic.ServerStarted += ServerStarted;
             logic.ServerExited += ServerExited;
 

--- a/NitroxLauncher/Patching/AppHelper.cs
+++ b/NitroxLauncher/Patching/AppHelper.cs
@@ -23,7 +23,7 @@ namespace NitroxLauncher
             {
                 MessageBoxResult result = MessageBox.Show(
                     "Nitrox launcher should be executed with administrator permissions in order to properly patch Subnautica while in Program Files directory, do you want to restart ?",
-                    "Program Files Path Detected",
+                    "Nitrox needs permissions",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Question,
                     MessageBoxResult.Yes,
@@ -43,14 +43,15 @@ namespace NitroxLauncher
 
                         // Start the application as new process
                         Process.Start(processStartInfo);
-
                         Environment.Exit(1);
-                    } catch (Exception)
+                    }
+                    catch (Exception)
                     {
                         Log.Error("Error while trying to instance an admin processus of the launcher, aborting");
                     }
                 }
 
+                //We might exit the application if the user says no ?
             }
             else
             {


### PR DESCRIPTION
We agreed on the fact that this textblock isn't really needy, moreover it's pushing the NitroxRelease Version out of the window