### PR TITLE
Fixed game finder not checking current directory

### DIFF
--- a/NitroxModel/Discovery/GameInstallationFinder.cs
+++ b/NitroxModel/Discovery/GameInstallationFinder.cs
@@ -11,7 +11,11 @@ namespace NitroxModel.Discovery
     /// </summary>
     public class GameInstallationFinder : IFindGameInstallation
     {
+        /// <summary>
+        ///     The order of these finders is VERY important. Only change if you know what you're doing.
+        /// </summary>
         private readonly IFindGameInstallation[] finders = {
+            new GameInCurrentDirectoryFinder(),
             new ConfigFileGameFinder(),
             new EpicGamesInstallationFinder(),
             new SteamGameRegistryFinder(),

--- a/NitroxModel/Discovery/InstallationFinders/GameInCurrentDirectoryFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/GameInCurrentDirectoryFinder.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using NitroxModel.DataStructures.Util;
+
+namespace NitroxModel.Discovery.InstallationFinders
+{
+    public class GameInCurrentDirectoryFinder : IFindGameInstallation
+    {
+        public Optional<string> FindGame(List<string> errors = null)
+        {
+            string currentDirectory = Directory.GetCurrentDirectory();
+            if (File.Exists(Path.Combine(currentDirectory, "Subnautica.exe")))
+            {
+                return Optional<string>.Of(currentDirectory);
+            }
+
+            return Optional<string>.Empty();
+        }
+    }
+}

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -262,6 +262,7 @@
     <Compile Include="DataStructures\TechType.cs" />
     <Compile Include="Discovery\InstallationFinders\EpicGamesInstallationFinder.cs" />
     <Compile Include="Discovery\IFindGameInstallation.cs" />
+    <Compile Include="Discovery\InstallationFinders\GameInCurrentDirectoryFinder.cs" />
     <Compile Include="Discovery\InstallationFinders\SteamGameRegistryFinder.cs" />
     <Compile Include="Discovery\InstallationFinders\ConfigFileGameFinder.cs" />
     <Compile Include="Helper\Mathf.cs" />


### PR DESCRIPTION
This caused the logs to be written to another game install directory depending on the order of the game install finders.