### PR TITLE
Loading screen version indicator now fades out

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
@@ -12,8 +12,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 
         public static void Initialize()
         {
-            AddTextToLoadingScreen("\nNitrox Alpha V" + assemblyVersion);
-            loadingScreenWarning = AddTextToLoadingScreen("\n\nExpect game breaking bugs");
+            loadingScreenWarning = AddTextToLoadingScreen("\n\nNitrox Alpha V" + assemblyVersion + "\nExpect game breaking bugs");
         }
 
         private static uGUI_TextFade AddTextToLoadingScreen(string text)


### PR DESCRIPTION
Tiny edit to correct a small oversight (at least I think it is one? if not, my bad!) that made the version number displayed while loading the game persist ingame.

I've made it fade out with the rest of the text.