### PR TITLE
Updated Args parsing logic for server

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChatInputField.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChatInputField.cs
@@ -109,8 +109,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
 
             if (chatMessage[0] == SERVER_COMMAND_PREFIX)
             {
-                // Remove "/" and split on arguments. TODO: Send as string and let server parse the command
-                session.Send(new ServerCommand(chatMessage.Remove(0, 1).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)));
+                session.Send(new ServerCommand(chatMessage.Remove(0, 1)));
             }
             else
             {

--- a/NitroxModel/Packets/ServerCommand.cs
+++ b/NitroxModel/Packets/ServerCommand.cs
@@ -5,16 +5,16 @@ namespace NitroxModel.Packets
     [Serializable]
     public class ServerCommand : Packet
     {
-        public string[] CmdArgs;
-
-        public ServerCommand(string[] args)
-        {
-            CmdArgs = args;
-        }
+        public readonly string Cmd;
 
         public ServerCommand(string cmd)
         {
-            CmdArgs = cmd.Split(' ');
+            Cmd = cmd;
+        }
+
+        public ServerCommand(string[] cmdArgs)
+        {
+            Cmd = string.Join(" ", cmdArgs);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_day_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_day_Patch.cs
@@ -15,7 +15,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static bool Prefix()
         {
             IPacketSender packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
-            packetSender.Send(new ServerCommand("day"));
+            packetSender.Send(new ServerCommand("time day"));
             return false;
         }
 

--- a/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_night_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_night_Patch.cs
@@ -15,7 +15,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static bool Prefix()
         {
             IPacketSender packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
-            packetSender.Send(new ServerCommand("night"));
+            packetSender.Send(new ServerCommand("time night"));
             return false;
         }
 

--- a/NitroxServer/Communication/Packets/Processors/ServerCommandProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ServerCommandProcessor.cs
@@ -17,10 +17,8 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(ServerCommand packet, Player player)
         {
-            string msg = string.Join(" ", packet.CmdArgs);
-
-            Log.Info($"{player.Name} issued server command: /{msg}");
-            cmdProcessor.ProcessCommand(msg, Optional<Player>.Of(player), player.Permissions);
+            Log.Info($"{player.Name} issued server command: /{packet.Cmd}");
+            cmdProcessor.ProcessCommand(packet.Cmd, Optional<Player>.Of(player), player.Permissions);
         }
     }
 }

--- a/NitroxServer/ConsoleCommands/ChangeAdminPasswordCommand.cs
+++ b/NitroxServer/ConsoleCommands/ChangeAdminPasswordCommand.cs
@@ -2,7 +2,6 @@
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Logger;
 using NitroxServer.ConsoleCommands.Abstract;
-using NitroxServer.GameLogic;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer.ConfigParser;
 

--- a/NitroxServer/ConsoleCommands/ChangeServerPasswordCommand.cs
+++ b/NitroxServer/ConsoleCommands/ChangeServerPasswordCommand.cs
@@ -2,7 +2,6 @@
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Logger;
 using NitroxServer.ConsoleCommands.Abstract;
-using NitroxServer.GameLogic;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer.ConfigParser;
 

--- a/NitroxServer/ConsoleCommands/DeopCommand.cs
+++ b/NitroxServer/ConsoleCommands/DeopCommand.cs
@@ -2,7 +2,6 @@
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer.GameLogic;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Logger;
 
 namespace NitroxServer.ConsoleCommands
 {

--- a/NitroxServer/ConsoleCommands/KickCommand.cs
+++ b/NitroxServer/ConsoleCommands/KickCommand.cs
@@ -28,9 +28,8 @@ namespace NitroxServer.ConsoleCommands
             try
             {
                 Player playerToKick = playerManager.GetConnectedPlayers().Single(t => t.Name == args[0]);
-                args = args.Skip(1).ToArray();
 
-                playerToKick.SendPacket(new PlayerKicked("You were kicked from the server! \n Reason: " + string.Join(" ", args)));
+                playerToKick.SendPacket(new PlayerKicked("You were kicked from the server!"));
                 playerManager.PlayerDisconnected(playerToKick.connection);
                 List<SimulatedEntity> revokedEntities = entitySimulation.CalculateSimulationChangesFromPlayerDisconnect(playerToKick);
 

--- a/NitroxServer/ConsoleCommands/ListCommand.cs
+++ b/NitroxServer/ConsoleCommands/ListCommand.cs
@@ -1,9 +1,9 @@
-﻿using NitroxModel.Logger;
-using NitroxServer.ConsoleCommands.Abstract;
+﻿using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;
 using System.Collections.Generic;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
+using NitroxModel.Logger;
 
 namespace NitroxServer.ConsoleCommands
 {
@@ -22,12 +22,19 @@ namespace NitroxServer.ConsoleCommands
 
             string playerList = "List of players : " + string.Join(", ", players);
 
-            if(players.Count == 0)
+            if (players.Count == 0)
             {
                 playerList += "No players online";
             }
 
-            SendMessageToPlayer(sender, playerList);
+            if (sender.IsPresent())
+            {
+                SendMessageToPlayer(sender, playerList);
+            }
+            else
+            {
+                Log.Info(playerList);
+            }
         }
 
         public override bool VerifyArgs(string[] args)

--- a/NitroxServer/ConsoleCommands/LoginCommand.cs
+++ b/NitroxServer/ConsoleCommands/LoginCommand.cs
@@ -1,8 +1,6 @@
 ﻿using NitroxServer.ConsoleCommands.Abstract;
 using NitroxModel.DataStructures.GameLogic;
-using NitroxServer.GameLogic;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Logger;
 using NitroxServer.ConfigParser;
 
 namespace NitroxServer.ConsoleCommands

--- a/NitroxServer/ConsoleCommands/OpCommand.cs
+++ b/NitroxServer/ConsoleCommands/OpCommand.cs
@@ -1,6 +1,5 @@
 ﻿using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Logger;
 using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;
 

--- a/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
+++ b/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
@@ -7,6 +7,7 @@ using NitroxServer.GameLogic;
 using NitroxModel.Packets;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
+using System;
 
 namespace NitroxServer.ConsoleCommands.Processor
 {
@@ -14,6 +15,7 @@ namespace NitroxServer.ConsoleCommands.Processor
     {
         private readonly Dictionary<string, Command> commands = new Dictionary<string, Command>();
         private readonly PlayerManager playerManager;
+        private readonly char[] splitChar = new[] { ' ' };
 
         public ConsoleCommandProcessor(IEnumerable<Command> cmds, PlayerManager playerManager)
         {
@@ -45,10 +47,8 @@ namespace NitroxServer.ConsoleCommands.Processor
             {
                 return;
             }
-            
-            string[] parts = msg.Split()
-                                .Where(arg => !string.IsNullOrEmpty(arg))
-                                .ToArray();
+
+            string[] parts = msg.Split(splitChar, StringSplitOptions.RemoveEmptyEntries);
 
             Command cmd;
 
@@ -85,8 +85,7 @@ namespace NitroxServer.ConsoleCommands.Processor
             }
             else
             {
-                string errorMessage = string.Format("Received Command Arguments for {0}: {1}", command.Name, command.ArgsDescription);
-                command.Notify(player, errorMessage);
+                command.Notify(player, string.Format("Received Command Arguments for {0}: {1}", command.Name, command.ArgsDescription));
             }
         }
     }

--- a/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
+++ b/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
@@ -14,12 +14,10 @@ namespace NitroxServer.ConsoleCommands.Processor
     public class ConsoleCommandProcessor
     {
         private readonly Dictionary<string, Command> commands = new Dictionary<string, Command>();
-        private readonly PlayerManager playerManager;
         private readonly char[] splitChar = new[] { ' ' };
 
-        public ConsoleCommandProcessor(IEnumerable<Command> cmds, PlayerManager playerManager)
+        public ConsoleCommandProcessor(IEnumerable<Command> cmds)
         {
-            this.playerManager = playerManager;
             foreach (Command cmd in cmds)
             {
                 if (commands.ContainsKey(cmd.Name))

--- a/NitroxServer/ConsoleCommands/TimeCommand.cs
+++ b/NitroxServer/ConsoleCommands/TimeCommand.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using NitroxModel.Core;
-using NitroxModel.DataStructures.GameLogic;
+﻿using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
 using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;

--- a/NitroxServer/ConsoleCommands/WhisperCommand.cs
+++ b/NitroxServer/ConsoleCommands/WhisperCommand.cs
@@ -4,7 +4,6 @@ using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;
 using NitroxModel.Packets;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Logger;
 
 namespace NitroxServer.ConsoleCommands
 {

--- a/NitroxServer/ServerAutoFacRegistrar.cs
+++ b/NitroxServer/ServerAutoFacRegistrar.cs
@@ -20,7 +20,7 @@ namespace NitroxServer
         {
             RegisterCoreDependencies(containerBuilder);
             RegisterWorld(containerBuilder);
-            
+
             RegisterGameSpecificServices(containerBuilder, Assembly.GetCallingAssembly());
             RegisterGameSpecificServices(containerBuilder, Assembly.GetExecutingAssembly());
         }
@@ -36,13 +36,9 @@ namespace NitroxServer
             containerBuilder.RegisterType<EntitySimulation>().SingleInstance();
             containerBuilder.RegisterType<ConsoleCommandProcessor>().SingleInstance();
 
-            containerBuilder.RegisterType<LiteNetLibServer>().SingleInstance();
-            
-            containerBuilder.Register<Communication.NetworkingLayer.NitroxServer>(ctx =>
-            {
-                return ctx.Resolve<LiteNetLibServer>();
-            }).SingleInstance();
-
+            containerBuilder.RegisterType<LiteNetLibServer>()
+                            .As<Communication.NetworkingLayer.NitroxServer>()
+                            .SingleInstance();
         }
 
         private void RegisterWorld(ContainerBuilder containerBuilder)
@@ -64,7 +60,7 @@ namespace NitroxServer
         }
 
         private void RegisterGameSpecificServices(ContainerBuilder containerBuilder, Assembly assembly)
-        {           
+        {
             containerBuilder
                 .RegisterAssemblyTypes(assembly)
                 .AssignableTo<Command>()

--- a/NitroxServer/ServerAutoFacRegistrar.cs
+++ b/NitroxServer/ServerAutoFacRegistrar.cs
@@ -36,9 +36,12 @@ namespace NitroxServer
             containerBuilder.RegisterType<EntitySimulation>().SingleInstance();
             containerBuilder.RegisterType<ConsoleCommandProcessor>().SingleInstance();
 
-            containerBuilder.RegisterType<LiteNetLibServer>()
-                            .As<Communication.NetworkingLayer.NitroxServer>()
-                            .SingleInstance();
+            containerBuilder.RegisterType<LiteNetLibServer>().SingleInstance();
+
+            containerBuilder.Register<Communication.NetworkingLayer.NitroxServer>(ctx =>
+            {
+                return ctx.Resolve<LiteNetLibServer>();
+            }).SingleInstance();
         }
 
         private void RegisterWorld(ContainerBuilder containerBuilder)


### PR DESCRIPTION
- Fixed List Command in Console
- Fixed Kick Command causing server to crash
- Moved Args Parsing logic from Client to ConsoleCommandProcessor
- Removed duplicated string.Join & string.Split that made the arguments split and join several times
- Fixed Day/Night dynamic patches with new Time command