### PR TITLE
Catch BadFormatImage Invalid DOS signature to display a better understandable text

### DIFF
--- a/NitroxLauncher/Pages/LaunchGamePage.xaml.cs
+++ b/NitroxLauncher/Pages/LaunchGamePage.xaml.cs
@@ -35,6 +35,11 @@ namespace NitroxLauncher.Pages
             {
                 await LauncherLogic.Instance.StartMultiplayerAsync();
             }
+            catch(BadImageFormatException ex)
+            {
+                //This exception is throw with "Invalid DOS Signature" which is a clue that some
+                MessageBox.Show($"Try to check your subnautica files throught Steam/EpicGames in order to fix the game: {ex.Message}", "Error, Seems like your game is corrupted :(", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.ToString(), "Error while starting in multiplayer mode", MessageBoxButton.OK, MessageBoxImage.Error);


### PR DESCRIPTION
This error is related to corrupted .exe or .dll, this could be Nitrox or more likely that Subnautica is corrupted and they need to check the game files