### PR TITLE
NitroxModel: Forward unity logs to "Nitrox Logs/"

### DIFF
--- a/NitroxModel/Logger/Log.cs
+++ b/NitroxModel/Logger/Log.cs
@@ -8,6 +8,7 @@ using log4net.Filter;
 using log4net.Layout;
 using log4net.Repository.Hierarchy;
 using NitroxModel.Discovery;
+using UnityEngine;
 
 namespace NitroxModel.Logger
 {
@@ -16,6 +17,7 @@ namespace NitroxModel.Logger
         private static bool inGameMessages;
 
         private static readonly ILog log = LogManager.GetLogger(GetLoggerName());
+        private static readonly ILog unityLog = LogManager.GetLogger("Unity");
         public static InGameLogger InGameLogger { get; set; }
 
         static Log()
@@ -142,6 +144,35 @@ namespace NitroxModel.Logger
             hierarchy.Root.AddAppender(fileAppender);
 
             hierarchy.Configured = true;
+
+        }
+
+        public static void RegisterUnityHandler()
+        {
+            Application.logMessageReceived += (condition, stacktrace, type) =>
+            {
+                switch (type)
+                {
+                    case LogType.Error:
+                        unityLog.Error(condition);
+                        break;
+                    case LogType.Assert:
+                        unityLog.Error($"Assertion failed: {condition}");
+                        break;
+                    case LogType.Warning:
+                        unityLog.Warn(condition);
+                        break;
+                    case LogType.Log:
+                        unityLog.Debug(condition);
+                        break;
+                    case LogType.Exception:
+                        unityLog.Error($"{condition}\n{stacktrace}");
+                        break;
+                    default:
+                        unityLog.Error($"Unknown type {type}: {condition}\n{stacktrace}");
+                        break;
+                }
+            };
         }
     }
 }

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -27,10 +27,11 @@ namespace NitroxPatcher
         {
             "NitroxModel.dll",
         };
-        
+
         public static void Execute()
         {
             Log.EnableInGameMessages();
+            Log.RegisterUnityHandler();
 
             if (container != null)
             {


### PR DESCRIPTION
Important information like uncaught exceptions that bubble all the way
to the engine do not end up in our logs. They can however be caught from
Unity and forwarded to our log wrapper for convenience.

While an alternative might be to omit Nitrox's logfile alltogether and
rely on Player.log this has the additional benefit of proper formatting;
the log tag includes the time and source (Server/Client/Unity) making
it much easier on the eyes.

--- 

As discussed on Discord this might be handy to have. I was astounded to not see any exceptions in the log while they were definitely occuring. Am I using the wrong logging facility (with `Player.log` and the console of an attached debugger as alternatives) and are these files simply unused?

TODO:
- Should we remove `LogType.Log`? The game is rather spammy here
- The `ConsoleAppender` indirectly forwards the logs to `Player.log`, making them appear twice. Any ideas to solve that, perhaps a filter on `LoggerName` or changing the layout of the loggers?