### PR TITLE
Fixed: No air if spawned inside base

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -43,7 +43,7 @@ namespace NitroxClient.GameLogic.InitialSync
                         // If player is not swimming
                         Player.main.SetCurrentSub(root);
 
-                        if (!root.isBase) // Additionally, if player is not in base (has to ba a vehicle)
+                        if (!root.isBase) // Additionally, if player is not in base (has to be a vehicle)
                         {
                             Quaternion vehicleAngle = root.transform.rotation;
                             position = vehicleAngle * position;

--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -38,13 +38,18 @@ namespace NitroxClient.GameLogic.InitialSync
                 {
                     SubRoot root = sub.Get().GetComponent<SubRoot>();
                     // Player position is relative to a subroot if in a subroot
-                    if (root != null && !root.isBase)
-                    {                        
+                    if (root != null)
+                    {
+                        // If player is not swimming
                         Player.main.SetCurrentSub(root);
-                        Quaternion vehicleAngle = root.transform.rotation;
-                        position = vehicleAngle * position;
-                        position = position + root.transform.position;
-                        Player.main.SetPosition(position);
+
+                        if (!root.isBase) // Additionally, if player is not in base (has to ba a vehicle)
+                        {
+                            Quaternion vehicleAngle = root.transform.rotation;
+                            position = vehicleAngle * position;
+                            position = position + root.transform.position;
+                            Player.main.SetPosition(position);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Players that have been spawned inside a base were swimming and lacking oxygen. Upon exiting the base to get oxygen, the "entering animation" was played and they actually entered the base, instead of exiting. This was patched. Now, if you spawn inside a base, you have oxygen and on exit via a hatch, you actually exit the base.