### PR TITLE
Fix server persist

### DIFF
--- a/NitroxClient/Communication/Abstract/IPacketSender.cs
+++ b/NitroxClient/Communication/Abstract/IPacketSender.cs
@@ -4,7 +4,13 @@ namespace NitroxClient.Communication.Abstract
 {
     public interface IPacketSender
     {
-        void Send(Packet packet);
+        /// <summary>
+        ///     Sends the packet. Returns true if packet was not suppressed.
+        /// </summary>
+        /// <param name="packet">The packet to send.</param>
+        /// <returns>True if not suppressed and actually sent.</returns>
+        bool Send(Packet packet);
+
         PacketSuppressor<T> Suppress<T>();
     }
 }

--- a/NitroxClient/Communication/MultiplayerSession/MultiplayerSessionManager.cs
+++ b/NitroxClient/Communication/MultiplayerSession/MultiplayerSessionManager.cs
@@ -94,11 +94,6 @@ namespace NitroxClient.Communication.MultiplayerSession
             }
         }
 
-        /// <summary>
-        /// Sends the packet to the server.
-        /// </summary>
-        /// <param name="packet">Packet to send</param>
-        /// <returns>True if packet was send successfully. False if suppressed.</returns>
         public bool Send(Packet packet)
         {
             Type packetType = packet.GetType();

--- a/NitroxClient/Communication/MultiplayerSession/MultiplayerSessionManager.cs
+++ b/NitroxClient/Communication/MultiplayerSession/MultiplayerSessionManager.cs
@@ -94,12 +94,20 @@ namespace NitroxClient.Communication.MultiplayerSession
             }
         }
 
-        public void Send(Packet packet)
+        /// <summary>
+        /// Sends the packet to the server.
+        /// </summary>
+        /// <param name="packet">Packet to send</param>
+        /// <returns>True if packet was send successfully. False if suppressed.</returns>
+        public bool Send(Packet packet)
         {
-            if (!suppressedPacketsTypes.Contains(packet.GetType()))
+            Type packetType = packet.GetType();
+            if (!suppressedPacketsTypes.Contains(packetType))
             {
                 Client.Send(packet);
+                return true;
             }
+            return false;
         }
 
         public PacketSuppressor<T> Suppress<T>()

--- a/NitroxClient/Communication/Packets/Processors/ItemContainerRemoveProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/ItemContainerRemoveProcessor.cs
@@ -1,5 +1,4 @@
-﻿using NitroxClient.Communication.Abstract;
-using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel.Packets;
 
@@ -7,12 +6,10 @@ namespace NitroxClient.Communication.Packets.Processors
 {
     public class ItemContainerRemoveProcessor : ClientPacketProcessor<ItemContainerRemove>
     {
-        private readonly IPacketSender packetSender;
         private readonly ItemContainers itemContainer;
 
-        public ItemContainerRemoveProcessor(IPacketSender packetSender, ItemContainers itemContainer)
+        public ItemContainerRemoveProcessor(ItemContainers itemContainer)
         {
-            this.packetSender = packetSender;
             this.itemContainer = itemContainer;
         }
 

--- a/NitroxClient/GameLogic/EscapePodManager.cs
+++ b/NitroxClient/GameLogic/EscapePodManager.cs
@@ -43,7 +43,6 @@ namespace NitroxClient.GameLogic
             EscapePod.main.playerSpawn.position = escapePod.Location + playerSpawnRelativeToEscapePodPosition; // This Might not correctly handle rotated EscapePods
 
             Rigidbody rigidbody = EscapePod.main.GetComponent<Rigidbody>();
-
             if (rigidbody != null)
             {
                 Log.Debug("Freezing escape pod rigidbody");
@@ -93,7 +92,7 @@ namespace NitroxClient.GameLogic
             }
             else
             {
-                escapePod = UnityEngine.Object.Instantiate(EscapePod.main.gameObject);
+                escapePod = Object.Instantiate(EscapePod.main.gameObject);
             }
 
             escapePod.transform.position = model.Location;

--- a/NitroxClient/GameLogic/Helper/InventoryContainerHelper.cs
+++ b/NitroxClient/GameLogic/Helper/InventoryContainerHelper.cs
@@ -12,13 +12,11 @@ namespace NitroxClient.GameLogic.Helper
             {
                 return Optional.Of(seamothStorageContainer.container);
             }
-
             StorageContainer storageContainer = owner.GetComponentInChildren<StorageContainer>();
             if (storageContainer != null)
             {
                 return Optional.Of(storageContainer.container);
             }
-
             if (owner.name == "Player")
             {
                 return Optional.Of(Inventory.Get().container);

--- a/NitroxClient/GameLogic/Helper/VehicleChildObjectIdentifierHelper.cs
+++ b/NitroxClient/GameLogic/Helper/VehicleChildObjectIdentifierHelper.cs
@@ -10,24 +10,24 @@ namespace NitroxClient.GameLogic.Helper
 {
     public class VehicleChildObjectIdentifierHelper
     {
-        private static readonly List<Type> interactiveChildTypes = new List<Type>() // we must sync ids of these types when creating vehicles (mainly cyclops)
+        private static readonly List<Type> interactiveChildTypes = new List<Type> // we must sync ids of these types when creating vehicles (mainly cyclops)
         {
-            { typeof(Openable) },
-            { typeof(CyclopsLocker) },
-            { typeof(Fabricator) },
-            { typeof(FireExtinguisherHolder) },
-            { typeof(StorageContainer) },
-            { typeof(SeamothStorageContainer) },
-            { typeof(VehicleDockingBay) },
-            { typeof(DockedVehicleHandTarget) },
-            { typeof(UpgradeConsole) },
-            { typeof(DockingBayDoor) },
-            { typeof(CyclopsDecoyLoadingTube) },
-            { typeof(BatterySource) },
-            { typeof(EnergyMixin) }
+            typeof(Openable),
+            typeof(CyclopsLocker),
+            typeof(Fabricator),
+            typeof(FireExtinguisherHolder),
+            typeof(StorageContainer),
+            typeof(SeamothStorageContainer),
+            typeof(VehicleDockingBay),
+            typeof(DockedVehicleHandTarget),
+            typeof(UpgradeConsole),
+            typeof(DockingBayDoor),
+            typeof(CyclopsDecoyLoadingTube),
+            typeof(BatterySource),
+            typeof(EnergyMixin)
         };
 
-        public static  List<InteractiveChildObjectIdentifier> ExtractInteractiveChildren(GameObject constructedObject)
+        public static List<InteractiveChildObjectIdentifier> ExtractInteractiveChildren(GameObject constructedObject)
         {
             List<InteractiveChildObjectIdentifier> interactiveChildren = new List<InteractiveChildObjectIdentifier>();
 
@@ -55,10 +55,10 @@ namespace NitroxClient.GameLogic.Helper
             return interactiveChildren;
         }
 
-        public static void SetInteractiveChildrenIds(GameObject constructedObject, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers)
+        public static void SetInteractiveChildrenIds(GameObject constructedObject, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers)
         {
             foreach (InteractiveChildObjectIdentifier childIdentifier in interactiveChildIdentifiers)
-            {                
+            {
                 Transform transform = constructedObject.transform.Find(childIdentifier.GameObjectNamePath);
 
                 if (transform != null)

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -73,7 +73,7 @@ namespace NitroxClient.GameLogic
             Optional<ItemsContainer> opContainer = InventoryContainerHelper.GetBasedOnOwnersType(owner);
             if (!opContainer.HasValue)
             {
-                Log.Error($"Could not find item container behaviour on object '{owner.name}' with Nitrox id '{ownerId}'");
+                Log.Warn($"Could not find item container behaviour on object '{owner.name}' with Nitrox id '{ownerId}'");
                 return;
             }
 

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -16,62 +16,32 @@ namespace NitroxClient.GameLogic
     public class ItemContainers
     {
         private readonly IPacketSender packetSender;
-        private readonly LocalPlayer localPlayer;
 
-        public ItemContainers(IPacketSender packetSender, LocalPlayer localPlayer)
+        public ItemContainers(IPacketSender packetSender)
         {
             this.packetSender = packetSender;
-            this.localPlayer = localPlayer;
         }
 
-        public void BroadcastItemAdd(Pickupable pickupable, Transform ownerTransform)
+        public void BroadcastItemAdd(Pickupable pickupable, Transform containerTransform)
         {
-            NitroxId ownerId = null;
-            bool isCyclopsLocker = Regex.IsMatch(ownerTransform.gameObject.name, @"Locker0([0-9])StorageRoot$", RegexOptions.IgnoreCase);
-            bool isEscapePodStorage = ownerTransform.parent.name.StartsWith("EscapePod");
-            if (isCyclopsLocker)
-            {
-                ownerId = GetCyclopsLockerId(ownerTransform);
-            }
-            else if (isEscapePodStorage)
-            {
-                ownerId = GetEscapePodStorageId(ownerTransform);
-            }
-            else
-            {
-                ownerId = NitroxEntity.GetId(ownerTransform.transform.parent.gameObject);
-            }
-
             NitroxId itemId = NitroxEntity.GetId(pickupable.gameObject);
             byte[] bytes = SerializationHelper.GetBytes(pickupable.gameObject);
 
-            ItemData itemData = new ItemData(ownerId, itemId, bytes);
-            ItemContainerAdd add = new ItemContainerAdd(itemData);
-            packetSender.Send(add);
+            ItemData itemData = new ItemData(GetOwner(containerTransform), itemId, bytes);
+            if (packetSender.Send(new ItemContainerAdd(itemData)))
+            {
+                Log.Debug($"Sent: Added item '{pickupable.GetTechType()}' to container '{containerTransform.gameObject.GetHierarchyPath()}'");
+            }
         }
 
-        public void BroadcastItemRemoval(Pickupable pickupable, Transform ownerTransform)
+        public void BroadcastItemRemoval(Pickupable pickupable, Transform containerTransform)
         {
-            NitroxId ownerId = null;
-
-            bool isCyclopsLocker = Regex.IsMatch(ownerTransform.gameObject.name, @"Locker0([0-9])StorageRoot$", RegexOptions.IgnoreCase);
-            bool isEscapePodStorage = ownerTransform.parent.name.StartsWith("EscapePod");
-            if (isCyclopsLocker)
-            {
-                ownerId = GetCyclopsLockerId(ownerTransform);
-            }
-            else if (isEscapePodStorage)
-            {
-                ownerId = GetEscapePodStorageId(ownerTransform);
-            }
-            else
-            {
-                ownerId = NitroxEntity.GetId(ownerTransform.transform.parent.gameObject);
-            }
-
             NitroxId itemId = NitroxEntity.GetId(pickupable.gameObject);
-            ItemContainerRemove remove = new ItemContainerRemove(ownerId, itemId);
-            packetSender.Send(remove);
+            if (packetSender.Send(new ItemContainerRemove(GetOwner(containerTransform), itemId)))
+            {
+                Log.Debug($"Sent: removed item '{pickupable.GetTechType()}' from container '{containerTransform.gameObject.GetHierarchyPath()}'");
+                Log.Debug(Environment.StackTrace);
+            }
         }
 
         public void AddItem(GameObject item, NitroxId containerId)
@@ -79,16 +49,16 @@ namespace NitroxClient.GameLogic
             Optional<GameObject> owner = NitroxEntity.GetObjectFrom(containerId);
             if (!owner.HasValue)
             {
-                Log.Info("Unable to find inventory container with id: " + containerId);
+                Log.Warn("Unable to find inventory container with id: " + containerId);
                 return;
             }
             Optional<ItemsContainer> opContainer = InventoryContainerHelper.GetBasedOnOwnersType(owner.Value);
             if (!opContainer.HasValue)
             {
-                Log.Error("Could not find container field on object " + owner.Value.name);
+                Log.Warn("Could not find container field on object " + owner.Value.name);
                 return;
             }
-            
+
             ItemsContainer container = opContainer.Value;
             Pickupable pickupable = item.RequireComponent<Pickupable>();
             using (packetSender.Suppress<ItemContainerAdd>())
@@ -96,7 +66,7 @@ namespace NitroxClient.GameLogic
                 container.UnsafeAdd(new InventoryItem(pickupable));
             }
         }
-        
+
         public void RemoveItem(NitroxId ownerId, NitroxId itemId)
         {
             GameObject owner = NitroxEntity.RequireObjectFrom(ownerId);
@@ -104,10 +74,10 @@ namespace NitroxClient.GameLogic
             Optional<ItemsContainer> opContainer = InventoryContainerHelper.GetBasedOnOwnersType(owner);
             if (!opContainer.HasValue)
             {
-                Log.Error("Could not find container field on object " + owner.name);
+                Log.Error($"Could not find item container behaviour on object '{owner.name}' with Nitrox id '{ownerId}'");
                 return;
             }
-            
+
             ItemsContainer container = opContainer.Value;
             Pickupable pickupable = item.RequireComponent<Pickupable>();
             using (packetSender.Suppress<ItemContainerRemove>())
@@ -120,25 +90,39 @@ namespace NitroxClient.GameLogic
         {
             string LockerId = ownerTransform.gameObject.name.Substring(7, 1);
             GameObject locker = ownerTransform.parent.gameObject.FindChild("submarine_locker_01_0" + LockerId);
-            
-            if (locker != null)
+            if (!locker)
             {
-                StorageContainer SC = locker.GetComponentInChildren<StorageContainer>();
-                if (SC != null)
-                {
-                    return NitroxEntity.GetId(SC.gameObject);
-                }
-                throw new Exception("Could not find StorageContainer From Object: submarine_locker_01_0" + LockerId);
-
+                throw new Exception("Could not find Locker Object: submarine_locker_01_0" + LockerId);
             }
-            throw new Exception("Could not find Locker Object: submarine_locker_01_0" + LockerId);
-
+            StorageContainer storageContainer = locker.GetComponentInChildren<StorageContainer>();
+            if (!storageContainer)
+            {
+                throw new Exception($"Could not find {nameof(StorageContainer)} From Object: submarine_locker_01_0{LockerId}");                
+            }
+            
+            return NitroxEntity.GetId(storageContainer.gameObject);
         }
 
         public NitroxId GetEscapePodStorageId(Transform ownerTransform)
         {
             StorageContainer SC = ownerTransform.parent.gameObject.RequireComponentInChildren<StorageContainer>();
             return NitroxEntity.GetId(SC.gameObject);
+        }
+
+        private NitroxId GetOwner(Transform ownerTransform)
+        {
+            bool isCyclopsLocker = Regex.IsMatch(ownerTransform.gameObject.name, @"Locker0([0-9])StorageRoot$", RegexOptions.IgnoreCase);
+            if (isCyclopsLocker)
+            {
+                return GetCyclopsLockerId(ownerTransform);
+            }
+            bool isEscapePodStorage = ownerTransform.parent.name.StartsWith("EscapePod");
+            if (isEscapePodStorage)
+            {
+                return GetEscapePodStorageId(ownerTransform);
+            }
+
+            return NitroxEntity.GetId(ownerTransform.parent.gameObject);
         }
     }
 }

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -40,7 +40,6 @@ namespace NitroxClient.GameLogic
             if (packetSender.Send(new ItemContainerRemove(GetOwner(containerTransform), itemId)))
             {
                 Log.Debug($"Sent: removed item '{pickupable.GetTechType()}' from container '{containerTransform.gameObject.GetHierarchyPath()}'");
-                Log.Debug(Environment.StackTrace);
             }
         }
 

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -48,13 +48,13 @@ namespace NitroxClient.GameLogic
             Optional<GameObject> owner = NitroxEntity.GetObjectFrom(containerId);
             if (!owner.HasValue)
             {
-                Log.Warn("Unable to find inventory container with id: " + containerId);
+                Log.Error("Unable to find inventory container with id: " + containerId);
                 return;
             }
             Optional<ItemsContainer> opContainer = InventoryContainerHelper.GetBasedOnOwnersType(owner.Value);
             if (!opContainer.HasValue)
             {
-                Log.Warn("Could not find container field on object " + owner.Value.name);
+                Log.Error("Could not find container field on object " + owner.Value.name);
                 return;
             }
 
@@ -73,7 +73,7 @@ namespace NitroxClient.GameLogic
             Optional<ItemsContainer> opContainer = InventoryContainerHelper.GetBasedOnOwnersType(owner);
             if (!opContainer.HasValue)
             {
-                Log.Warn($"Could not find item container behaviour on object '{owner.name}' with Nitrox id '{ownerId}'");
+                Log.Error($"Could not find item container behaviour on object '{owner.name}' with Nitrox id '{ownerId}'");
                 return;
             }
 

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -43,7 +43,7 @@ namespace NitroxClient.GameLogic
             CreateVehicle(vehicleModel.TechType.Enum(), vehicleModel.Id, vehicleModel.Position, vehicleModel.Rotation, vehicleModel.InteractiveChildIdentifiers, vehicleModel.DockingBayId, vehicleModel.Name, vehicleModel.HSB, vehicleModel.Colours, vehicleModel.Health);            
         }
 
-        public void CreateVehicle(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
+        public void CreateVehicle(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
         {
             if (techType == TechType.Cyclops)
             {
@@ -133,7 +133,7 @@ namespace NitroxClient.GameLogic
             }
         }
 
-        private void OnVehiclePrefabLoaded(TechType techType, GameObject prefab, NitroxId id, Vector3 spawnPosition, Quaternion spawnRotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
+        private void OnVehiclePrefabLoaded(TechType techType, GameObject prefab, NitroxId id, Vector3 spawnPosition, Quaternion spawnRotation, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
         {
             // Partially copied from SubConsoleCommand.OnSubPrefabLoaded
             GameObject gameObject = Utils.SpawnPrefabAt(prefab, null, spawnPosition);

--- a/NitroxClient/MonoBehaviours/NitroxEntity.cs
+++ b/NitroxClient/MonoBehaviours/NitroxEntity.cs
@@ -72,7 +72,7 @@ namespace NitroxClient.MonoBehaviours
         public static NitroxId GetId(GameObject gameObject)
         {
             NitroxEntity entity = gameObject.GetComponent<NitroxEntity>();
-            if (entity != null)
+            if (entity)
             {
                 return entity.Id;
             }

--- a/NitroxClient/Unity/Helper/GameObjectHelper.cs
+++ b/NitroxClient/Unity/Helper/GameObjectHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using NitroxModel.Helper;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -72,6 +73,44 @@ namespace NitroxClient.Unity.Helper
                 return obj;
             }
             return null;
+        }
+
+        public static string GetHierarchyPath(this GameObject obj)
+        {
+            if (!obj)
+            {
+                return "";
+            }
+
+            return GetHierarchyPathBuilder(obj, new StringBuilder());
+        }
+
+        public static string GetHierarchyPath(this Component component)
+        {
+            if (!component)
+            {
+                return "";
+            }
+
+            // Append component name
+            StringBuilder builder = new StringBuilder();
+            builder.Insert(0, component.name);
+            builder.Insert(0, ".");
+
+            // Append path of GameObject hierarchy
+            return GetHierarchyPathBuilder(component.gameObject, builder);
+        }
+
+        private static string GetHierarchyPathBuilder(this GameObject obj, StringBuilder builder)
+        {
+            Transform parent = obj.transform;
+            while (parent)
+            {
+                builder.Insert(0, parent.name);
+                builder.Insert(0, "/");
+                parent = parent.transform.parent;
+            }
+            return builder.ToString();
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
+++ b/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NitroxModel.Helper;
-using UnityEngine;
 using ProtoBufNet;
+using UnityEngine;
 
 namespace NitroxModel.DataStructures.GameLogic
 {
@@ -10,13 +10,25 @@ namespace NitroxModel.DataStructures.GameLogic
     public class AbsoluteEntityCell
     {
         [ProtoMember(1)]
-        public Int3 BatchId { get; set; }
-        
+        public Int3 BatchId { get; }
+
         [ProtoMember(2)]
-        public Int3 CellId { get; set; }
-        
+        public Int3 CellId { get; }
+
         [ProtoMember(3)]
-        public int Level { get; set; }
+        public int Level { get; }
+
+        private Int3 BatchPosition => BatchId * Map.Main.BatchSize - Map.Main.BatchDimensionCenter;
+        public Int3 Position => BatchPosition + CellId * GetCellSize();
+
+        public Int3 Center
+        {
+            get
+            {
+                Int3 cellSize = GetCellSize();
+                return BatchPosition + CellId * cellSize + (cellSize >> 1);
+            }
+        }
 
         public AbsoluteEntityCell()
         {
@@ -37,66 +49,24 @@ namespace NitroxModel.DataStructures.GameLogic
             Vector3 localPosition = (worldSpace + Map.Main.BatchDimensionCenter.ToVector3()) / Map.Main.BatchSize;
             BatchId = Int3.Floor(localPosition);
 
-            Vector3 cell = (localPosition - BatchId.ToVector3()) * GetCellsPerBlock();            
+            Vector3 cell = (localPosition - BatchId.ToVector3()) * GetCellsPerBlock();
             CellId = Int3.Floor(new Vector3(cell.x + 0.0001f, cell.y + 0.0001f, cell.z + 0.0001f));
         }
 
-        private Int3 BatchPosition => BatchId * Map.Main.BatchSize - Map.Main.BatchDimensionCenter;
-        public Int3 Position => BatchPosition + CellId * GetCellSize();
-        public Int3 Center
+        public static bool operator ==(AbsoluteEntityCell left, AbsoluteEntityCell right)
         {
-            get
-            {
-                Int3 cellSize = GetCellSize();
-                return BatchPosition + CellId * cellSize + (cellSize >> 1);
-            }
+            return Equals(left, right);
         }
 
-        public override string ToString()
+        public static bool operator !=(AbsoluteEntityCell left, AbsoluteEntityCell right)
         {
-            return "[AbsoluteEntityCell Position: " + Position + " BatchId: " + BatchId + " CellId: " + CellId + " Level: " + Level + " ]";
-        }
-
-        public override bool Equals(object obj)
-        {
-            // Check for null values and compare run-time types.
-            if (obj == null || GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            AbsoluteEntityCell cell = (AbsoluteEntityCell)obj;
-
-            return cell.Level == Level && cell.BatchId == BatchId && cell.CellId == CellId;
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (269 + Level * 23 + BatchId.GetHashCode()) * 23 + CellId.GetHashCode();
-            }
-        }
-
-        public Int3 GetCellSize()
-        {
-            return GetCellSize(Map.Main.BatchDimensions);
-        }
-
-        public Int3 GetCellSize(Int3 blocksPerBatch)
-        {
-            return GetCellSize(Level, blocksPerBatch);
+            return !Equals(left, right);
         }
 
         public static Int3 GetCellSize(int level, Int3 blocksPerBatch)
         {
             // Our own implementation for BatchCells.GetCellSize, that works on the server and client.
             return blocksPerBatch / GetCellsPerBlock(level);
-        }
-
-        public int GetCellsPerBlock()
-        {
-            return GetCellsPerBlock(Level);
         }
 
         public static int GetCellsPerBlock(int level)
@@ -112,6 +82,59 @@ namespace NitroxModel.DataStructures.GameLogic
                 default:
                     throw new Exception();
             }
+        }
+
+        public override string ToString()
+        {
+            return "[AbsoluteEntityCell Position: " + Position + " BatchId: " + BatchId + " CellId: " + CellId + " Level: " + Level + " ]";
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+            return Equals((AbsoluteEntityCell)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = BatchId != null ? BatchId.GetHashCode() : 0;
+                hash = (hash * 397) ^ (CellId != null ? CellId.GetHashCode() : 0);
+                hash = (hash * 397) ^ Level;
+                return hash;
+            }
+        }
+
+        public Int3 GetCellSize()
+        {
+            return GetCellSize(Map.Main.BatchDimensions);
+        }
+
+        public Int3 GetCellSize(Int3 blocksPerBatch)
+        {
+            return GetCellSize(Level, blocksPerBatch);
+        }
+
+        public int GetCellsPerBlock()
+        {
+            return GetCellsPerBlock(Level);
+        }
+
+        protected bool Equals(AbsoluteEntityCell other)
+        {
+            return Equals(BatchId, other.BatchId) && Equals(CellId, other.CellId) && Level == other.Level;
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
+++ b/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
@@ -80,7 +80,7 @@ namespace NitroxModel.DataStructures.GameLogic
                 case 3:
                     return 5;
                 default:
-                    throw new Exception();
+                    throw new Exception($"Given level '{level}' does not have any defined cells.");
             }
         }
 

--- a/NitroxModel/DataStructures/GameLogic/PDALogEntry.cs
+++ b/NitroxModel/DataStructures/GameLogic/PDALogEntry.cs
@@ -23,5 +23,10 @@ namespace NitroxModel.DataStructures.GameLogic
             Key = key;
             Timestamp = timestamp;
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(Key)}: {Key}, {nameof(Timestamp)}: {Timestamp}";
+        }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/VehicleModel.cs
+++ b/NitroxModel/DataStructures/GameLogic/VehicleModel.cs
@@ -1,7 +1,7 @@
-﻿using NitroxModel.DataStructures.Util;
-using ProtoBufNet;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using NitroxModel.DataStructures.Util;
+using ProtoBufNet;
 using UnityEngine;
 
 namespace NitroxModel.DataStructures.GameLogic
@@ -23,7 +23,7 @@ namespace NitroxModel.DataStructures.GameLogic
         public Quaternion Rotation { get; set; }
 
         [ProtoMember(5)]
-        public List<InteractiveChildObjectIdentifier> InteractiveChildIdentifiers { get; set; } = new List<InteractiveChildObjectIdentifier>();
+        public ThreadSafeCollection<InteractiveChildObjectIdentifier> InteractiveChildIdentifiers { get; }
 
         [ProtoMember(6)]
         public Optional<NitroxId> DockingBayId { get; set; }
@@ -42,17 +42,19 @@ namespace NitroxModel.DataStructures.GameLogic
 
         public VehicleModel()
         {
-            InteractiveChildIdentifiers = new List<InteractiveChildObjectIdentifier>();
+            InteractiveChildIdentifiers = new ThreadSafeCollection<InteractiveChildObjectIdentifier>();
             DockingBayId = Optional.Empty;
         }
 
-        public VehicleModel(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
+        public VehicleModel(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb,
+            Vector3[] colours,
+            float health)
         {
             TechType = techType;
             Id = id;
             Position = position;
             Rotation = rotation;
-            InteractiveChildIdentifiers = interactiveChildIdentifiers;
+            InteractiveChildIdentifiers = new ThreadSafeCollection<InteractiveChildObjectIdentifier>(interactiveChildIdentifiers);
             DockingBayId = dockingBayId;
             Name = name;
             HSB = hsb;

--- a/NitroxModel/DataStructures/NitroxId.cs
+++ b/NitroxModel/DataStructures/NitroxId.cs
@@ -6,6 +6,9 @@ using ProtoBufNet;
 
 namespace NitroxModel.DataStructures
 {
+    /// <summary>
+    ///     Used to reference a Unity GameObject and makes it possible to synchronize a GameObject between connected players.
+    /// </summary>
     [ProtoContract]
     [Serializable]
     public class NitroxId : ISerializable
@@ -19,7 +22,7 @@ namespace NitroxModel.DataStructures
         }
 
         /// <summary>
-        /// Create a NitroxId from a string
+        ///     Create a NitroxId from a string
         /// </summary>
         /// <param name="str">a NitroxID as string</param>
         public NitroxId(string str)
@@ -38,6 +41,24 @@ namespace NitroxModel.DataStructures
             guid = new Guid(bytes);
         }
 
+        public static bool operator ==(NitroxId id1, NitroxId id2)
+        {
+            if (ReferenceEquals(id1, null))
+            {
+                if (ReferenceEquals(id2, null))
+                {
+                    return true;
+                }
+                return false;
+            }
+            return id1.Equals(id2);
+        }
+
+        public static bool operator !=(NitroxId id1, NitroxId id2)
+        {
+            return !(id1 == id2);
+        }
+
         [SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -50,24 +71,6 @@ namespace NitroxModel.DataStructures
 
             return id != null &&
                    guid.Equals(id.guid);
-        }
-
-        public static bool operator ==(NitroxId id1, NitroxId id2)
-        {
-            if (Object.ReferenceEquals(id1, null))
-            {
-                if (Object.ReferenceEquals(id2, null))
-                {
-                    return true;
-                }
-                return false;
-            }
-            return id1.Equals(id2);
-        }
-
-        public static bool operator !=(NitroxId id1, NitroxId id2)
-        {
-            return !(id1 == id2);
         }
 
         public override int GetHashCode()

--- a/NitroxModel/DataStructures/SimulatedEntity.cs
+++ b/NitroxModel/DataStructures/SimulatedEntity.cs
@@ -20,7 +20,7 @@ namespace NitroxModel.DataStructures
 
         public override string ToString()
         {
-            return "[SimulatedEntity Id: " + Id + " PlayerId: " + PlayerId + " IsEntity: " + ChangesPosition + " LockType: " + LockType + "]";
+            return $"[SimulatedEntity Id: '{Id}' PlayerId: {PlayerId} IsEntity: {ChangesPosition} LockType: {LockType}]";
         }
     }
 }

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -75,6 +75,17 @@ namespace NitroxModel.DataStructures
             collection = new List<T>(initialCapacity);
         }
 
+        public bool IsSet
+        {
+            get
+            {
+                lock (locker)
+                {
+                    return collection is ISet<T>;
+                }
+            }
+        }
+
         public ThreadSafeCollection(IEnumerable<T> collection, bool createCopy = true)
         {
             ICollection<T> coll = collection as ICollection<T>;
@@ -175,7 +186,7 @@ namespace NitroxModel.DataStructures
                 IList<T> list = collection as IList<T>;
                 if (list != null)
                 {
-                    list.RemoveAt(0);
+                    list.RemoveAt(index);
                     return true;
                 }
                 ISet<T> set = collection as ISet<T>;

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -211,5 +211,24 @@ namespace NitroxModel.DataStructures
         {
             return GetEnumerator();
         }
+
+        public void RemoveAll(Func<T, bool> predicate)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                foreach (T item in collection)
+                {
+                    if (predicate(item))
+                    {
+                        collection.Remove(item);
+                    }
+                }
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
     }
 }

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -13,37 +13,12 @@ namespace NitroxModel.DataStructures
     public class ThreadSafeCollection<T> : IList<T>
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [ProtoMember(1)]
-        private ICollection<T> collection;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         [ProtoIgnore]
         private readonly object locker = new object();
 
-        void IList<T>.RemoveAt(int index)
-        {
-            lock (locker)
-            {
-                IList<T> asList = collection as IList<T>;
-                if (asList != null)
-                {
-                    asList.RemoveAt(index);
-                    return;
-                }
-
-                ICollection<T> set = CreateCopy(collection);
-                int currentIndex = 0;
-                foreach (T item in collection)
-                {
-                    if (index != currentIndex)
-                    {
-                        set.Add(item);
-                    }
-                    currentIndex++;
-                }
-                collection = set;
-            }
-        }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [ProtoMember(1)]
+        private ICollection<T> collection;
 
         public T this[int i]
         {
@@ -64,7 +39,7 @@ namespace NitroxModel.DataStructures
                         asList[i] = value;
                         return;
                     }
-                    
+
                     ICollection<T> set = CreateCopy(collection);
                     int currentIndex = 0;
                     foreach (T item in collection)
@@ -275,6 +250,39 @@ namespace NitroxModel.DataStructures
                         collection.Remove(item);
                     }
                 }
+            }
+        }
+
+        public IEnumerable<T> Clone()
+        {
+            lock (locker)
+            {
+                return CreateCopy(collection);
+            }
+        }
+
+        void IList<T>.RemoveAt(int index)
+        {
+            lock (locker)
+            {
+                IList<T> asList = collection as IList<T>;
+                if (asList != null)
+                {
+                    asList.RemoveAt(index);
+                    return;
+                }
+
+                ICollection<T> set = CreateCopy(collection);
+                int currentIndex = 0;
+                foreach (T item in collection)
+                {
+                    if (index != currentIndex)
+                    {
+                        set.Add(item);
+                    }
+                    currentIndex++;
+                }
+                collection = set;
             }
         }
 

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using ProtoBufNet;
+
+namespace NitroxModel.DataStructures
+{
+    [DebuggerDisplay("Items = {" + nameof(collection) + "}")]
+    [ProtoContract]
+    [Serializable]
+    public class ThreadSafeCollection<T> : IDisposable, IEnumerable<T>
+    {
+        [ProtoMember(1)]
+        private readonly ICollection<T> collection;
+
+        private readonly ReaderWriterLockSlim locker = new ReaderWriterLockSlim();
+
+        public T this[int i]
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return collection.ElementAt(i);
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return collection.Count;
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+        }
+
+        public ThreadSafeCollection()
+        {
+            collection = new List<T>();
+        }
+
+        public ThreadSafeCollection(IEnumerable<T> collection, bool createCopy = true)
+        {
+            ICollection<T> coll = collection as ICollection<T>;
+            if (coll == null || createCopy)
+            {
+                this.collection = CreateCopy(collection);
+                return;
+            }
+            this.collection = coll;
+        }
+
+        public void Add(T item)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                collection.Add(item);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                return collection.Remove(item);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool RemoveAt(int index)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                IList<T> list = collection as IList<T>;
+                if (list != null)
+                {
+                    list.RemoveAt(0);
+                    return true;
+                }
+                ISet<T> set = collection as ISet<T>;
+                if (set != null)
+                {
+                    T elem = set.ElementAtOrDefault(index);
+                    return elem != null && set.Remove(elem);
+                }
+                return false;
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return collection.Contains(item);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public T TryGetValue(int index, out bool succeeded)
+        {
+            try
+            {
+                succeeded = false;
+                locker.EnterReadLock();
+                T result = collection.ElementAtOrDefault(index);
+                succeeded = !Equals(result, default(T));
+                return result;
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public void Dispose()
+        {
+            locker?.Dispose();
+        }
+
+        public List<T> ToList()
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return new List<T>(collection);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return CreateCopy(collection).GetEnumerator();
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        ///     Clears the collection and adds the given items.
+        /// </summary>
+        /// <param name="items">Items to add onto the empty collection.</param>
+        public void Set(IEnumerable<T> items)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                collection.Clear();
+                foreach (T item in items)
+                {
+                    collection.Add(item);
+                }
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        private ICollection<T> CreateCopy(IEnumerable<T> data)
+        {
+            if (data is ISet<T>)
+            {
+                return new HashSet<T>(data);
+            }
+            return new List<T>(data);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -261,6 +261,21 @@ namespace NitroxModel.DataStructures
             }
         }
 
+        public T Find(Func<T, bool> predicate)
+        {
+            lock (locker)
+            {
+                foreach (T item in collection)
+                {
+                    if (predicate(item))
+                    {
+                        return item;
+                    }
+                }
+            }
+            throw new ArgumentNullException(nameof(predicate), "No item in collection matches select predicate.");
+        }
+
         void IList<T>.RemoveAt(int index)
         {
             lock (locker)

--- a/NitroxModel/DataStructures/ThreadSafeCollection.cs
+++ b/NitroxModel/DataStructures/ThreadSafeCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using NitroxModel.Helper;
 using ProtoBufNet;
 
 namespace NitroxModel.DataStructures
@@ -274,6 +275,8 @@ namespace NitroxModel.DataStructures
 
         public T Find(Func<T, bool> predicate)
         {
+            Validate.NotNull(predicate);
+            
             lock (locker)
             {
                 foreach (T item in collection)
@@ -283,8 +286,8 @@ namespace NitroxModel.DataStructures
                         return item;
                     }
                 }
+                return default(T);
             }
-            throw new ArgumentNullException(nameof(predicate), "No item in collection matches select predicate.");
         }
 
         void IList<T>.RemoveAt(int index)

--- a/NitroxModel/DataStructures/ThreadSafeDictionary.cs
+++ b/NitroxModel/DataStructures/ThreadSafeDictionary.cs
@@ -14,8 +14,7 @@ namespace NitroxModel.DataStructures
 
         [ProtoIgnore]
         private readonly ReaderWriterLockSlim locker = new ReaderWriterLockSlim();
-
-        // [ProtoMember(1)]
+        
         public ICollection<TKey> Keys
         {
             get
@@ -32,7 +31,6 @@ namespace NitroxModel.DataStructures
             }
         }
 
-        // [ProtoMember(2)]
         public ICollection<TValue> Values
         {
             get

--- a/NitroxModel/DataStructures/ThreadSafeDictionary.cs
+++ b/NitroxModel/DataStructures/ThreadSafeDictionary.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using ProtoBufNet;
+
+namespace NitroxModel.DataStructures
+{
+    [ProtoContract]
+    public class ThreadSafeDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDisposable
+    {
+        [ProtoIgnore]
+        private readonly IDictionary<TKey, TValue> dictionary;
+
+        [ProtoIgnore]
+        private readonly ReaderWriterLockSlim locker = new ReaderWriterLockSlim();
+
+        // [ProtoMember(1)]
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return new List<TKey>(dictionary.Keys);
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+        }
+
+        // [ProtoMember(2)]
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return new List<TValue>(dictionary.Values);
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return dictionary[key];
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+            set
+            {
+                try
+                {
+                    locker.EnterWriteLock();
+                    dictionary[key] = value;
+                }
+                finally
+                {
+                    locker.ExitWriteLock();
+                }
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                try
+                {
+                    locker.EnterReadLock();
+                    return dictionary.Count;
+                }
+                finally
+                {
+                    locker.ExitReadLock();
+                }
+            }
+        }
+
+        public bool IsReadOnly { get; } = false;
+
+        public ThreadSafeDictionary()
+        {
+            dictionary = new Dictionary<TKey, TValue>();
+        }
+
+        public ThreadSafeDictionary(IDictionary<TKey, TValue> dictionary, bool createCopy = true)
+        {
+            this.dictionary = createCopy ? new Dictionary<TKey, TValue>(dictionary) : dictionary;
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                dictionary.Add(item);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public void Clear()
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                dictionary.Clear();
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return dictionary.Contains(item);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            try
+            {
+                locker.EnterReadLock();
+                dictionary.CopyTo(array, arrayIndex);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                return dictionary.Remove(item);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return dictionary.ContainsKey(key);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                dictionary.Add(key, value);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            try
+            {
+                locker.EnterWriteLock();
+                return dictionary.Remove(key);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return dictionary.TryGetValue(key, out value);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        public void Dispose()
+        {
+            locker?.Dispose();
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            try
+            {
+                locker.EnterReadLock();
+                return new Dictionary<TKey, TValue>(dictionary).GetEnumerator();
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -261,6 +261,8 @@
     <Compile Include="DataStructures\Int3.cs" />
     <Compile Include="DataStructures\Surrogates\TechTypeSurrogate.cs" />
     <Compile Include="DataStructures\TechType.cs" />
+    <Compile Include="DataStructures\ThreadSafeCollection.cs" />
+    <Compile Include="DataStructures\ThreadSafeDictionary.cs" />
     <Compile Include="Discovery\InstallationFinders\EpicGamesInstallationFinder.cs" />
     <Compile Include="Discovery\IFindGameInstallation.cs" />
     <Compile Include="Discovery\InstallationFinders\GameInCurrentDirectoryFinder.cs" />

--- a/NitroxModel/Packets/InitialPlayerSync.cs
+++ b/NitroxModel/Packets/InitialPlayerSync.cs
@@ -1,17 +1,18 @@
-﻿using NitroxModel.DataStructures.GameLogic;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using UnityEngine;
-using NitroxModel.DataStructures.Util;
+using System.Linq;
 using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
+using UnityEngine;
 
 namespace NitroxModel.Packets
 {
     [Serializable]
     public class InitialPlayerSync : Packet
     {
-        public List<EscapePodModel> EscapePodsData { get; }
         public NitroxId AssignedEscapePodId;
+        public List<EscapePodModel> EscapePodsData { get; }
         public List<EquippedItemData> EquippedItems { get; }
         public List<EquippedItemData> Modules { get; }
         public List<BasePiece> BasePieces { get; }
@@ -30,25 +31,43 @@ namespace NitroxModel.Packets
         public string GameMode { get; }
         public Perms Permissions { get; }
 
-        public InitialPlayerSync(NitroxId playerGameObjectId, bool firstTimeConnecting, List<EscapePodModel> escapePodsData, NitroxId assignedEscapePodId, List<EquippedItemData> equipment, List<EquippedItemData> modules, List<BasePiece> basePieces, List<VehicleModel> vehicles, List<ItemData> inventoryItems, List<ItemData> storageSlots, InitialPDAData pdaData, InitialStoryGoalData storyGoalData, Vector3 playerSpawnData, Optional<NitroxId> playerSubRootId, PlayerStatsData playerStatsData, List<InitialRemotePlayerData> remotePlayerData, List<Entity> globalRootEntities, string gameMode, Perms perms)
+        public InitialPlayerSync(NitroxId playerGameObjectId,
+            bool firstTimeConnecting,
+            IEnumerable<EscapePodModel> escapePodsData,
+            NitroxId assignedEscapePodId,
+            IEnumerable<EquippedItemData> equipment,
+            IEnumerable<EquippedItemData> modules,
+            IEnumerable<BasePiece> basePieces,
+            IEnumerable<VehicleModel> vehicles,
+            IEnumerable<ItemData> inventoryItems,
+            IEnumerable<ItemData> storageSlots,
+            InitialPDAData pdaData,
+            InitialStoryGoalData storyGoalData,
+            Vector3 playerSpawnData,
+            Optional<NitroxId> playerSubRootId,
+            PlayerStatsData playerStatsData,
+            IEnumerable<InitialRemotePlayerData> remotePlayerData,
+            IEnumerable<Entity> globalRootEntities,
+            string gameMode,
+            Perms perms)
         {
-            EscapePodsData = escapePodsData;
+            EscapePodsData = escapePodsData.ToList();
             AssignedEscapePodId = assignedEscapePodId;
             PlayerGameObjectId = playerGameObjectId;
             FirstTimeConnecting = firstTimeConnecting;
-            EquippedItems = equipment;
-            Modules = modules;
-            BasePieces = basePieces;
-            Vehicles = vehicles;
-            InventoryItems = inventoryItems;
-            StorageSlots = storageSlots;
+            EquippedItems = equipment.ToList();
+            Modules = modules.ToList();
+            BasePieces = basePieces.ToList();
+            Vehicles = vehicles.ToList();
+            InventoryItems = inventoryItems.ToList();
+            StorageSlots = storageSlots.ToList();
             PDAData = pdaData;
             StoryGoalData = storyGoalData;
             PlayerSpawnData = playerSpawnData;
             PlayerSubRootId = playerSubRootId;
             PlayerStatsData = playerStatsData;
-            RemotePlayerData = remotePlayerData;
-            GlobalRootEntities = globalRootEntities;
+            RemotePlayerData = remotePlayerData.ToList();
+            GlobalRootEntities = globalRootEntities.ToList();
             GameMode = gameMode;
             Permissions = perms;
         }

--- a/NitroxModel/Packets/SimulationOwnershipChange.cs
+++ b/NitroxModel/Packets/SimulationOwnershipChange.cs
@@ -37,7 +37,7 @@ namespace NitroxModel.Packets
 
             foreach (SimulatedEntity entity in Entities)
             {
-                stringBuilder.Append(entity.ToString());
+                stringBuilder.Append(entity);
             }
 
             stringBuilder.Append("]");

--- a/NitroxPatcher/Patches/Dynamic/CyclopsDecoyLaunchButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsDecoyLaunchButton_OnClick_Patch.cs
@@ -8,7 +8,7 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsDecoyLaunchButton_OnClick_Patch : NitroxPatch, IDynamicPatch
+    internal class CyclopsDecoyLaunchButton_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(CyclopsDecoyLaunchButton);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
@@ -10,12 +10,18 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static ItemContainers itemContainers;
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {
+            if (itemContainers == null)
+            {
+                itemContainers = NitroxServiceLocator.LocateService<ItemContainers>();
+            }
+            
             if (item != null)
             {
-                NitroxServiceLocator.LocateService<ItemContainers>().BroadcastItemAdd(item.item, __instance.tr);
+                itemContainers.BroadcastItemAdd(item.item, __instance.tr);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
@@ -10,18 +10,12 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static ItemContainers itemContainers;
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {
-            if (itemContainers == null)
-            {
-                itemContainers = NitroxServiceLocator.LocateService<ItemContainers>();
-            }
-            
             if (item != null)
             {
-                itemContainers.BroadcastItemAdd(item.item, __instance.tr);
+                NitroxServiceLocator.LocateService<ItemContainers>().BroadcastItemAdd(item.item, __instance.tr);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
@@ -10,12 +10,18 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(InventoryItem) }, null);
+        private static ItemContainers itemContainers = null;
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {
+            if (itemContainers == null)
+            {
+                itemContainers = NitroxServiceLocator.LocateService<ItemContainers>();
+            }
+            
             if (item != null)
             {
-                NitroxServiceLocator.LocateService<ItemContainers>().BroadcastItemRemoval(item.item, __instance.tr);
+                itemContainers.BroadcastItemRemoval(item.item, __instance.tr);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
@@ -9,19 +9,13 @@ namespace NitroxPatcher.Patches.Dynamic
     public class ItemsContainer_NotifyRemoveItem_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(InventoryItem) }, null);
-        private static ItemContainers itemContainers = null;
+        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(InventoryItem) }, null);
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {
-            if (itemContainers == null)
-            {
-                itemContainers = NitroxServiceLocator.LocateService<ItemContainers>();
-            }
-            
             if (item != null)
             {
-                itemContainers.BroadcastItemRemoval(item.item, __instance.tr);
+                NitroxServiceLocator.LocateService<ItemContainers>().BroadcastItemRemoval(item.item, __instance.tr);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/PingManager_NotifyRename_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PingManager_NotifyRename_Patch.cs
@@ -13,7 +13,6 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly Type TARGET_CLASS = typeof(PingManager);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod(nameof(PingManager.NotifyRename), BindingFlags.Public | BindingFlags.Static);
-        private static IPacketSender packetSender;
 
         public static void Postfix(PingInstance instance)
         {
@@ -21,12 +20,7 @@ namespace NitroxPatcher.Patches.Dynamic
             {
                 return;
             }
-
-            if (packetSender == null)
-            {
-                packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
-            }
-            packetSender.Send(new PingRenamed(NitroxEntity.GetId(instance.gameObject), instance.GetLabel(), SerializationHelper.GetBytes(instance.gameObject)));
+            NitroxServiceLocator.LocateService<IPacketSender>().Send(new PingRenamed(NitroxEntity.GetId(instance.gameObject), instance.GetLabel(), SerializationHelper.GetBytes(instance.gameObject)));
         }
 
         public override void Patch(HarmonyInstance harmony)

--- a/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
@@ -11,10 +11,11 @@ using UnityEngine;
 namespace NitroxPatcher.Patches.Dynamic
 {
     /// <summary>
-    /// Hook onto <see cref="SubFire.CreateFire(SubFire.RoomFire)"/>. We do this on the fire creation method because unlike <see cref="SubRoot.OnTakeDamage(DamageInfo)"/>, fires
-    /// can be created outside of <see cref="SubFire.OnTakeDamage(DamageInfo)"/>
+    ///     Hook onto <see cref="SubFire.CreateFire(SubFire.RoomFire)" />. We do this on the fire creation method because
+    ///     unlike <see cref="SubRoot.OnTakeDamage(DamageInfo)" />, fires
+    ///     can be created outside of <see cref="SubFire.OnTakeDamage(DamageInfo)" />
     /// </summary>
-    class SubFire_CreateFire_Patch : NitroxPatch, IDynamicPatch
+    internal class SubFire_CreateFire_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(SubFire);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("CreateFire", BindingFlags.Instance | BindingFlags.Public);
@@ -37,14 +38,15 @@ namespace NitroxPatcher.Patches.Dynamic
             {
                 List<Transform> availableNodes = (List<Transform>)__instance.ReflectionGet("availableNodes");
                 Dictionary<CyclopsRooms, SubFire.RoomFire> roomFiresDict = (Dictionary<CyclopsRooms, SubFire.RoomFire>)__instance.ReflectionGet("roomFires");
-                
+
+                Fires fires = NitroxServiceLocator.LocateService<Fires>();
                 foreach (Transform transform in availableNodes)
                 {
                     if (transform.childCount > 0)
                     {
                         int nodeIndex = Array.IndexOf(roomFiresDict[startInRoom.roomLinks.room].spawnNodes, transform);
                         Fire fire = transform.GetComponentInChildren<Fire>();
-                        NitroxServiceLocator.LocateService<Fires>().OnCreate(transform.GetComponentInChildren<Fire>(), startInRoom, nodeIndex);
+                        fires.OnCreate(transform.GetComponentInChildren<Fire>(), startInRoom, nodeIndex);
                         return;
                     }
                 }

--- a/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Serialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Serialize_Patch.cs
@@ -12,6 +12,10 @@ namespace NitroxPatcher.Patches.Persistent
     {
         private static readonly Type TARGET_TYPE = typeof(ProtobufSerializer);
         private static readonly MethodInfo TARGET_METHOD = TARGET_TYPE.GetMethod("Serialize", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        /// <summary>
+        ///     This patch is in a hot path so it needs this optimization.
+        /// </summary>
         private static readonly NitroxProtobufSerializer serializer = NitroxServiceLocator.LocateServicePreLifetime<NitroxProtobufSerializer>();
 
         public static bool Prefix(Stream stream, object source, Type type)

--- a/NitroxServer-Subnautica/GameLogic/Entities/Spawning/CrashFishBootstrapper.cs
+++ b/NitroxServer-Subnautica/GameLogic/Entities/Spawning/CrashFishBootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel_Subnautica.Helper;
-using NitroxServer.GameLogic.Entities.EntityBootstrappers;
 using NitroxServer.GameLogic.Entities.Spawning;
 
 namespace NitroxServer_Subnautica.GameLogic.Entities.Spawning.EntityBootstrappers

--- a/NitroxServer-Subnautica/GameLogic/Entities/Spawning/ReefbackBootstrapper.cs
+++ b/NitroxServer-Subnautica/GameLogic/Entities/Spawning/ReefbackBootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel_Subnautica.Helper;
-using NitroxServer.GameLogic.Entities.EntityBootstrappers;
 using NitroxServer.GameLogic.Entities.Spawning;
 using static NitroxServer_Subnautica.GameLogic.Entities.Spawning.EntityBootstrappers.ReefbackSpawnData;
 

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -25,18 +25,17 @@ namespace NitroxServer_Subnautica
             NitroxServiceLocator.InitializeDependencyContainer(new SubnauticaServerAutoFacRegistrar());
             NitroxServiceLocator.BeginNewLifetimeScope();
 
-            Server server = null;
+            Server server;
             try
             {
                 server = NitroxServiceLocator.LocateService<Server>();
                 Log.Info($"Loaded save\n{server.SaveSummary}");
-                server.Start();
-            }
-            catch (SocketException e)
-            {
-                Log.Error("Unable to start server", e);
-                server?.Stop();
-                return;
+                if (!server.Start())
+                {
+                    Log.Error("Unable to start server.");
+                    Console.WriteLine("\nPress any key to continue..");
+                    Console.ReadKey(true);
+                }
             }
             catch (Exception e)
             {

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using NitroxModel.Core;

--- a/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
+++ b/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
@@ -4,7 +4,6 @@ using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel_Subnautica.DataStructures.GameLogic.Entities;
 using NitroxModel_Subnautica.Helper;
 using NitroxServer;
-using NitroxServer.GameLogic.Entities.EntityBootstrappers;
 using NitroxServer.GameLogic.Entities.Spawning;
 using NitroxServer.Serialization;
 using NitroxServer_Subnautica.GameLogic.Entities;

--- a/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
@@ -37,8 +37,7 @@ namespace NitroxServer.Communication.NetworkingLayer.LiteNetLib
             {
                 return false;
             }
-
-            Log.Info("Using LiteNetLib as networking library");
+            
             isStopped = false;
             return true;
         }

--- a/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
@@ -22,10 +22,8 @@ namespace NitroxServer.Communication.NetworkingLayer.LiteNetLib
             listener = new EventBasedNetListener();
             server = new NetManager(listener);
         }
-        public override void Start()
+        public override bool Start()
         {
-            Log.Info("Using LiteNetLib as networking library");
-
             listener.PeerConnectedEvent += PeerConnected;
             listener.PeerDisconnectedEvent += PeerDisconnected;
             listener.NetworkReceiveEvent += NetworkDataReceived;
@@ -35,9 +33,14 @@ namespace NitroxServer.Communication.NetworkingLayer.LiteNetLib
             server.UnconnectedMessagesEnabled = true;
             server.UpdateTime = 15;
             server.UnsyncedEvents = true;
-            server.Start(portNumber);
+            if (!server.Start(portNumber))
+            {
+                return false;
+            }
 
+            Log.Info("Using LiteNetLib as networking library");
             isStopped = false;
+            return true;
         }
 
         public override void Stop()

--- a/NitroxServer/Communication/NetworkingLayer/NitroxServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/NitroxServer.cs
@@ -30,7 +30,7 @@ namespace NitroxServer.Communication.NetworkingLayer
             maxConn = serverConfig.MaxConnections;
         }
 
-        public abstract void Start();
+        public abstract bool Start();
 
         public abstract void Stop();
         

--- a/NitroxServer/Communication/Packets/PacketHandler.cs
+++ b/NitroxServer/Communication/Packets/PacketHandler.cs
@@ -13,8 +13,8 @@ namespace NitroxServer.Communication.Packets
 {
     public class PacketHandler
     {
-        private PlayerManager playerManager;
-        private DefaultServerPacketProcessor defaultServerPacketProcessor;
+        private readonly PlayerManager playerManager;
+        private readonly DefaultServerPacketProcessor defaultServerPacketProcessor;
 
         public PacketHandler(PlayerManager playerManager, DefaultServerPacketProcessor packetProcessor)
         {
@@ -25,7 +25,6 @@ namespace NitroxServer.Communication.Packets
         public void Process(Packet packet, NitroxConnection connection)
         {
             Player player = playerManager.GetPlayer(connection);
-
             if (player == null)
             {
                 ProcessUnauthenticated(packet, connection);

--- a/NitroxServer/Communication/Packets/Processors/DroppedItemPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DroppedItemPacketProcessor.cs
@@ -35,7 +35,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
             foreach (Player player in playerManager.GetConnectedPlayers())
             {
-                bool isOtherPlayer = !Equals(player, droppingPlayer);
+                bool isOtherPlayer = player != droppingPlayer;
                 if (isOtherPlayer && player.CanSee(entity))
                 {
                     CellEntities cellEntities = new CellEntities(entity);

--- a/NitroxServer/Communication/Packets/Processors/ItemContainerAddPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ItemContainerAddPacketProcessor.cs
@@ -19,7 +19,6 @@ namespace NitroxServer.Communication.Packets.Processors
         public override void Process(ItemContainerAdd packet, Player player)
         {
             inventoryManager.ItemAdded(packet.ItemData);
-
             if (packet.ItemData.ContainerId != player.GameObjectId)
             {
                 playerManager.SendPacketToOtherPlayers(packet, player);

--- a/NitroxServer/Communication/Packets/Processors/ItemContainerRemovePacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ItemContainerRemovePacketProcessor.cs
@@ -19,7 +19,6 @@ namespace NitroxServer.Communication.Packets.Processors
         public override void Process(ItemContainerRemove packet, Player player)
         {
             inventoryManager.ItemRemoved(packet.ItemId);
-
             if (packet.OwnerId != player.GameObjectId)
             {
                 playerManager.SendPacketToOtherPlayers(packet, player);

--- a/NitroxServer/Communication/Packets/Processors/MultiplayerSessionReservationRequestProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/MultiplayerSessionReservationRequestProcessor.cs
@@ -9,7 +9,7 @@ namespace NitroxServer.Communication.Packets.Processors
 {
     public class MultiplayerSessionReservationRequestProcessor : UnauthenticatedPacketProcessor<MultiplayerSessionReservationRequest>
     {
-        private PlayerManager playerManager;
+        private readonly PlayerManager playerManager;
 
         public MultiplayerSessionReservationRequestProcessor(PlayerManager playerManager)
         {

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -40,7 +40,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 playerManager.SendPacketToOtherPlayers(addEscapePod, player);
             }
 
-            List<EquippedItemData> equippedItems = player.getAllEquipment();
+            List<EquippedItemData> equippedItems = player.GetEquipment();
             List<TechType> techTypes = equippedItems.Select(equippedItem => equippedItem.TechType).ToList();
 
             PlayerJoinedMultiplayerSession playerJoinedPacket = new PlayerJoinedMultiplayerSession(player.PlayerContext, techTypes);
@@ -57,7 +57,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 world.EscapePodManager.GetEscapePods(),
                 assignedEscapePodId,
                 equippedItems,
-                player.getAllModules(),
+                player.GetModules(),
                 world.BaseManager.GetBasePiecesForNewlyConnectedPlayer(),
                 world.VehicleManager.GetVehicles(),
                 world.InventoryManager.GetAllInventoryItems(),
@@ -83,7 +83,7 @@ namespace NitroxServer.Communication.Packets.Processors
             {
                 if (!player.Equals(otherPlayer))
                 {
-                    List<EquippedItemData> equippedItems = otherPlayer.getAllEquipment();
+                    List<EquippedItemData> equippedItems = otherPlayer.GetEquipment();
                     List<TechType> techTypes = equippedItems.Select(equippedItem => equippedItem.TechType).ToList();
 
                     InitialRemotePlayerData remotePlayer = new InitialRemotePlayerData(otherPlayer.PlayerContext, otherPlayer.Position, otherPlayer.SubRootId, techTypes);

--- a/NitroxServer/Communication/Packets/Processors/StoryEventSendProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/StoryEventSendProcessor.cs
@@ -18,17 +18,17 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(StoryEventSend packet, Player player)
         {
-            if (packet.StoryEventType == StoryEventType.RADIO)
+            switch (packet.StoryEventType)
             {
-                storyGoalData.AddRadioMessage(packet.Key);
-            }
-            if (packet.StoryEventType == StoryEventType.GOAL_UNLOCK)
-            {
-                storyGoalData.AddGoalUnlock(packet.Key);
-            }
-            else
-            {
-                storyGoalData.AddStoryGoal(packet.Key);
+                case StoryEventType.RADIO:
+                    storyGoalData.RadioQueue.Add(packet.Key);
+                    break;
+                case StoryEventType.GOAL_UNLOCK:
+                    storyGoalData.GoalUnlocks.Add(packet.Key);
+                    break;
+                default:
+                    storyGoalData.CompletedGoals.Add(packet.Key);
+                    break;
             }
             playerManager.SendPacketToOtherPlayers(packet, player);
         }

--- a/NitroxServer/ConsoleCommands/ListCommand.cs
+++ b/NitroxServer/ConsoleCommands/ListCommand.cs
@@ -1,6 +1,7 @@
 ﻿using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;
 using System.Collections.Generic;
+using System.Linq;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Logger;
@@ -18,11 +19,10 @@ namespace NitroxServer.ConsoleCommands
 
         public override void RunCommand(string[] args, Optional<Player> sender)
         {
-            List<Player> players = playerManager.GetConnectedPlayers();
-
+            IEnumerable<Player> players = playerManager.GetConnectedPlayers();
             string playerList = "List of players : " + string.Join(", ", players);
 
-            if (players.Count == 0)
+            if (!players.Any())
             {
                 playerList += "No players online";
             }

--- a/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
+++ b/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
@@ -26,7 +26,6 @@ namespace NitroxServer.ConsoleCommands.Processor
                 }
 
                 commands[cmd.Name] = cmd;
-
                 foreach (string alias in cmd.Alias)
                 {
                     if (commands.ContainsKey(alias))

--- a/NitroxServer/ConsoleCommands/SummaryCommand.cs
+++ b/NitroxServer/ConsoleCommands/SummaryCommand.cs
@@ -1,0 +1,34 @@
+﻿using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Logger;
+using NitroxServer.ConsoleCommands.Abstract;
+
+namespace NitroxServer.ConsoleCommands
+{
+    internal class SummaryCommand : Command
+    {
+        private readonly Server server;
+
+        public SummaryCommand(Server server) : base("summary", Perms.PLAYER, "", "Shows persisted data")
+        {
+            this.server = server;
+        }
+
+        public override void RunCommand(string[] args, Optional<Player> sender)
+        {
+            if (sender.HasValue)
+            {
+                SendMessageToPlayer(sender, server.SaveSummary);
+            }
+            else
+            {
+                Log.Info(server.SaveSummary);
+            }
+        }
+
+        public override bool VerifyArgs(string[] args)
+        {
+            return args.Length == 0;
+        }
+    }
+}

--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -121,8 +121,7 @@ namespace NitroxServer.GameLogic.Entities
             entity.Transform.Rotation = rotation;
 
             AbsoluteEntityCell newCell = entity.AbsoluteEntityCell;
-
-            if (!Equals(oldCell, newCell))
+            if (oldCell != newCell)
             {
                 EntitySwitchedCells(entity, oldCell, newCell);
             }

--- a/NitroxServer/GameLogic/Entities/EntitySimulator.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulator.cs
@@ -92,9 +92,12 @@ namespace NitroxServer.GameLogic.Entities
             {
                 List<Entity> entities = entityManager.GetEntities(cell);
                 assignedEntities.AddRange(
-                    entities.Where(entity => cell.Level <= entity.Level &&
-                                             (entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType) || !entity.SpawnedByServer) &&
-                                             simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE)));
+                    entities.Where(entity =>
+                    {
+                        bool shouldBeOwnershipSimulated = entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType) || !entity.SpawnedByServer;
+                        bool canAquireLockForPlayer = simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
+                        return cell.Level <= entity.Level && shouldBeOwnershipSimulated && canAquireLockForPlayer;
+                    }));
             }
 
             return assignedEntities;

--- a/NitroxServer/GameLogic/Entities/EntitySimulator.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulator.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Logger;
 
 namespace NitroxServer.GameLogic.Entities
@@ -11,9 +12,9 @@ namespace NitroxServer.GameLogic.Entities
         private static readonly SimulationLockType DEFAULT_ENTITY_SIMULATION_LOCKTYPE = SimulationLockType.TRANSIENT;
 
         private readonly EntityManager entityManager;
-        private readonly SimulationOwnershipData simulationOwnershipData;
         private readonly PlayerManager playerManager;
         private readonly HashSet<TechType> serverSpawnedSimulationWhiteList;
+        private readonly SimulationOwnershipData simulationOwnershipData;
 
         public EntitySimulation(EntityManager entityManager, SimulationOwnershipData simulationOwnershipData, PlayerManager playerManager, HashSet<TechType> serverSpawnedSimulationWhiteList)
         {
@@ -45,6 +46,16 @@ namespace NitroxServer.GameLogic.Entities
             return ownershipChanges;
         }
 
+        public SimulatedEntity AssignNewEntityToPlayer(Entity entity, Player player)
+        {
+            if (simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
+            {
+                return new SimulatedEntity(entity.Id, player.Id, true, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
+            }
+
+            throw new Exception("New entity was already being simulated by someone else: " + entity.Id);
+        }
+
         private void AssignLoadedCellEntitySimulation(Player player, AbsoluteEntityCell[] addedCells, List<SimulatedEntity> ownershipChanges)
         {
             List<Entity> entities = AssignForCells(player, addedCells);
@@ -59,11 +70,9 @@ namespace NitroxServer.GameLogic.Entities
         {
             foreach (Entity entity in entities)
             {
-                AbsoluteEntityCell entityCell = entity.AbsoluteEntityCell;
-
                 foreach (Player player in playerManager.GetConnectedPlayers())
                 {
-                    bool isOtherPlayer = (player != oldPlayer);
+                    bool isOtherPlayer = player != oldPlayer;
 
                     if (isOtherPlayer && player.CanSee(entity) && simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
                     {
@@ -74,16 +83,6 @@ namespace NitroxServer.GameLogic.Entities
                 }
             }
         }
-        
-        public SimulatedEntity AssignNewEntityToPlayer(Entity entity, Player player)
-        {
-            if(simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
-            {
-                return new SimulatedEntity(entity.Id, player.Id, true, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
-            }
-
-            throw new System.Exception("New entity was already being simulated by someone else: " + entity.Id);
-        }
 
         private List<Entity> AssignForCells(Player player, AbsoluteEntityCell[] added)
         {
@@ -92,11 +91,10 @@ namespace NitroxServer.GameLogic.Entities
             foreach (AbsoluteEntityCell cell in added)
             {
                 List<Entity> entities = entityManager.GetEntities(cell);
-
                 assignedEntities.AddRange(
                     entities.Where(entity => cell.Level <= entity.Level &&
-                                                ((entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType)) || !entity.SpawnedByServer) &&
-                                                simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE)));                       
+                                             (entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType) || !entity.SpawnedByServer) &&
+                                             simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE)));
             }
 
             return assignedEntities;
@@ -105,13 +103,12 @@ namespace NitroxServer.GameLogic.Entities
         private List<Entity> RevokeForCells(Player player, AbsoluteEntityCell[] removed)
         {
             List<Entity> revokedEntities = new List<Entity>();
-
             foreach (AbsoluteEntityCell cell in removed)
             {
                 List<Entity> entities = entityManager.GetEntities(cell);
-                
+
                 revokedEntities.AddRange(
-                    entities.Where(entity => entity.Level <= cell.Level && simulationOwnershipData.RevokeIfOwner(entity.Id, player)));                        
+                    entities.Where(entity => entity.Level <= cell.Level && simulationOwnershipData.RevokeIfOwner(entity.Id, player)));
             }
 
             return revokedEntities;

--- a/NitroxServer/GameLogic/Entities/EntitySimulator.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulator.cs
@@ -95,9 +95,8 @@ namespace NitroxServer.GameLogic.Entities
                     entities.Where(entity =>
                     {
                         bool isSpawnedByServerAndWhitelisted = entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType);
-                        bool shouldBeOwnershipSimulated = isSpawnedByServerAndWhitelisted || !entity.SpawnedByServer;
-                        bool canAquireLockForPlayer = simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
-                        return cell.Level <= entity.Level && shouldBeOwnershipSimulated && canAquireLockForPlayer;
+                        bool isEligibleForSimulation = isSpawnedByServerAndWhitelisted || !entity.SpawnedByServer;
+                        return cell.Level <= entity.Level && isEligibleForSimulation && simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
                     }));
             }
 

--- a/NitroxServer/GameLogic/Entities/EntitySimulator.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulator.cs
@@ -94,7 +94,8 @@ namespace NitroxServer.GameLogic.Entities
                 assignedEntities.AddRange(
                     entities.Where(entity =>
                     {
-                        bool shouldBeOwnershipSimulated = entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType) || !entity.SpawnedByServer;
+                        bool isSpawnedByServerAndWhitelisted = entity.SpawnedByServer && serverSpawnedSimulationWhiteList.Contains(entity.TechType);
+                        bool shouldBeOwnershipSimulated = isSpawnedByServerAndWhitelisted || !entity.SpawnedByServer;
                         bool canAquireLockForPlayer = simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
                         return cell.Level <= entity.Level && shouldBeOwnershipSimulated && canAquireLockForPlayer;
                     }));

--- a/NitroxServer/GameLogic/Entities/EntitySimulator.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulator.cs
@@ -106,9 +106,7 @@ namespace NitroxServer.GameLogic.Entities
             foreach (AbsoluteEntityCell cell in removed)
             {
                 List<Entity> entities = entityManager.GetEntities(cell);
-
-                revokedEntities.AddRange(
-                    entities.Where(entity => entity.Level <= cell.Level && simulationOwnershipData.RevokeIfOwner(entity.Id, player)));
+                revokedEntities.AddRange(entities.Where(entity => entity.Level <= cell.Level && simulationOwnershipData.RevokeIfOwner(entity.Id, player)));
             }
 
             return revokedEntities;

--- a/NitroxServer/GameLogic/Entities/Spawning/BatchEntitySpawner.cs
+++ b/NitroxServer/GameLogic/Entities/Spawning/BatchEntitySpawner.cs
@@ -6,7 +6,6 @@ using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Logger;
-using NitroxServer.GameLogic.Entities.EntityBootstrappers;
 using NitroxServer.Serialization;
 using NitroxServer.Serialization.Resources.Datastructures;
 using UnityEngine;

--- a/NitroxServer/GameLogic/Entities/Spawning/DeterministicBatchGenerator.cs
+++ b/NitroxServer/GameLogic/Entities/Spawning/DeterministicBatchGenerator.cs
@@ -5,7 +5,7 @@ namespace NitroxServer.GameLogic.Entities.Spawning
 {
     public class DeterministicBatchGenerator
     {
-        private Random random;
+        private readonly Random random;
 
         public DeterministicBatchGenerator(Int3 batchId)
         {

--- a/NitroxServer/GameLogic/Entities/Spawning/IEntityBootstrapper.cs
+++ b/NitroxServer/GameLogic/Entities/Spawning/IEntityBootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿using NitroxModel.DataStructures.GameLogic;
-using NitroxServer.GameLogic.Entities.Spawning;
 
-namespace NitroxServer.GameLogic.Entities.EntityBootstrappers
+namespace NitroxServer.GameLogic.Entities.Spawning
 {
     public interface IEntityBootstrapper
     {

--- a/NitroxServer/GameLogic/EscapePodData.cs
+++ b/NitroxServer/GameLogic/EscapePodData.cs
@@ -10,11 +10,9 @@ namespace NitroxServer.GameLogic
         [ProtoMember(1)]
         public List<EscapePodModel> EscapePods;
 
-        public static EscapePodData from(List<EscapePodModel> escapePods)
+        public static EscapePodData From(List<EscapePodModel> escapePods)
         {
-            EscapePodData escapePodData = new EscapePodData();
-            escapePodData.EscapePods = escapePods;
-
+            EscapePodData escapePodData = new EscapePodData { EscapePods = escapePods };
             return escapePodData;
         }
     }

--- a/NitroxServer/GameLogic/EscapePodManager.cs
+++ b/NitroxServer/GameLogic/EscapePodManager.cs
@@ -10,94 +10,78 @@ namespace NitroxServer.GameLogic
     {
         public const int ESCAPE_POD_X_OFFSET = 40;
 
-        private List<EscapePodModel> escapePods;
-        private Dictionary<ushort, EscapePodModel> escapePodsByPlayerId;
+        public ThreadSafeCollection<EscapePodModel> EscapePods { get; }
+        private readonly ThreadSafeDictionary<ushort, EscapePodModel> escapePodsByPlayerId = new ThreadSafeDictionary<ushort, EscapePodModel>();
         private EscapePodModel podForNextPlayer;
 
         public EscapePodManager(List<EscapePodModel> escapePods)
         {
-            this.escapePods = escapePods;
+            EscapePods = new ThreadSafeCollection<EscapePodModel>(escapePods);
 
-            initializePodForNextPlayer();
-            initializeEscapePodsByPlayerId();
+            InitializePodForNextPlayer();
+            InitializeEscapePodsByPlayerId();
         }
 
         public NitroxId AssignPlayerToEscapePod(ushort playerId, out Optional<EscapePodModel> newlyCreatedPod)
         {
             newlyCreatedPod = Optional.Empty;
 
-            lock (escapePodsByPlayerId)
+            if (escapePodsByPlayerId.ContainsKey(playerId))
             {
-                if (escapePodsByPlayerId.ContainsKey(playerId))
-                {
-                    return escapePodsByPlayerId[playerId].Id;
-                }
-
-                if (podForNextPlayer.IsFull())
-                {
-                    newlyCreatedPod = Optional.Of(CreateNewEscapePod());
-                    podForNextPlayer = newlyCreatedPod.Value;
-                }
-
-                podForNextPlayer.AssignedPlayers.Add(playerId);
-                escapePodsByPlayerId[playerId] = podForNextPlayer;
+                return escapePodsByPlayerId[playerId].Id;
             }
+
+            if (podForNextPlayer.IsFull())
+            {
+                newlyCreatedPod = Optional.Of(CreateNewEscapePod());
+                podForNextPlayer = newlyCreatedPod.Value;
+            }
+
+            podForNextPlayer.AssignedPlayers.Add(playerId);
+            escapePodsByPlayerId[playerId] = podForNextPlayer;
 
             return podForNextPlayer.Id;
         }
 
         public List<EscapePodModel> GetEscapePods()
         {
-            lock(escapePods)
-            {
-                // coyp to prevent mutation at the caller
-                return new List<EscapePodModel>(escapePods);
-            }
+            return EscapePods.ToList();
         }
 
         public void RepairEscapePod(NitroxId id)
         {
-            lock(escapePods)
-            {
-                EscapePodModel escapePod = escapePods.Find(ep => ep.Id == id);
-                escapePod.Damaged = false;
-            }
+            EscapePodModel escapePod = EscapePods.Find(ep => ep.Id == id);
+            escapePod.Damaged = false;
         }
 
         public void RepairEscapePodRadio(NitroxId id)
         {
-            lock (escapePods)
-            {
-                EscapePodModel escapePod = escapePods.Find(ep => ep.RadioId == id);
-                escapePod.RadioDamaged = false;
-            }
+            EscapePodModel escapePod = EscapePods.Find(ep => ep.RadioId == id);
+            escapePod.RadioDamaged = false;
         }
         
         private EscapePodModel CreateNewEscapePod()
         {
-            lock (escapePods)
-            {
-                int totalEscapePods = escapePods.Count;
+            int totalEscapePods = EscapePods.Count;
 
-                EscapePodModel escapePod = new EscapePodModel();
-                escapePod.InitEscapePodModel(new NitroxId(),
-                    new Vector3(-112.2f + ESCAPE_POD_X_OFFSET * totalEscapePods, 0.0f, -322.6f),
-                    new NitroxId(),
-                    new NitroxId(),
-                    new NitroxId(),
-                    new NitroxId(),
-                    true,
-                    true);
+            EscapePodModel escapePod = new EscapePodModel();
+            escapePod.InitEscapePodModel(new NitroxId(),
+                                         new Vector3(-112.2f + ESCAPE_POD_X_OFFSET * totalEscapePods, 0.0f, -322.6f),
+                                         new NitroxId(),
+                                         new NitroxId(),
+                                         new NitroxId(),
+                                         new NitroxId(),
+                                         true,
+                                         true);
 
-                escapePods.Add(escapePod);
+            EscapePods.Add(escapePod);
 
-                return escapePod;
-            }
+            return escapePod;
         }
 
-        private void initializePodForNextPlayer()
+        private void InitializePodForNextPlayer()
         {
-            foreach (EscapePodModel pod in escapePods)
+            foreach (EscapePodModel pod in EscapePods)
             {
                 if (!pod.IsFull())
                 {
@@ -109,11 +93,10 @@ namespace NitroxServer.GameLogic
             podForNextPlayer = CreateNewEscapePod();
         }
 
-        private void initializeEscapePodsByPlayerId()
+        private void InitializeEscapePodsByPlayerId()
         {
-            escapePodsByPlayerId = new Dictionary<ushort, EscapePodModel>();
-
-            foreach (EscapePodModel pod in escapePods)
+            escapePodsByPlayerId.Clear();
+            foreach (EscapePodModel pod in EscapePods)
             {
                 foreach (ushort playerId in pod.AssignedPlayers)
                 {

--- a/NitroxServer/GameLogic/Items/InventoryData.cs
+++ b/NitroxServer/GameLogic/Items/InventoryData.cs
@@ -1,6 +1,7 @@
-﻿using NitroxModel.DataStructures.GameLogic;
+﻿using System.Collections.Generic;
+using System.Linq;
+using NitroxModel.DataStructures.GameLogic;
 using ProtoBufNet;
-using System.Collections.Generic;
 
 namespace NitroxServer.GameLogic.Items
 {
@@ -13,13 +14,22 @@ namespace NitroxServer.GameLogic.Items
         [ProtoMember(2)]
         public List<ItemData> StorageSlotItems = new List<ItemData>();
 
-        public static InventoryData From(List<ItemData> inventoryItems, List<ItemData> storageSlotItems)
+        private InventoryData()
         {
-            InventoryData inventoryData = new InventoryData();
-            inventoryData.InventoryItems = inventoryItems;
-            inventoryData.StorageSlotItems = storageSlotItems;
+        }
 
-            return inventoryData;
+        public static InventoryData From(IEnumerable<ItemData> inventoryItems, IEnumerable<ItemData> storageSlotItems)
+        {
+            return new InventoryData
+            {
+                InventoryItems = inventoryItems.ToList(),
+                StorageSlotItems = storageSlotItems.ToList()
+            };
+        }
+
+        public override string ToString()
+        {
+            return $"[{nameof(InventoryData)} - {nameof(InventoryItems)}: {InventoryItems.Count}, {nameof(StorageSlotItems)}: {StorageSlotItems.Count}]";
         }
     }
 }

--- a/NitroxServer/GameLogic/Items/InventoryManager.cs
+++ b/NitroxServer/GameLogic/Items/InventoryManager.cs
@@ -20,10 +20,7 @@ namespace NitroxServer.GameLogic.Items
         public void ItemAdded(ItemData itemData)
         {
             inventoryItemsById[itemData.ItemId] = itemData;
-
-#if DEBUG
             Log.Debug($"Received inventory item '{itemData.ItemId}' to container '{itemData.ContainerId}'. Total items: {inventoryItemsById.Count}");
-#endif
         }
 
         public void ItemRemoved(NitroxId itemId)

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -15,19 +15,19 @@ namespace NitroxServer.GameLogic
     // TODO: These methods a a little chunky. Need to look at refactoring just to clean them up and get them around 30 lines a piece.
     public class PlayerManager
     {
-        private readonly Dictionary<NitroxConnection, ConnectionAssets> assetsByConnection = new Dictionary<NitroxConnection, ConnectionAssets>();
-        private readonly ServerConfig serverConfig;
-        private readonly Dictionary<string, PlayerContext> reservations = new Dictionary<string, PlayerContext>();
-        private readonly HashSet<string> reservedPlayerNames = new HashSet<string>();
-        private readonly Dictionary<string, Player> allPlayersByName;
-        private ushort currentPlayerId = 0;
+        private readonly ThreadSafeDictionary<string, Player> allPlayersByName;
+        private readonly ThreadSafeDictionary<NitroxConnection, ConnectionAssets> assetsByConnection = new ThreadSafeDictionary<NitroxConnection, ConnectionAssets>();
+        private readonly ThreadSafeDictionary<string, PlayerContext> reservations = new ThreadSafeDictionary<string, PlayerContext>();
+        private readonly ThreadSafeCollection<string> reservedPlayerNames = new ThreadSafeCollection<string>();
 
         private readonly PlayerStatsData defaultPlayerStats;
+        private readonly ServerConfig serverConfig;
+        private ushort currentPlayerId;
 
         public PlayerManager(List<Player> players, ServerConfig serverConfig)
         {
-            allPlayersByName = players.ToDictionary(x => x.Name);            
-            currentPlayerId = (players.Count == 0) ? (ushort) 0 : players.Max(x => x.Id);
+            allPlayersByName = new ThreadSafeDictionary<string, Player>(players.ToDictionary(x => x.Name), false);
+            currentPlayerId = players.Count == 0 ? (ushort)0 : players.Max(x => x.Id);
             defaultPlayerStats = serverConfig.DefaultPlayerStats;
 
             this.serverConfig = serverConfig;
@@ -35,18 +35,12 @@ namespace NitroxServer.GameLogic
 
         public List<Player> GetConnectedPlayers()
         {
-            lock (assetsByConnection)
-            {
-                return ConnectedPlayers();
-            }
+            return ConnectedPlayers().ToList();
         }
 
-        public List<Player> GetAllPlayers()
+        public IEnumerable<Player> GetAllPlayers()
         {
-            lock(allPlayersByName)
-            {
-                return new List<Player>(allPlayersByName.Values);
-            }
+            return allPlayersByName.Values;
         }
 
         public MultiplayerSessionReservation ReservePlayerContext(
@@ -55,189 +49,168 @@ namespace NitroxServer.GameLogic
             AuthenticationContext authenticationContext,
             string correlationId)
         {
-            lock (assetsByConnection)
+            // TODO: ServerPassword in NitroxClient
+
+            if (!string.IsNullOrEmpty(serverConfig.ServerPassword) && (!authenticationContext.ServerPassword.HasValue || authenticationContext.ServerPassword.Value != serverConfig.ServerPassword))
             {
-                // TODO: ServerPassword in NitroxClient
-
-                if (!string.IsNullOrEmpty(serverConfig.ServerPassword) && (!authenticationContext.ServerPassword.HasValue || (authenticationContext.ServerPassword.Value != serverConfig.ServerPassword)))
-                {
-                    MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.AUTHENTICATION_FAILED;
-                    return new MultiplayerSessionReservation(correlationId, rejectedState);
-                }
-
-                if (reservedPlayerNames.Count >= serverConfig.MaxConnections)
-                {
-                    MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.SERVER_PLAYER_CAPACITY_REACHED;
-                    return new MultiplayerSessionReservation(correlationId, rejectedState);
-                }
-
-                string playerName = authenticationContext.Username;
-                if (reservedPlayerNames.Contains(playerName))
-                {
-                    MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.UNIQUE_PLAYER_NAME_CONSTRAINT_VIOLATED;
-                    return new MultiplayerSessionReservation(correlationId, rejectedState);
-                }
-
-                ConnectionAssets assetPackage;
-                assetsByConnection.TryGetValue(connection, out assetPackage);
-                if (assetPackage == null)
-                {
-                    assetPackage = new ConnectionAssets();
-                    assetsByConnection.Add(connection, assetPackage);
-                    reservedPlayerNames.Add(playerName);
-                }
-
-                Player player;
-                allPlayersByName.TryGetValue(playerName, out player);
-
-                bool hasSeenPlayerBefore = player != null;
-                ushort playerId = (hasSeenPlayerBefore) ? player.Id : ++currentPlayerId;
-
-                PlayerContext playerContext = new PlayerContext(playerName, playerId, !hasSeenPlayerBefore, playerSettings);
-                string reservationKey = Guid.NewGuid().ToString();
-
-                reservations.Add(reservationKey, playerContext);
-                assetPackage.ReservationKey = reservationKey;
-
-                return new MultiplayerSessionReservation(correlationId, playerId, reservationKey);
+                MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.AUTHENTICATION_FAILED;
+                return new MultiplayerSessionReservation(correlationId, rejectedState);
             }
+
+            if (reservedPlayerNames.Count >= serverConfig.MaxConnections)
+            {
+                MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.SERVER_PLAYER_CAPACITY_REACHED;
+                return new MultiplayerSessionReservation(correlationId, rejectedState);
+            }
+
+            string playerName = authenticationContext.Username;
+            if (reservedPlayerNames.Contains(playerName))
+            {
+                MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.UNIQUE_PLAYER_NAME_CONSTRAINT_VIOLATED;
+                return new MultiplayerSessionReservation(correlationId, rejectedState);
+            }
+
+            ConnectionAssets assetPackage;
+            assetsByConnection.TryGetValue(connection, out assetPackage);
+            if (assetPackage == null)
+            {
+                assetPackage = new ConnectionAssets();
+                assetsByConnection.Add(connection, assetPackage);
+                reservedPlayerNames.Add(playerName);
+            }
+
+            Player player;
+            allPlayersByName.TryGetValue(playerName, out player);
+
+            bool hasSeenPlayerBefore = player != null;
+            ushort playerId = hasSeenPlayerBefore ? player.Id : ++currentPlayerId;
+
+            PlayerContext playerContext = new PlayerContext(playerName, playerId, !hasSeenPlayerBefore, playerSettings);
+            string reservationKey = Guid.NewGuid().ToString();
+
+            reservations.Add(reservationKey, playerContext);
+            assetPackage.ReservationKey = reservationKey;
+
+            return new MultiplayerSessionReservation(correlationId, playerId, reservationKey);
         }
 
         public Player PlayerConnected(NitroxConnection connection, string reservationKey, out bool wasBrandNewPlayer)
         {
-            lock (assetsByConnection)
+            PlayerContext playerContext = reservations[reservationKey];
+            Validate.NotNull(playerContext);
+            ConnectionAssets assetPackage = assetsByConnection[connection];
+            Validate.NotNull(assetPackage);
+
+            wasBrandNewPlayer = playerContext.WasBrandNewPlayer;
+
+            Player player;
+
+            if (!allPlayersByName.TryGetValue(playerContext.PlayerName, out player))
             {
-                ConnectionAssets assetPackage = assetsByConnection[connection];
-                PlayerContext playerContext = reservations[reservationKey];
-                Validate.NotNull(playerContext);
-
-                wasBrandNewPlayer = playerContext.WasBrandNewPlayer;
-                
-                Player player;
-                
-                lock (allPlayersByName)
-                {
-                    if (!allPlayersByName.TryGetValue(playerContext.PlayerName, out player))
-                    {
-                        player = new Player(playerContext.PlayerId, playerContext.PlayerName, playerContext, connection, NitroxVector3.Zero, new NitroxId(), Optional.Empty, Perms.PLAYER, defaultPlayerStats, new List<EquippedItemData>(), new List<EquippedItemData>());
-                        allPlayersByName[playerContext.PlayerName] = player;
-                    }
-                }
-
-                // TODO: make a ConnectedPlayer wrapper so this is not stateful
-                player.PlayerContext = playerContext;
-                player.connection = connection;
-
-                assetPackage.Player = player;
-                assetPackage.ReservationKey = null;
-                reservations.Remove(reservationKey);
-
-                return player;
+                player = new Player(playerContext.PlayerId,
+                    playerContext.PlayerName,
+                    playerContext,
+                    connection,
+                    NitroxVector3.Zero,
+                    new NitroxId(),
+                    Optional.Empty,
+                    Perms.PLAYER,
+                    defaultPlayerStats,
+                    new List<EquippedItemData>(),
+                    new List<EquippedItemData>());
+                allPlayersByName[playerContext.PlayerName] = player;
             }
+
+            // TODO: make a ConnectedPlayer wrapper so this is not stateful
+            player.PlayerContext = playerContext;
+            player.connection = connection;
+
+            assetPackage.Player = player;
+            assetPackage.ReservationKey = null;
+            reservations.Remove(reservationKey);
+
+            return player;
         }
 
         public void PlayerDisconnected(NitroxConnection connection)
         {
-            lock (assetsByConnection)
+            ConnectionAssets assetPackage;
+            assetsByConnection.TryGetValue(connection, out assetPackage);
+
+            if (assetPackage == null)
             {
-                ConnectionAssets assetPackage = null;
-                assetsByConnection.TryGetValue(connection, out assetPackage);
-
-                if (assetPackage == null)
-                {
-                    return;
-                }
-
-                if (assetPackage.ReservationKey != null)
-                {
-                    PlayerContext playerContext = reservations[assetPackage.ReservationKey];
-                    reservedPlayerNames.Remove(playerContext.PlayerName);
-                    reservations.Remove(assetPackage.ReservationKey);
-                }
-
-                if (assetPackage.Player != null)
-                {
-                    Player player = assetPackage.Player;
-                    reservedPlayerNames.Remove(player.Name);
-                }
-
-                assetsByConnection.Remove(connection);
+                return;
             }
+
+            if (assetPackage.ReservationKey != null)
+            {
+                PlayerContext playerContext = reservations[assetPackage.ReservationKey];
+                reservedPlayerNames.Remove(playerContext.PlayerName);
+                reservations.Remove(assetPackage.ReservationKey);
+            }
+
+            if (assetPackage.Player != null)
+            {
+                Player player = assetPackage.Player;
+                reservedPlayerNames.Remove(player.Name);
+            }
+
+            assetsByConnection.Remove(connection);
         }
-        
+
         public bool TryGetPlayerByName(string playerName, out Player foundPlayer)
         {
-            lock (assetsByConnection)
+            foundPlayer = null;
+            foreach (Player player in ConnectedPlayers())
             {
-                foundPlayer = null;
-                foreach (Player player in ConnectedPlayers())
+                if (player.Name == playerName)
                 {
-                    if (player.Name == playerName)
-                    {
-                        foundPlayer = player;
-                        return true;
-                    }
+                    foundPlayer = player;
+                    return true;
                 }
-
-                return false;
             }
+
+            return false;
         }
 
         public Player GetPlayer(NitroxConnection connection)
         {
-            lock (assetsByConnection)
-            {
-                ConnectionAssets assetPackage = null;
-                assetsByConnection.TryGetValue(connection, out assetPackage);
-                return assetPackage?.Player;
-            }
+            ConnectionAssets assetPackage;
+            assetsByConnection.TryGetValue(connection, out assetPackage);
+            return assetPackage?.Player;
         }
 
         public Optional<Player> GetPlayer(string playerName)
         {
-            lock (allPlayersByName)
-            {
-                Player player;
-                allPlayersByName.TryGetValue(playerName, out player);
-
-                return Optional.OfNullable(player);
-            }
+            Player player;
+            allPlayersByName.TryGetValue(playerName, out player);
+            return Optional.OfNullable(player);
         }
 
         public void SendPacketToAllPlayers(Packet packet)
         {
-            lock (assetsByConnection)
+            foreach (Player player in ConnectedPlayers())
             {
-                foreach (Player player in ConnectedPlayers())
+                player.SendPacket(packet);
+            }
+        }
+
+        public void SendPacketToOtherPlayers(Packet packet, Player sendingPlayer)
+        {
+            foreach (Player player in ConnectedPlayers())
+            {
+                if (!Equals(player, sendingPlayer))
                 {
                     player.SendPacket(packet);
                 }
             }
         }
 
-        public void SendPacketToOtherPlayers(Packet packet, Player sendingPlayer)
+        private IEnumerable<Player> ConnectedPlayers()
         {
-            lock (assetsByConnection)
-            {
-                foreach (Player player in ConnectedPlayers())
-                {
-                    if (player != sendingPlayer)
-                    {
-                        player.SendPacket(packet);
-                    }
-                }
-            }
-        }
-
-        private List<Player> ConnectedPlayers()
-        {
-            lock (assetsByConnection)
-            {
-                return assetsByConnection.Values
-                    .Where(assetPackage => assetPackage.Player != null)
-                    .Select(assetPackage => assetPackage.Player)
-                    .ToList();
-            }
+            return assetsByConnection.Values
+                .Where(assetPackage => assetPackage.Player != null)
+                .Select(assetPackage => assetPackage.Player);
         }
     }
 }

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -18,7 +18,7 @@ namespace NitroxServer.GameLogic
         private readonly ThreadSafeDictionary<string, Player> allPlayersByName;
         private readonly ThreadSafeDictionary<NitroxConnection, ConnectionAssets> assetsByConnection = new ThreadSafeDictionary<NitroxConnection, ConnectionAssets>();
         private readonly ThreadSafeDictionary<string, PlayerContext> reservations = new ThreadSafeDictionary<string, PlayerContext>();
-        private readonly ThreadSafeCollection<string> reservedPlayerNames = new ThreadSafeCollection<string>();
+        private readonly ThreadSafeCollection<string> reservedPlayerNames = new ThreadSafeCollection<string>(new HashSet<string>());
 
         private readonly PlayerStatsData defaultPlayerStats;
         private readonly ServerConfig serverConfig;

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -199,7 +199,7 @@ namespace NitroxServer.GameLogic
         {
             foreach (Player player in ConnectedPlayers())
             {
-                if (!Equals(player, sendingPlayer))
+                if (player != sendingPlayer)
                 {
                     player.SendPacket(packet);
                 }

--- a/NitroxServer/GameLogic/Players/PlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PlayerData.cs
@@ -3,7 +3,6 @@ using ProtoBufNet;
 using System.Collections.Generic;
 using UnityEngine;
 using NitroxModel.DataStructures;
-using NitroxModel.Logger;
 
 namespace NitroxServer.GameLogic.Players
 {

--- a/NitroxServer/GameLogic/Players/PlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PlayerData.cs
@@ -47,8 +47,8 @@ namespace NitroxServer.GameLogic.Players
             {
                 PersistedPlayerData persistedPlayer = new PersistedPlayerData();
                 persistedPlayer.Name = player.Name;
-                persistedPlayer.EquippedItems = player.getAllEquipment();
-                persistedPlayer.Modules = player.getAllModules();
+                persistedPlayer.EquippedItems = player.GetEquipment();
+                persistedPlayer.Modules = player.GetModules();
                 persistedPlayer.Id = player.Id;
                 persistedPlayer.SpawnPosition = player.Position;
                 persistedPlayer.CurrentStats = player.Stats;

--- a/NitroxServer/GameLogic/Players/PlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PlayerData.cs
@@ -39,7 +39,7 @@ namespace NitroxServer.GameLogic.Players
             return boPlayers;
         }
 
-        public static PlayerData From(List<Player> players)
+        public static PlayerData From(IEnumerable<Player> players)
         {
             List<PersistedPlayerData> persistedPlayers = new List<PersistedPlayerData>();
 

--- a/NitroxServer/GameLogic/TimeKeeper.cs
+++ b/NitroxServer/GameLogic/TimeKeeper.cs
@@ -9,31 +9,32 @@ namespace NitroxServer.GameLogic
         // Values taken directly from hardcoded subnautica values
         private static readonly DateTime SUBNAUTICA_FUTURE_START_DATE = new DateTime(2287, 5, 7, 9, 36, 0);
 
-        private static readonly float SUBNAUTICA_BEGIN_TIME_OFFSET = 1200f / 86400f *
-                                                            (3600f * (float)SUBNAUTICA_FUTURE_START_DATE.Hour +
-                                                             60f * (float)SUBNAUTICA_FUTURE_START_DATE.Minute +
-                                                             (float)SUBNAUTICA_FUTURE_START_DATE.Second);
-
-        public DateTime ServerStartTime { get; set; } = DateTime.Now;
+        private static readonly float SUBNAUTICA_BEGIN_TIME_OFFSET = 1200f /
+                                                                     86400f *
+                                                                     (3600f * SUBNAUTICA_FUTURE_START_DATE.Hour +
+                                                                      60f * SUBNAUTICA_FUTURE_START_DATE.Minute +
+                                                                      SUBNAUTICA_FUTURE_START_DATE.Second);
 
         // Discrepancy value for player based time modifications
         private float correctionValue;
 
+        public DateTime ServerStartTime { get; set; } = DateTime.Now;
+
         public void SetDay()
         {
-            correctionValue += 1200.0f - GetCurrentTime() % 1200.0f + 600.0f;
+            correctionValue += 1200.0f - CurrentTime % 1200.0f + 600.0f;
             SendCurrentTimePacket();
         }
 
         public void SetNight()
         {
-            correctionValue += 1200.0f - GetCurrentTime() % 1200.0f;
+            correctionValue += 1200.0f - CurrentTime % 1200.0f;
             SendCurrentTimePacket();
         }
 
         public void SkipTime()
         {
-            correctionValue += 600.0f - GetCurrentTime() % 600.0f;
+            correctionValue += 600.0f - CurrentTime % 600.0f;
             SendCurrentTimePacket();
         }
 
@@ -42,19 +43,22 @@ namespace NitroxServer.GameLogic
         {
             if (player != null)
             {
-                player.SendPacket(new TimeChange(GetCurrentTime()));
+                player.SendPacket(new TimeChange(CurrentTime));
             }
             else
             {
                 PlayerManager playerManager = NitroxServiceLocator.LocateService<PlayerManager>();
-                playerManager.SendPacketToAllPlayers(new TimeChange(GetCurrentTime()));
+                playerManager.SendPacketToAllPlayers(new TimeChange(CurrentTime));
             }
         }
 
-        private float GetCurrentTime()
+        private float CurrentTime
         {
-            TimeSpan interval = DateTime.Now - ServerStartTime;
-            return Convert.ToSingle(interval.TotalSeconds) + SUBNAUTICA_BEGIN_TIME_OFFSET + correctionValue;
+            get
+            {
+                TimeSpan interval = DateTime.Now - ServerStartTime;
+                return SUBNAUTICA_BEGIN_TIME_OFFSET + Convert.ToSingle(interval.TotalSeconds) + correctionValue;
+            }
         }
     }
 }

--- a/NitroxServer/GameLogic/Unlockables/StoryGoalData.cs
+++ b/NitroxServer/GameLogic/Unlockables/StoryGoalData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using ProtoBufNet;
 
@@ -8,94 +9,22 @@ namespace NitroxServer.GameLogic.Unlockables
     public class StoryGoalData
     {
         [ProtoMember(1)]
-        public List<string> SerializeCompletedGoals
-        {
-            get
-            {
-                lock (completedGoals)
-                {
-                    return completedGoals;
-                }
-            }
-            set { completedGoals = value; }
-        }
-
+        public ThreadSafeCollection<string> CompletedGoals { get; } = new ThreadSafeCollection<string>();
+        
         [ProtoMember(2)]
-        public List<string> SerializeRadioQueue
-        {
-            get
-            {
-                lock (radioQueue)
-                {
-                    return radioQueue;
-                }
-            }
-            set { radioQueue = value; }
-        }
-
+        public ThreadSafeCollection<string> RadioQueue { get; } = new ThreadSafeCollection<string>();
+        
         [ProtoMember(3)]
-        public List<string> SerializeGoalUnlocks
-        {
-            get
-            {
-                lock (goalUnlocks)
-                {
-                    return goalUnlocks;
-                }
-            }
-            set { goalUnlocks = value; }
-        }
-
-        [ProtoIgnore]
-        private List<string> completedGoals = new List<string>();
-        
-        [ProtoIgnore]
-        private List<string> radioQueue = new List<string>();
-        
-        [ProtoIgnore]
-        private List<string> goalUnlocks = new List<string>();
-
-        public void AddStoryGoal(string entry)
-        {
-            lock (completedGoals)
-            {
-                completedGoals.Add(entry);
-            }
-        }
-
-        public void AddRadioMessage(string entry)
-        {
-            lock (radioQueue)
-            {
-                radioQueue.Add(entry);
-            }
-        }
-
-        public void AddGoalUnlock(string entry)
-        {
-            lock (goalUnlocks)
-            {
-                goalUnlocks.Add(entry);
-            }
-        }
+        public ThreadSafeCollection<string> GoalUnlocks { get; } = new ThreadSafeCollection<string>();
 
         public void RemovedLatestRadioMessage()
         {
-            lock (radioQueue)
-            {
-                radioQueue.RemoveAt(0);
-            }
+            RadioQueue.RemoveAt(0);
         }
 
         public InitialStoryGoalData GetInitialStoryGoalData()
         {
-            lock (completedGoals)
-            {
-                lock (radioQueue)
-                {
-                    return new InitialStoryGoalData(new List<string>(completedGoals), new List<string>(radioQueue), new List<string>(goalUnlocks));
-                }
-            }
+            return new InitialStoryGoalData(new List<string>(CompletedGoals), new List<string>(RadioQueue), new List<string>(GoalUnlocks));
         }
     }
 }

--- a/NitroxServer/GameLogic/Vehicles/VehicleData.cs
+++ b/NitroxServer/GameLogic/Vehicles/VehicleData.cs
@@ -1,6 +1,7 @@
 ﻿using NitroxModel.DataStructures.GameLogic;
 using ProtoBufNet;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NitroxServer.GameLogic.Vehicles
 {
@@ -10,12 +11,12 @@ namespace NitroxServer.GameLogic.Vehicles
         [ProtoMember(1)]
         public List<VehicleModel> Vehicles = new List<VehicleModel>();
         
-        public static VehicleData From(List<VehicleModel> vehicles)
+        public static VehicleData From(IEnumerable<VehicleModel> vehicles)
         {
-            VehicleData vehicleData = new VehicleData();
-            vehicleData.Vehicles = vehicles;
-
-            return vehicleData;
+            return new VehicleData
+            {
+                Vehicles = vehicles.ToList()
+            };
         }
     }
 }

--- a/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
+++ b/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
@@ -74,12 +74,9 @@ namespace NitroxServer.GameLogic.Vehicles
 
         public Optional<VehicleModel> GetVehicleModel(NitroxId id)
         {
-            lock (vehiclesById)
-            {
-                VehicleModel vehicleModel;
-                vehiclesById.TryGetValue(id, out vehicleModel);
-                return Optional.OfNullable(vehicleModel);
-            }
+            VehicleModel vehicleModel;
+            vehiclesById.TryGetValue(id, out vehicleModel);
+            return Optional.OfNullable(vehicleModel);
         }
 
         public Optional<T> GetVehicleModel<T>(NitroxId id) where T : VehicleModel

--- a/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
+++ b/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
@@ -1,109 +1,75 @@
-﻿using NitroxModel.DataStructures.GameLogic;
-using System.Collections.Generic;
-using NitroxModel.DataStructures.Util;
-using UnityEngine;
-using NitroxServer.GameLogic.Items;
-using NitroxModel.DataStructures;
+﻿using System.Collections.Generic;
 using System.Linq;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
+using NitroxServer.GameLogic.Items;
+using UnityEngine;
 
 namespace NitroxServer.GameLogic.Vehicles
 {
     public class VehicleManager
     {
-        private InventoryManager inventoryManager;
-        private Dictionary<NitroxId, VehicleModel> vehiclesById = new Dictionary<NitroxId, VehicleModel>();
+        private readonly InventoryManager inventoryManager;
+        private readonly ThreadSafeDictionary<NitroxId, VehicleModel> vehiclesById;
 
         public VehicleManager(List<VehicleModel> vehicles, InventoryManager inventoryManager)
         {
-            vehiclesById = vehicles.ToDictionary(vehicle => vehicle.Id);
+            vehiclesById = new ThreadSafeDictionary<NitroxId, VehicleModel>(vehicles.ToDictionary(vehicle => vehicle.Id), false);
             this.inventoryManager = inventoryManager;
         }
 
-        public List<VehicleModel> GetVehicles()
+        public IEnumerable<VehicleModel> GetVehicles()
         {
-            lock(vehiclesById)
-            {
-                return new List<VehicleModel>(vehiclesById.Values);
-            }
+            return vehiclesById.Values;
         }
 
         public void UpdateVehicle(VehicleMovementData vehicleMovement)
         {
-            lock (vehiclesById)
+            if (vehiclesById.ContainsKey(vehicleMovement.Id))
             {
-                if (vehiclesById.ContainsKey(vehicleMovement.Id))
-                {
-                    VehicleModel vehicleModel = vehiclesById[vehicleMovement.Id];
-                    vehicleModel.Position = vehicleMovement.Position;
-                    vehicleModel.Rotation = vehicleMovement.Rotation;
-                    vehicleModel.Health = vehicleMovement.Health;
-                }
+                VehicleModel vehicleModel = vehiclesById[vehicleMovement.Id];
+                vehicleModel.Position = vehicleMovement.Position;
+                vehicleModel.Rotation = vehicleMovement.Rotation;
+                vehicleModel.Health = vehicleMovement.Health;
             }
         }
 
         public void UpdateVehicleChildObjects(NitroxId id, List<InteractiveChildObjectIdentifier> interactiveChildObjectIdentifier)
         {
-            lock (vehiclesById)
+            if (vehiclesById.ContainsKey(id))
             {
-                if (vehiclesById.ContainsKey(id))
-                {
-                    vehiclesById[id].InteractiveChildIdentifiers = interactiveChildObjectIdentifier;
-                }
+                vehiclesById[id].InteractiveChildIdentifiers.Set(interactiveChildObjectIdentifier);
             }
         }
 
         public void UpdateVehicleName(NitroxId id, string name)
         {
-            lock (vehiclesById)
+            if (vehiclesById.ContainsKey(id))
             {
-                if (vehiclesById.ContainsKey(id))
-                {
-                    vehiclesById[id].Name = name;
-                }
+                vehiclesById[id].Name = name;
             }
         }
 
         public void UpdateVehicleColours(int index, NitroxId id, Vector3 hsb, Color colour)
         {
-            lock (vehiclesById)
+            if (vehiclesById.ContainsKey(id))
             {
-                if (vehiclesById.ContainsKey(id))
-                {
-                    Vector4 tmpVect = colour;
-                    vehiclesById[id].Colours[index] = tmpVect;
-                    vehiclesById[id].HSB[index] = hsb;
-                }
+                Vector4 tmpVect = colour;
+                vehiclesById[id].Colours[index] = tmpVect;
+                vehiclesById[id].HSB[index] = hsb;
             }
         }
 
         public void AddVehicle(VehicleModel vehicleModel)
         {
-            lock (vehiclesById)
-            {
-                vehiclesById.Add(vehicleModel.Id, vehicleModel);
-            }
+            vehiclesById.Add(vehicleModel.Id, vehicleModel);
         }
 
         public void RemoveVehicle(NitroxId id)
         {
-            lock (vehiclesById)
-            {
-                RemoveItemsFromVehicle(id);
-                vehiclesById.Remove(id);
-            }
-        }
-
-        private void RemoveItemsFromVehicle(NitroxId id)
-        {
-            // Remove items in vehicles (for now just batteries)
-            VehicleModel vehicle = vehiclesById[id];
-            
-            inventoryManager.StorageItemRemoved(vehicle.Id);
-
-            foreach (InteractiveChildObjectIdentifier child in vehicle.InteractiveChildIdentifiers)
-            {
-                inventoryManager.StorageItemRemoved(child.Id);
-            }            
+            RemoveItemsFromVehicle(id);
+            vehiclesById.Remove(id);
         }
 
         public Optional<VehicleModel> GetVehicleModel(NitroxId id)
@@ -119,6 +85,17 @@ namespace NitroxServer.GameLogic.Vehicles
         public Optional<T> GetVehicleModel<T>(NitroxId id) where T : VehicleModel
         {
             return Optional.OfNullable(GetVehicleModel(id).Value as T);
+        }
+
+        private void RemoveItemsFromVehicle(NitroxId id)
+        {
+            // Remove items in vehicles (for now just batteries)
+            VehicleModel vehicle = vehiclesById[id];
+            inventoryManager.StorageItemRemoved(vehicle.Id);
+            foreach (InteractiveChildObjectIdentifier child in vehicle.InteractiveChildIdentifiers)
+            {
+                inventoryManager.StorageItemRemoved(child.Id);
+            }
         }
     }
 }

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -319,6 +319,7 @@
     <Compile Include="ConsoleCommands\LoginCommand.cs" />
     <Compile Include="ConsoleCommands\OpCommand.cs" />
     <Compile Include="ConsoleCommands\BroadcastCommand.cs" />
+    <Compile Include="ConsoleCommands\SummaryCommand.cs" />
     <Compile Include="ConsoleCommands\TimeCommand.cs" />
     <Compile Include="ConsoleCommands\WhisperCommand.cs" />
     <Compile Include="Exceptions\DuplicateRegistrationException.cs" />

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -13,8 +13,11 @@ namespace NitroxServer
     public class Player : IProcessorContext
     {
         private readonly List<EquippedItemData> equippedItems;
+        private readonly object equippedItemsLock = new object();
         private readonly List<EquippedItemData> modules;
+        private readonly object modulesLock = new object();
         private readonly HashSet<AbsoluteEntityCell> visibleCells = new HashSet<AbsoluteEntityCell>();
+        private readonly object visibleCellsLock = new object();
         public NitroxConnection connection { get; set; }
 
         public PlayerSettings PlayerSettings => PlayerContext.PlayerSettings;
@@ -77,7 +80,7 @@ namespace NitroxServer
 
         public void AddCells(IEnumerable<AbsoluteEntityCell> cells)
         {
-            lock (visibleCells)
+            lock (visibleCellsLock)
             {
                 foreach (AbsoluteEntityCell cell in cells)
                 {
@@ -88,7 +91,7 @@ namespace NitroxServer
 
         public void RemoveCells(IEnumerable<AbsoluteEntityCell> cells)
         {
-            lock (visibleCells)
+            lock (visibleCellsLock)
             {
                 foreach (AbsoluteEntityCell cell in cells)
                 {
@@ -99,7 +102,7 @@ namespace NitroxServer
 
         public bool HasCellLoaded(AbsoluteEntityCell cell)
         {
-            lock (visibleCells)
+            lock (visibleCellsLock)
             {
                 return visibleCells.Contains(cell);
             }
@@ -107,7 +110,7 @@ namespace NitroxServer
 
         public void AddModule(EquippedItemData module)
         {
-            lock (modules)
+            lock (modulesLock)
             {
                 modules.Add(module);
             }
@@ -115,7 +118,7 @@ namespace NitroxServer
 
         public void RemoveModule(NitroxId id)
         {
-            lock (modules)
+            lock (modulesLock)
             {
                 modules.RemoveAll(item => item.ItemId == id);
             }
@@ -123,7 +126,7 @@ namespace NitroxServer
 
         public List<EquippedItemData> getAllModules()
         {
-            lock (modules)
+            lock (modulesLock)
             {
                 return new List<EquippedItemData>(modules);
             }
@@ -131,7 +134,7 @@ namespace NitroxServer
 
         public void AddEquipment(EquippedItemData equipment)
         {
-            lock (equippedItems)
+            lock (equippedItemsLock)
             {
                 equippedItems.Add(equipment);
             }
@@ -139,7 +142,7 @@ namespace NitroxServer
 
         public void RemoveEquipment(NitroxId id)
         {
-            lock (equippedItems)
+            lock (equippedItemsLock)
             {
                 equippedItems.RemoveAll(item => item.ItemId == id);
             }
@@ -147,7 +150,7 @@ namespace NitroxServer
 
         public List<EquippedItemData> getAllEquipment()
         {
-            lock (equippedItems)
+            lock (equippedItemsLock)
             {
                 return new List<EquippedItemData>(equippedItems);
             }

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -106,9 +106,9 @@ namespace NitroxServer
             modules.RemoveAll(item => item.ItemId == id);
         }
 
-        public List<EquippedItemData> getAllModules()
+        public List<EquippedItemData> GetModules()
         {
-            return new List<EquippedItemData>(modules);
+            return modules.ToList();
         }
 
         public void AddEquipment(EquippedItemData equipment)
@@ -121,9 +121,9 @@ namespace NitroxServer
             equippedItems.RemoveAll(item => item.ItemId == id);
         }
 
-        public List<EquippedItemData> getAllEquipment()
+        public List<EquippedItemData> GetEquipment()
         {
-            return new List<EquippedItemData>(equippedItems);
+            return equippedItems.ToList();
         }
 
         public override string ToString()

--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -1,38 +1,38 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Configuration;
 using System.Text;
-using System.ComponentModel;
-using NitroxModel.Logger;
 using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.Logger;
 
 namespace NitroxServer.ConfigParser
 {
     public class ServerConfig
     {
+        private readonly ServerConfigItem<string> adminPasswordSetting = new ServerConfigItem<string>("AdminPassword", GenerateRandomString(12, false));
+        private readonly ServerConfigItem<bool> disableConsoleSetting = new ServerConfigItem<bool>("DisableConsole", true);
+        private readonly ServerConfigItem<float> foodSetting = new ServerConfigItem<float>("StartFood", 50.5f);
+        private readonly ServerConfigItem<string> gameModeSetting = new ServerConfigItem<string>("GameMode", "Survival");
+        private readonly ServerConfigItem<float> healthSetting = new ServerConfigItem<float>("StartHealth", 80);
+        private readonly ServerConfigItem<float> infectionSetting = new ServerConfigItem<float>("StartInfection", 0);
+        private readonly ServerConfigItem<int> maxConnectionsSetting = new ServerConfigItem<int>("MaxConnections", 100);
+        private readonly ServerConfigItem<float> maxOxygenSetting = new ServerConfigItem<float>("StartMaxOxygen", 45);
+        private readonly ServerConfigItem<float> oxygenSetting = new ServerConfigItem<float>("StartOxygen", 45);
         private readonly ServerConfigItem<int> portSetting = new ServerConfigItem<int>("Port", 11000);
         private readonly ServerConfigItem<int> saveIntervalSetting = new ServerConfigItem<int>("SaveInterval", 60000);
-        private readonly ServerConfigItem<int> maxConnectionsSetting = new ServerConfigItem<int>("MaxConnections", 100);
-        private readonly ServerConfigItem<bool> disableConsoleSetting = new ServerConfigItem<bool>("DisableConsole", true);
         private readonly ServerConfigItem<string> saveNameSetting = new ServerConfigItem<string>("SaveName", "save");
         private readonly ServerConfigItem<string> serverPasswordSetting = new ServerConfigItem<string>("ServerPassword", "");
-        private readonly ServerConfigItem<string> adminPasswordSetting = new ServerConfigItem<string>("AdminPassword", GenerateRandomString(12, false));
-        private readonly ServerConfigItem<string> gameModeSetting = new ServerConfigItem<string>("GameMode", "Survival");
-        private readonly ServerConfigItem<float> oxygenSetting = new ServerConfigItem<float>("StartOxygen", 45);
-        private readonly ServerConfigItem<float> maxOxygenSetting = new ServerConfigItem<float>("StartMaxOxygen", 45);
-        private readonly ServerConfigItem<float> healthSetting = new ServerConfigItem<float>("StartHealth", 80);
-        private readonly ServerConfigItem<float> foodSetting = new ServerConfigItem<float>("StartFood", 50.5f);
         private readonly ServerConfigItem<float> waterSetting = new ServerConfigItem<float>("StartWater", 90.5f);
-        private readonly ServerConfigItem<float> infectionSetting = new ServerConfigItem<float>("StartInfection", 0);
 
-        public int ServerPort { get { return portSetting.Value; } }
-        public int SaveInterval { get { return saveIntervalSetting.Value; } }
-        public int MaxConnections { get { return maxConnectionsSetting.Value; } }
-        public bool DisableConsole { get { return disableConsoleSetting.Value; } }
-        public string SaveName { get { return saveNameSetting.Value; } }
-        public string ServerPassword { get { return serverPasswordSetting.Value; } }
-        public string AdminPassword { get { return adminPasswordSetting.Value; } }
-        public string GameMode { get { return gameModeSetting.Value; } }
-        public PlayerStatsData DefaultPlayerStats { get { return new PlayerStatsData(oxygenSetting.Value, maxOxygenSetting.Value, healthSetting.Value, foodSetting.Value, waterSetting.Value, infectionSetting.Value); } }
+        public int ServerPort => portSetting.Value;
+        public int SaveInterval => saveIntervalSetting.Value;
+        public int MaxConnections => maxConnectionsSetting.Value;
+        public bool DisableConsole => disableConsoleSetting.Value;
+        public string SaveName => saveNameSetting.Value;
+        public string ServerPassword => serverPasswordSetting.Value;
+        public string AdminPassword => adminPasswordSetting.Value;
+        public string GameMode => gameModeSetting.Value;
+        public PlayerStatsData DefaultPlayerStats => new PlayerStatsData(oxygenSetting.Value, maxOxygenSetting.Value, healthSetting.Value, foodSetting.Value, waterSetting.Value, infectionSetting.Value);
 
         // Generate a random string with a given size and case.   
         // If second parameter is true, the return string is lowercase  
@@ -52,22 +52,6 @@ namespace NitroxServer.ConfigParser
                 return builder.ToString().ToLower();
             }
             return builder.ToString();
-        }
-
-        private void RefreshAppSettingsValue(string key, string value)
-        {
-            try
-            {
-                Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-                config.AppSettings.Settings[key].Value = value;
-                config.Save(ConfigurationSaveMode.Modified);
-
-                ConfigurationManager.RefreshSection("appSettings");
-            }
-            catch (Exception ex)
-            {
-                Log.Error("Can't refresh server app settings", ex);
-            }
         }
 
         public void ChangeAdminPassword(string password)
@@ -93,12 +77,29 @@ namespace NitroxServer.ConfigParser
             saveIntervalSetting.Value = intervalInMillis;
             RefreshAppSettingsValue(saveIntervalSetting.Name, intervalInMillis.ToString());
         }
+
+        private void RefreshAppSettingsValue(string key, string value)
+        {
+            try
+            {
+                Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                config.AppSettings.Settings[key].Value = value;
+                config.Save(ConfigurationSaveMode.Modified);
+
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Can't refresh server app settings", ex);
+            }
+        }
     }
 
     internal class ServerConfigItem<T>
     {
-        public T Value;
         public readonly string Name;
+        public T Value;
+
         public ServerConfigItem(string itemName, T defaultValue)
         {
             Name = itemName;
@@ -106,11 +107,6 @@ namespace NitroxServer.ConfigParser
             try
             {
                 TypeConverter converter = TypeDescriptor.GetConverter(typeof(T));
-                if (converter == null)
-                {
-                    return;
-                }
-
                 string text = ConfigurationManager.AppSettings[itemName];
 
                 // Empty string is ignored
@@ -126,9 +122,11 @@ namespace NitroxServer.ConfigParser
                 }
 
                 Value = (T)converter.ConvertFromString(text);
-
             }
-            catch (Exception) { }
+            catch (Exception)
+            {
+                Log.Warn($"Failed to read server config field '{itemName}'. Using default value '{defaultValue}'.");
+            }
         }
     }
 }

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -44,7 +44,7 @@ namespace NitroxServer.Serialization.World
                 persistedData.WorldData.InventoryData = InventoryData.From(world.InventoryManager.GetAllInventoryItems(), world.InventoryManager.GetAllStorageSlotItems());
                 persistedData.PlayerData = PlayerData.From(world.PlayerManager.GetAllPlayers());
                 persistedData.WorldData.GameData = world.GameData;
-                persistedData.WorldData.EscapePodData = EscapePodData.from(world.EscapePodManager.GetEscapePods());
+                persistedData.WorldData.EscapePodData = EscapePodData.From(world.EscapePodManager.GetEscapePods());
 
                 if (!Directory.Exists(config.SaveName))
                 {

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -15,7 +15,6 @@ using NitroxServer.ConfigParser;
 using NitroxModel.DataStructures;
 using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic.Entities;
-using NitroxServer.GameLogic.Entities.EntityBootstrappers;
 using NitroxServer.Serialization.Resources.Datastructures;
 using NitroxModel.DataStructures.GameLogic;
 
@@ -156,7 +155,6 @@ namespace NitroxServer.Serialization.World
         public World Load()
         {
             Optional<World> fileLoadedWorld = LoadFromFile();
-
             if (fileLoadedWorld.HasValue)
             {
                 return fileLoadedWorld.Value;

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -65,16 +65,22 @@ namespace NitroxServer
             isSaving = false;
         }
 
-        public void Start()
+        public bool Start()
         {
+            if (!server.Start())
+            {
+                return false;
+            }
+            Log.Info("Nitrox Server Started");
             IsRunning = true;
+            EnablePeriodicSaving();
+            
 #if RELEASE
             // Help new players on which IP they should give to their friends
             IpLogger.PrintServerIps();
 #endif
-            server.Start();
-            Log.Info("Nitrox Server Started");
-            EnablePeriodicSaving();
+            
+            return true;
         }
 
         public void Stop()

--- a/NitroxTest/DataStructures/ThreadSafeCollectionTest.cs
+++ b/NitroxTest/DataStructures/ThreadSafeCollectionTest.cs
@@ -69,5 +69,17 @@ namespace NitroxTest.DataStructures
             set.Remove("test 0");
             set[0].ShouldBeEquivalentTo("test 1");
         }
+
+        [TestMethod]
+        public void Find()
+        {
+            list.Find(s => s == "test 1").ShouldBeEquivalentTo("test 1");
+            list.Find(s => s == "tesT 1").Should().BeNull();
+            list.Find(s => s == "test 1361").Should().BeNull();
+            
+            set.Find(s => s == "test 7").ShouldBeEquivalentTo("test 7");
+            set.Find(s => s == "tesT 7").Should().BeNull();
+            set.Find(s => s == "test 1361").Should().BeNull();
+        }
     }
 }

--- a/NitroxTest/DataStructures/ThreadSafeCollectionTest.cs
+++ b/NitroxTest/DataStructures/ThreadSafeCollectionTest.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxModel.DataStructures;
+
+namespace NitroxTest.DataStructures
+{
+    [TestClass]
+    public class ThreadSafeCollectionTest
+    {
+        private ThreadSafeCollection<string> list;
+        private ThreadSafeCollection<string> set;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            list = new ThreadSafeCollection<string>();
+            set = new ThreadSafeCollection<string>(new HashSet<string>());
+            for (int i = 0; i < 10; i++)
+            {
+                set.Add($"test {i}");
+                list.Add($"test {i}");
+            }
+        }
+
+        [TestMethod]
+        public void IsSet()
+        {
+            set.IsSet.ShouldBeEquivalentTo(true);
+            list.IsSet.ShouldBeEquivalentTo(false);
+        }
+
+        [TestMethod]
+        public void Insert()
+        {
+            list.Insert(5, "derp");
+            list[5].ShouldBeEquivalentTo("derp");
+            list[0] = "Hello world!";
+            list[0].ShouldBeEquivalentTo("Hello world!");
+
+            set.Insert(8, "wot");
+            set[8].ShouldBeEquivalentTo("wot");
+            set[set.Count - 1] = "Hello world!";
+            set[set.Count - 1].ShouldBeEquivalentTo("Hello world!");
+        }
+
+        [TestMethod]
+        public void RemoveAt()
+        {
+            list.RemoveAt(5);
+            foreach (string item in list)
+            {
+                item.Should().NotBe("test 5");
+            }
+
+            set.RemoveAt(5);
+            foreach (string item in set)
+            {
+                item.Should().NotBe("test 5");
+            }
+        }
+
+        [TestMethod]
+        public void Remove()
+        {
+            list.Remove("test 0");
+            list[0].ShouldBeEquivalentTo("test 1");
+
+            set.Remove("test 0");
+            set[0].ShouldBeEquivalentTo("test 1");
+        }
+    }
+}

--- a/NitroxTest/Model/OptionalTest.cs
+++ b/NitroxTest/Model/OptionalTest.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
-using UnityEngine;
 
 namespace NitroxTest.Model
 {
@@ -92,7 +88,7 @@ namespace NitroxTest.Model
         [TestMethod]
         public void OptionalSetValueNull()
         {
-            Optional<Exosuit> op = Optional.Of(new Exosuit());
+            Optional<Random> op = Optional.Of(new Random());
             op.HasValue.Should().BeTrue();
             Action setNull = () => { op = null; };
             setNull.ShouldThrow<ArgumentNullException>("Setting optional to null should not be allowed.");

--- a/NitroxTest/Model/Packets/PacketsSerializableTest.cs
+++ b/NitroxTest/Model/Packets/PacketsSerializableTest.cs
@@ -14,7 +14,7 @@ namespace NitroxTest.Model.Packets
     [TestClass]
     public class PacketsSerializableTest
     {
-        private HashSet<Type> visitedTypes = new HashSet<Type>();
+        private readonly HashSet<Type> visitedTypes = new HashSet<Type>();
 
         public void IsSerializable(Type t)
         {

--- a/NitroxTest/Model/Packets/PacketsSerializableTest.cs
+++ b/NitroxTest/Model/Packets/PacketsSerializableTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxModel.DataStructures.Surrogates;
 using NitroxModel.Packets;
@@ -37,10 +38,12 @@ namespace NitroxTest.Model.Packets
         [TestMethod]
         public void AllPacketsAreSerializable()
         {
-            typeof(Packet).Assembly.GetTypes()
+            foreach (Type packetType in typeof(Packet).Assembly.GetTypes()
                 .Where(p => typeof(Packet).IsAssignableFrom(p) && p.IsClass && !p.IsAbstract)
-                .ToList()
-                .ForEach(IsSerializable);
+                .ToList())
+            {
+                IsSerializable(packetType);
+            }
         }
 
         [TestMethod]
@@ -61,7 +64,8 @@ namespace NitroxTest.Model.Packets
             foreach (Type type in surrogates)
             {
                 ISerializationSurrogate surrogate = (ISerializationSurrogate)Activator.CreateInstance(type);
-                Type surrogatedType = type.BaseType.GetGenericArguments()[0];
+                Type surrogatedType = type.BaseType?.GetGenericArguments()[0];
+                surrogatedType.Should().NotBeNull();
                 surrogateSelector.AddSurrogate(surrogatedType, streamingContext, surrogate);
             }
 

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Patcher\Patches\Equipment_RemoveItem_PatchTest.cs" />
     <Compile Include="Patcher\Test\PatchTestHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Serialization\InteractiveChildObjectIdentifiersSerializationtest.cs" />
     <Compile Include="Serialization\PdaStateDataSerializationTest.cs" />
     <Compile Include="SetupAssemblyInitializer.cs" />
     <Compile Include="Threading\ThreadSafeCollectionTest.cs" />

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Patcher\Patches\Equipment_RemoveItem_PatchTest.cs" />
     <Compile Include="Patcher\Test\PatchTestHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Serialization\PdaStateDataSerializationTest.cs" />
     <Compile Include="SetupAssemblyInitializer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Client\PlayerPreferences\PlayerPreferenceManagerTests.cs" />
     <Compile Include="Client\PlayerPreferences\TestConstants.cs" />
     <Compile Include="Core\DependencyInjectionTests.cs" />
+    <Compile Include="DataStructures\ThreadSafeCollectionTest.cs" />
     <Compile Include="Model\OptionalTest.cs" />
     <Compile Include="Model\PacketProcessorTest.cs" />
     <Compile Include="Model\Packets\PacketsSerializableTest.cs" />

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\PdaStateDataSerializationTest.cs" />
     <Compile Include="SetupAssemblyInitializer.cs" />
+    <Compile Include="Threading\ThreadSafeCollectionTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NitroxClient\NitroxClient.csproj">

--- a/NitroxTest/Serialization/InteractiveChildObjectIdentifiersSerializationtest.cs
+++ b/NitroxTest/Serialization/InteractiveChildObjectIdentifiersSerializationtest.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxServer.GameLogic.Unlockables;
+using NitroxServer.Serialization;
+using NitroxTechType = NitroxModel.DataStructures.TechType;
+
+namespace NitroxTest.Serialization
+{
+    [TestClass]
+    public class InteractiveChildObjectIdentifiersSerializationtest
+    {
+        private ThreadSafeCollection<InteractiveChildObjectIdentifier> state;
+        private readonly Random random = new Random();
+
+        [TestInitialize]
+        public void Setup()
+        {
+            state = new ThreadSafeCollection<InteractiveChildObjectIdentifier>();
+            state.Add(new InteractiveChildObjectIdentifier(new NitroxId(), "/BlablaScene/SomeBlablaContainer/BlaItem"));
+            byte[] idBytes = new byte[16];
+            random.NextBytes(idBytes);
+            state.Add(new InteractiveChildObjectIdentifier(new NitroxId(idBytes), ""));
+            state.Add(new InteractiveChildObjectIdentifier(new NitroxId(), " herp "));
+        }
+
+        [TestMethod]
+        public void Sanity()
+        {
+            ServerProtobufSerializer server = new ServerProtobufSerializer();
+
+            ThreadSafeCollection<InteractiveChildObjectIdentifier> deserialized;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                server.Serialize(stream, state);
+                stream.Position = 0;
+                deserialized = server.Deserialize<ThreadSafeCollection<InteractiveChildObjectIdentifier>>(stream);
+            }
+
+            deserialized.Count.Should().BeGreaterThan(0);
+            deserialized[0].GameObjectNamePath.ShouldBeEquivalentTo("/BlablaScene/SomeBlablaContainer/BlaItem");
+            deserialized[1].GameObjectNamePath.ShouldBeEquivalentTo("");
+            deserialized[2].GameObjectNamePath.ShouldBeEquivalentTo(" herp ");
+
+            int iterationCount = 0;
+            foreach (InteractiveChildObjectIdentifier id in deserialized)
+            {
+                iterationCount++;
+                id.Id.ToString().Should().MatchRegex("^[a-zA-Z0-9\\-]{10,}$"); // matches hex and - character
+                id.GameObjectNamePath.Should().NotBeNull();
+            }
+            
+            iterationCount.ShouldBeEquivalentTo(3);
+        }
+    }
+}

--- a/NitroxTest/Serialization/PdaStateDataSerializationTest.cs
+++ b/NitroxTest/Serialization/PdaStateDataSerializationTest.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxServer.GameLogic.Unlockables;
+using NitroxServer.Serialization;
+using NitroxTechType = NitroxModel.DataStructures.TechType;
+
+namespace NitroxTest.Serialization
+{
+    [TestClass]
+    public class PdaStateDataSerializationTest
+    {
+        private PDAStateData state;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            state = new PDAStateData();
+            state.PdaLog.Add(new PDALogEntry("Some key", 25.125f));
+            state.EncyclopediaEntries.Add("Test encyclopedia entry");
+            state.EncyclopediaEntries.Add("Test encyclopedia entry again");
+            state.EncyclopediaEntries.Add("");
+            state.PartiallyUnlockedByTechType.Add(new NitroxTechType("Battery"), new PDAEntry(new NitroxTechType("Areogel"), 1f, 1));
+        }
+
+        [TestMethod]
+        public void Sanity()
+        {
+            ServerProtobufSerializer server = new ServerProtobufSerializer();
+
+            PDAStateData deserialized;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                server.Serialize(stream, state);
+                stream.Position = 0;
+                deserialized = server.Deserialize<PDAStateData>(stream);
+            }
+
+            deserialized.PdaLog.Count.ShouldBeEquivalentTo(1);
+            deserialized.PdaLog[0].Key.ShouldBeEquivalentTo("Some key");
+            deserialized.EncyclopediaEntries.Count.ShouldBeEquivalentTo(3);
+            deserialized.EncyclopediaEntries[2].ShouldBeEquivalentTo("");
+            deserialized.PartiallyUnlockedByTechType.Count.ShouldBeEquivalentTo(1);
+            deserialized.PartiallyUnlockedByTechType[new NitroxTechType("Battery")].Progress.ShouldBeEquivalentTo(1f);
+        }
+    }
+}

--- a/NitroxTest/Threading/ThreadSafeCollectionTest.cs
+++ b/NitroxTest/Threading/ThreadSafeCollectionTest.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxModel.DataStructures;
+
+namespace NitroxTest.Threading
+{
+    [TestClass]
+    public class ThreadSafeCollectionTest
+    {
+        [TestMethod]
+        public void ReadAndWriteSimultanious()
+        {
+            int iterations = 500000;
+
+            ThreadSafeCollection<string> comeGetMe = new ThreadSafeCollection<string>(iterations);
+            List<long> countsRead = new List<long>();
+            long addCount = 0;
+
+            Random r = new Random();
+            DoReaderWriter(() =>
+                {
+                    countsRead.Add(Interlocked.Read(ref addCount));
+                },
+                i =>
+                {
+                    comeGetMe.Add(new string(Enumerable.Repeat(' ', 10).Select(c => (char)r.Next('A', 'Z')).ToArray()));
+                    Interlocked.Increment(ref addCount);
+                },
+                iterations);
+
+            addCount.ShouldBeEquivalentTo(iterations);
+            countsRead.Count.Should().BeGreaterThan(0);
+            countsRead.Last().ShouldBeEquivalentTo(iterations);
+            comeGetMe.Count.ShouldBeEquivalentTo(iterations);
+        }
+
+        [TestMethod]
+        public void IterateAndAddSimultanious()
+        {
+            int iterations = 500000;
+
+            ThreadSafeCollection<string> comeGetMe = new ThreadSafeCollection<string>(iterations);
+            long addCount = 0;
+            long iterationsReadMany = 0;
+
+            Random r = new Random();
+            DoReaderWriter(() =>
+                {
+                    foreach (string item in comeGetMe)
+                    {
+                        item.Length.Should().BeGreaterThan(0);
+                        Interlocked.Increment(ref iterationsReadMany);
+                    }
+                },
+                i =>
+                {
+                    comeGetMe.Add(new string(Enumerable.Repeat(' ', 10).Select(c => (char)r.Next('A', 'Z')).ToArray()));
+                    Interlocked.Increment(ref addCount);
+                },
+                iterations);
+
+            addCount.ShouldBeEquivalentTo(iterations);
+            iterationsReadMany.Should().BePositive();
+        }
+
+        [TestMethod]
+        public void IterateAndAdd()
+        {
+            ThreadSafeCollection<int> nums = new ThreadSafeCollection<int>()
+            {
+                1,2,3,4,5
+            };
+
+            foreach (int num in nums)
+            {
+                if (num == 3)
+                {
+                    nums.Add(10);
+                }
+            }
+            
+            nums.Count.ShouldBeEquivalentTo(6);
+            nums.Last().ShouldBeEquivalentTo(10);
+        }
+
+        private void DoReaderWriter(Action reader, Action<int> writer, int iterators)
+        {
+            ManualResetEvent barrier = new ManualResetEvent(false);
+            Thread readerThread = new Thread(() =>
+            {
+                while (!barrier.SafeWaitHandle.IsClosed)
+                {
+                    reader();
+                    Thread.Yield();
+                }
+                
+                // Read one last time after writer finishes
+                reader();
+            });
+            Thread writerThread = new Thread(() =>
+            {
+                for (int i = 0; i < iterators; i++)
+                {
+                    writer(i);
+                }
+                barrier.Set(); // Signal done
+            });
+
+            readerThread.Start();
+            writerThread.Start();
+            barrier.WaitOne(); // Wait for signal
+        }
+    }
+}


### PR DESCRIPTION
 - Added thread safe collections that are serializable to assist server persist
 - Added debug logs for when items are added to containers and change packet is send to server
 - Added utility for getting scene path of GameObject
 - Fixed unit tests except the connection unit tests (these take more time to properly understand the featureset and write unit test for, again)
 - Added 'summary' command to server commands to display general information about the save. Not all is printed yet but it helps for debugging.
 - Changed the IP printing stuff to be release only to reduce unnecessary network requests in development.
- Fixed case where server couldn't start listening on socket but was ignored since LiteNetLib eats the exception and just prints it.