### PR TITLE
Spring cleanup of patches

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/BaseDeconstructable_Deconstructor_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseDeconstructable_Deconstructor_Patch.cs
@@ -15,8 +15,7 @@ namespace NitroxPatcher.Patches.Dynamic
      */
     public class BaseDeconstructable_Deconstructor_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(BaseDeconstructable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(BaseDeconstructable).GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Prefix(BaseDeconstructable __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Base_ClearGeometry_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_ClearGeometry_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Harmony;
 using NitroxClient.MonoBehaviours;
@@ -12,8 +11,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Base_ClearGeometry_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Base);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ClearGeometry", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Base).GetMethod("ClearGeometry", BindingFlags.Public | BindingFlags.Instance);
 
         /**
          * When new bases are constructed it will sometimes clear all of the pieces 

--- a/NitroxPatcher/Patches/Dynamic/Base_CopyFrom_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_CopyFrom_Patch.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Harmony;
+﻿using Harmony;
 using System.Reflection;
 using NitroxClient.MonoBehaviours;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class Base_CopyFrom_Patch : NitroxPatch, IDynamicPatch
+    public class Base_CopyFrom_Patch : NitroxPatch, IDynamicPatch
     {
         public readonly MethodInfo METHOD = typeof(Base).GetMethod(nameof(Base.CopyFrom), BindingFlags.Public | BindingFlags.Instance);
 

--- a/NitroxPatcher/Patches/Dynamic/Base_SpawnPiece_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_SpawnPiece_Patch.cs
@@ -10,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Base_SpawnPiece_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Base);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SpawnPiece", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(Base).GetNestedType("Piece", BindingFlags.NonPublic | BindingFlags.Instance), typeof(Int3), typeof(Quaternion), typeof(Base.Direction?) }, null);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Base).GetMethod("SpawnPiece", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(Base).GetNestedType("Piece", BindingFlags.NonPublic | BindingFlags.Instance), typeof(Int3), typeof(Quaternion), typeof(Base.Direction?) }, null);
         
         /**
          * This function is called directly after the game clears all base pieces (to update

--- a/NitroxPatcher/Patches/Dynamic/Bed_EnterInUseMode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Bed_EnterInUseMode_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Core;
@@ -7,10 +6,9 @@ using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class Bed_EnterInUseMode_Patch : NitroxPatch, IDynamicPatch
+    public class Bed_EnterInUseMode_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Bed);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("EnterInUseMode", BindingFlags.Instance | BindingFlags.NonPublic);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Bed).GetMethod("EnterInUseMode", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static void Postfix()
         {

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -9,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Constructable_Construct_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Constructable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Construct");
+        public static readonly MethodInfo TARGET_METHOD = typeof(Constructable).GetMethod("Construct");
 
         private static Base lastTargetBase;
         private static Int3 lastTargetBaseOffset;

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Deconstruct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Deconstruct_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Constructable_Deconstruct_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Constructable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Deconstruct");
+        public static readonly MethodInfo TARGET_METHOD = typeof(Constructable).GetMethod("Deconstruct");
         
         public static void Postfix(Constructable __instance, bool __result)
         {

--- a/NitroxPatcher/Patches/Dynamic/Constructable_SetState_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_SetState_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.Helper;
@@ -14,8 +13,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Constructable_SetState_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Constructable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SetState", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Constructable).GetMethod("SetState", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(Constructable __instance, bool value)
         {

--- a/NitroxPatcher/Patches/Dynamic/ConstructorInput_Craft_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ConstructorInput_Craft_Patch.cs
@@ -8,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class ConstructorInput_Craft_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ConstructorInput);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Craft", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ConstructorInput).GetMethod("Craft", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(ConstructorInput __instance, TechType techType, float duration)
         {

--- a/NitroxPatcher/Patches/Dynamic/CrashHome_Spawn_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CrashHome_Spawn_Patch.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
     public class CrashHome_Spawn_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CrashHome);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Spawn", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CrashHome).GetMethod("Spawn", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix() // Disables Crashfish automatic spawning on the client
         {

--- a/NitroxPatcher/Patches/Dynamic/Creature_ChooseBestAction_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Creature_ChooseBestAction_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Creature_ChooseBestAction_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Creature);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ChooseBestAction", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Creature).GetMethod("ChooseBestAction", BindingFlags.NonPublic | BindingFlags.Instance);
 
         private static CreatureAction previousAction;
 

--- a/NitroxPatcher/Patches/Dynamic/CyclopsDamagePoint_OnRepair_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsDamagePoint_OnRepair_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -10,10 +9,9 @@ namespace NitroxPatcher.Patches.Dynamic
     /// <see cref="CyclopsExternalDamageManager.RepairPoint(CyclopsDamagePoint)"/> would seem like the correct method to patch, but adding to its postfix will
     /// execute before <see cref="CyclopsDamagePoint.OnRepair"/> is finished working. Both owners and non-owners will be able to repair damage points on a ship.
     /// </summary>
-    class CyclopsDamagePoint_OnRepair_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsDamagePoint_OnRepair_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsDamagePoint);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsDamagePoint).GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsDamagePoint __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsDecoyLaunchButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsDecoyLaunchButton_OnClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -8,10 +7,9 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    internal class CyclopsDecoyLaunchButton_OnClick_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsDecoyLaunchButton_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsDecoyLaunchButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsDecoyLaunchButton).GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsHornButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsEngineChangeState_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsEngineChangeState_OnClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsEngineChangeState_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsEngineChangeState);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsEngineChangeState).GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsEngineChangeState __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsExternalDamageManager_CreatePoint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsExternalDamageManager_CreatePoint_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -7,10 +6,9 @@ using NitroxModel.Core;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsExternalDamageManager_CreatePoint_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsExternalDamageManager_CreatePoint_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsExternalDamageManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("CreatePoint", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsExternalDamageManager).GetMethod("CreatePoint", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsExternalDamageManager __instance, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsFireSuppressionButton_StartCooldown_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsFireSuppressionButton_StartCooldown_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -12,10 +11,9 @@ namespace NitroxPatcher.Patches.Dynamic
      * Relays Cyclops FireSuppressionSystem to other players
      * This method was used instead of the OnClick to ensure, that the the suppression really started
      */
-    class CyclopsFireSuppressionButton_StartCooldown_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsFireSuppressionButton_StartCooldown_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsFireSuppressionSystemButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("StartCooldown", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsFireSuppressionSystemButton).GetMethod("StartCooldown", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsFireSuppressionSystemButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsHelmHUDManager_Start_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsHelmHUDManager_Start_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsHelmHUDManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsHelmHUDManager).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_StopPiloting_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_StopPiloting_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxModel.Helper;
 
@@ -7,8 +6,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsHelmHUDManager_StopPiloting_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsHelmHUDManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("StopPiloting", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsHelmHUDManager).GetMethod("StopPiloting", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsHelmHUDManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsHelmHUDManager).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHornButton_OnPress_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHornButton_OnPress_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsHornButton_OnPress_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsHornButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPress", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsHornButton).GetMethod("OnPress", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsHornButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_OnSubConstructionComplete_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_OnSubConstructionComplete_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -13,10 +12,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsLightingPanel_OnSubConstructionComplete_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsLightingPanel_OnSubConstructionComplete_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsLightingPanel);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SubConstructionComplete", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsLightingPanel).GetMethod("SubConstructionComplete", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsLightingPanel __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleFloodlights_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleFloodlights_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsLightingPanel_ToggleFloodlights_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsLightingPanel);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ToggleFloodlights", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsLightingPanel).GetMethod("ToggleFloodlights", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsLightingPanel __instance, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleInternalLighting_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleInternalLighting_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsLightingPanel_ToggleInternalLighting_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsLightingPanel);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ToggleInternalLighting", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsLightingPanel).GetMethod("ToggleInternalLighting", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsLightingPanel __instance, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -12,8 +11,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsMotorModeButton_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsMotorModeButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsMotorModeButton).GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsMotorModeButton __instance, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_SaveEngineStateAndPowerDown_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_SaveEngineStateAndPowerDown_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxModel.Helper;
 
@@ -7,8 +6,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsMotorMode_SaveEngineStateAndPowerDown_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsMotorMode);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SaveEngineStateAndPowerDown", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsMotorMode).GetMethod("SaveEngineStateAndPowerDown", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(CyclopsMotorMode __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_OnClick_Patch.cs
@@ -11,6 +11,7 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly Type TARGET_CLASS = typeof(CyclopsShieldButton);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+
         public static readonly OpCode START_CUT_CODE = OpCodes.Ldsfld;
         public static readonly OpCode START_CUT_CODE_CALL = OpCodes.Callvirt;
         public static readonly FieldInfo PLAYER_MAIN_FIELD = typeof(Player).GetField("main", BindingFlags.Public | BindingFlags.Static);

--- a/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_OnClick_Patch.cs
@@ -9,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsShieldButton_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsShieldButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsShieldButton).GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static readonly OpCode START_CUT_CODE = OpCodes.Ldsfld;
         public static readonly OpCode START_CUT_CODE_CALL = OpCodes.Callvirt;

--- a/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_StartShield_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_StartShield_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -8,10 +7,9 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsShieldButton_StartShield_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsShieldButton_StartShield_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsShieldButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("StartShield", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsShieldButton).GetMethod("StartShield", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsShieldButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_StopShield_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsShieldButton_StopShield_Patch.cs
@@ -8,10 +8,9 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsShieldButton_StopShield_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsShieldButton_StopShield_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsShieldButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("StopShield", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsShieldButton).GetMethod("StopShield", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsShieldButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSilentRunningAbilityButton_TurnOffSilentRunning_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSilentRunningAbilityButton_TurnOffSilentRunning_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsSilentRunningAbilityButton_TurnOffSilentRunning_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsSilentRunningAbilityButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("TurnOffSilentRunning", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsSilentRunningAbilityButton).GetMethod("TurnOffSilentRunning", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsSilentRunningAbilityButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSilentRunningAbilityButton_TurnOnSilentRunning_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSilentRunningAbilityButton_TurnOnSilentRunning_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class CyclopsSilentRunningAbilityButton_TurnOnSilentRunning_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsSilentRunningAbilityButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("TurnOnSilentRunning", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsSilentRunningAbilityButton).GetMethod("TurnOnSilentRunning", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(CyclopsSilentRunningAbilityButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -8,10 +7,9 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsSonarButton_OnClick_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsSonarButton_OnClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CyclopsSonarButton);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CyclopsSonarButton).GetMethod("OnClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(CyclopsSonarButton __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
@@ -11,15 +11,15 @@ using NitroxModel.DataStructures;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
     {
-
         public static readonly Type TARGET_CLASS = typeof(CyclopsSonarButton);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SonarPing", BindingFlags.NonPublic | BindingFlags.Instance);
+
         public static readonly OpCode JUMP_TARGET_CODE = OpCodes.Ldsfld;
         public static readonly FieldInfo JUMP_TARGET_FIELD = typeof(SNCameraRoot).GetField("main", BindingFlags.Public | BindingFlags.Static);
 
-        
+
         // Send ping to other players        
         public static void Postfix(CyclopsSonarButton __instance)
         {
@@ -27,7 +27,7 @@ namespace NitroxPatcher.Patches.Dynamic
             NitroxServiceLocator.LocateService<Cyclops>().BroadcastSonarPing(id);
         }
 
-       
+
         /* As the ping would be always be executed it should be restricted to players, that are in the cyclops
         * Therefore the code generated from AssembleNewCode will be injected before the ping would be send but after energy consumption
         * End result:
@@ -46,7 +46,7 @@ namespace NitroxPatcher.Patches.Dynamic
         * 	SNCameraRoot.main.SonarPing();
         * 	this.soundFX.Play();
         * }
-        */        
+        */
         public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
         {
             List<CodeInstruction> instructionList = instructions.ToList();
@@ -59,10 +59,10 @@ namespace NitroxPatcher.Patches.Dynamic
             for (int i = 0; i < instructionList.Count; i++)
             {
                 CodeInstruction instruction = instructionList[i];
-                if(instruction.opcode.Equals(JUMP_TARGET_CODE) && instruction.operand.Equals(JUMP_TARGET_FIELD))
-                {                    
+                if (instruction.opcode.Equals(JUMP_TARGET_CODE) && instruction.operand.Equals(JUMP_TARGET_FIELD))
+                {
                     Label jumpLabel = instruction.labels[0];
-                    IEnumerable<CodeInstruction> injectInstructions = AssembleNewCode(jumpLabel,toInjectJump);
+                    IEnumerable<CodeInstruction> injectInstructions = AssembleNewCode(jumpLabel, toInjectJump);
                     foreach (CodeInstruction injectInstruction in injectInstructions)
                     {
                         yield return injectInstruction;
@@ -83,10 +83,10 @@ namespace NitroxPatcher.Patches.Dynamic
                     }
                 }
                 yield return instruction;
-            }           
+            }
         }
 
-        private static IEnumerable<CodeInstruction> AssembleNewCode(Label outJumpLabel,Label innerJumpLabel)
+        private static IEnumerable<CodeInstruction> AssembleNewCode(Label outJumpLabel, Label innerJumpLabel)
         {
             //Code to inject:
             /*
@@ -96,7 +96,7 @@ namespace NitroxPatcher.Patches.Dynamic
 		     * }
              * 
              */
-                List<CodeInstruction> injectInstructions = new List<CodeInstruction>();
+            List<CodeInstruction> injectInstructions = new List<CodeInstruction>();
 
             CodeInstruction instruction = new CodeInstruction(OpCodes.Ldsfld);
             instruction.operand = typeof(Player).GetField("main", BindingFlags.Public | BindingFlags.Static);
@@ -107,7 +107,7 @@ namespace NitroxPatcher.Patches.Dynamic
             instruction.operand = typeof(Player).GetMethod("get_currentSub", BindingFlags.Public | BindingFlags.Instance);
             injectInstructions.Add(instruction);
 
-            instruction = new CodeInstruction(OpCodes.Ldarg_0);            
+            instruction = new CodeInstruction(OpCodes.Ldarg_0);
             injectInstructions.Add(instruction);
 
             instruction = new CodeInstruction(OpCodes.Ldfld);

--- a/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_day_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_day_Patch.cs
@@ -7,10 +7,9 @@ using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class DayNightCycle_OnConsoleCommand_day_Patch : NitroxPatch, IDynamicPatch
+    public class DayNightCycle_OnConsoleCommand_day_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(DayNightCycle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnConsoleCommand_day", BindingFlags.Instance | BindingFlags.NonPublic);
+        public static readonly MethodInfo TARGET_METHOD = typeof(DayNightCycle).GetMethod("OnConsoleCommand_day", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static bool Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_night_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DayNightCycle_OnConsoleCommand_night_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Core;
@@ -7,10 +6,9 @@ using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class DayNightCycle_OnConsoleCommand_night_Patch : NitroxPatch, IDynamicPatch
+    public class DayNightCycle_OnConsoleCommand_night_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(DayNightCycle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnConsoleCommand_night", BindingFlags.Instance | BindingFlags.NonPublic);
+        public static readonly MethodInfo TARGET_METHOD = typeof(DayNightCycle).GetMethod("OnConsoleCommand_night", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static bool Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
@@ -4,7 +4,7 @@ using NitroxClient.GameLogic;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class DevConsole_Update_Patch : NitroxPatch, IDynamicPatch
+    public class DevConsole_Update_Patch : NitroxPatch, IDynamicPatch
     {
         public static void Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/DockedVehicleHandTarget_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DockedVehicleHandTarget_OnHandClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class DockedVehicleHandTarget_OnHandClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(DockedVehicleHandTarget);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(DockedVehicleHandTarget).GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
 
         private static DockedVehicleHandTarget dockedVehicle;
         private static VehicleDockingBay vehicleDockingBay;

--- a/NitroxPatcher/Patches/Dynamic/EnergyInterface_ModifyCharge_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyInterface_ModifyCharge_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.MonoBehaviours;
 
@@ -7,8 +6,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class EnergyInterface_ModifyCharge_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EnergyInterface);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ModifyCharge", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EnergyInterface).GetMethod("ModifyCharge", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(EnergyInterface __instance, float amount, float __result)
         {

--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnAddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnAddItem_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -7,10 +6,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class EnergyMixin_OnAddItem_Patch : NitroxPatch, IDynamicPatch
+    public class EnergyMixin_OnAddItem_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EnergyMixin);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EnergyMixin).GetMethod("OnAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(EnergyMixin __instance, InventoryItem item)
         {

--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnRemoveItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnRemoveItem_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -7,10 +6,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class EnergyMixin_OnRemoveItem_Patch : NitroxPatch, IDynamicPatch
+    public class EnergyMixin_OnRemoveItem_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EnergyMixin);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EnergyMixin).GetMethod("OnRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(EnergyMixin __instance, InventoryItem item)
         {

--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_SpawnDefault_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_SpawnDefault_Patch.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class EnergyMixin_SpawnDefault_Patch : NitroxPatch, IDynamicPatch
+    public class EnergyMixin_SpawnDefault_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EnergyMixin);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SpawnDefault", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EnergyMixin).GetMethod("SpawnDefault", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(EnergyMixin __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/EntityCell_QueueForAwake_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EntityCell_QueueForAwake_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class EntityCell_QueueForAwake_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EntityCell);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("QueueForAwake");
+        public static readonly MethodInfo TARGET_METHOD = typeof(EntityCell).GetMethod("QueueForAwake");
 
         public static bool Prefix(EntityCell __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/EntityCell_QueueForSleep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EntityCell_QueueForSleep_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class EntityCell_QueueForSleep_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EntityCell);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("QueueForSleep");
+        public static readonly MethodInfo TARGET_METHOD = typeof(EntityCell).GetMethod("QueueForSleep");
 
         public static bool Prefix(EntityCell __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Equipment_AddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Equipment_AddItem_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Equipment_AddItem_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Equipment);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("AddItem", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Equipment).GetMethod("AddItem", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(Equipment __instance, bool __result, string slot, InventoryItem newItem)
         {

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 
@@ -7,8 +6,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class EscapePod_Awake_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EscapePod);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EscapePod).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(EscapePod __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_OnRepair_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_OnRepair_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class EscapePod_OnRepair_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EscapePod);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EscapePod).GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(EscapePod __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_OnPickup_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_OnPickup_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -9,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class ExosuitClawArm_OnPickup_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ExosuitClawArm);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPickup");
+        public static readonly MethodInfo TARGET_METHOD = typeof(ExosuitClawArm).GetMethod("OnPickup");
 
         public static bool Prefix(ExosuitClawArm __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_TryUse_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_TryUse_Patch.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitClawArm_TryUse_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitClawArm_TryUse_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ExosuitClawArm);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("TryUse", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ExosuitClawArm).GetMethod("TryUse", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(bool __result, ExosuitClawArm __instance,float ___cooldownTime)
         {

--- a/NitroxPatcher/Patches/Dynamic/ExosuitDrillArm_OnUseDown_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitDrillArm_OnUseDown_Patch.cs
@@ -7,7 +7,7 @@ using NitroxModel_Subnautica.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitDrillArm_OnUseDown_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitDrillArm_OnUseDown_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(ExosuitDrillArm);
         public static readonly Type TARGET_INTERFACE = typeof(IExosuitArm);

--- a/NitroxPatcher/Patches/Dynamic/ExosuitDrillArm_OnUseUp_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitDrillArm_OnUseUp_Patch.cs
@@ -7,7 +7,7 @@ using NitroxModel_Subnautica.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitDrillArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitDrillArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(ExosuitDrillArm);
         public static readonly Type TARGET_INTERFACE = typeof(IExosuitArm);

--- a/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnHit_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnHit_Patch.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
 using NitroxModel.DataStructures.Util;
 using NitroxModel_Subnautica.Packets;
-using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitGrapplingArm_OnHit_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitGrapplingArm_OnHit_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ExosuitGrapplingArm);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnHit");
+        public static readonly MethodInfo TARGET_METHOD = typeof(ExosuitGrapplingArm).GetMethod("OnHit");
 
         public static bool Prefix(ExosuitGrapplingArm __instance, GrapplingHook ___hook)
         {

--- a/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnUseUp_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnUseUp_Patch.cs
@@ -7,7 +7,7 @@ using NitroxModel_Subnautica.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitGrapplingArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitGrapplingArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(ExosuitGrapplingArm);
         public static readonly Type TARGET_INTERFACE = typeof(IExosuitArm);

--- a/NitroxPatcher/Patches/Dynamic/ExosuitTorpedoArm_OnUseUp_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitTorpedoArm_OnUseUp_Patch.cs
@@ -7,7 +7,7 @@ using NitroxModel_Subnautica.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitTorpedoArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitTorpedoArm_OnUseUp_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(ExosuitTorpedoArm);
         public static readonly Type TARGET_INTERFACE = typeof(IExosuitArm);

--- a/NitroxPatcher/Patches/Dynamic/ExosuitTorpedoArm_Shoot_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitTorpedoArm_Shoot_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,10 +10,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ExosuitTorpedoArm_Shoot_Patch : NitroxPatch, IDynamicPatch
+    public class ExosuitTorpedoArm_Shoot_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ExosuitTorpedoArm);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Shoot", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ExosuitTorpedoArm).GetMethod("Shoot", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Prefix(ExosuitTorpedoArm __instance, bool __result, TorpedoType torpedoType, Transform siloTransform)
         {

--- a/NitroxPatcher/Patches/Dynamic/Exosuit_SpawnArm_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Exosuit_SpawnArm_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Exosuit_ArmSpawned_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Exosuit);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("UpdateColliders", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Exosuit).GetMethod("UpdateColliders", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(Exosuit __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Fabricator_OnCraftingBegin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Fabricator_OnCraftingBegin_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Fabricator_OnCraftingBegin_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Fabricator);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnCraftingBegin", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Fabricator).GetMethod("OnCraftingBegin", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(Fabricator __instance, TechType techType, float duration)
         {

--- a/NitroxPatcher/Patches/Dynamic/Fire_Douse_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Fire_Douse_Patch.cs
@@ -8,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Fire_Douse_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Fire);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Douse", BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Fire).GetMethod("Douse", BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
 
         public static void Postfix(Fire __instance, float amount)
         {

--- a/NitroxPatcher/Patches/Dynamic/FreezeTime_Begin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FreezeTime_Begin_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using UWE;
 
@@ -7,8 +6,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class FreezeTime_Begin_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(FreezeTime);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Begin", BindingFlags.Public | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(FreezeTime).GetMethod("Begin", BindingFlags.Public | BindingFlags.Static);
 
         public static bool Prefix(string userId, bool dontPauseSound)
         {

--- a/NitroxPatcher/Patches/Dynamic/GameSettings_SerializeInputSettings_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/GameSettings_SerializeInputSettings_Patch.cs
@@ -10,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class GameSettings_SerializeInputSettings_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(GameSettings);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SerializeInputSettings", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(GameSettings).GetMethod("SerializeInputSettings", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Postfix(GameSettings.ISerializer serializer)
         {

--- a/NitroxPatcher/Patches/Dynamic/IngameMenu_OnSelect_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IngameMenu_OnSelect_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using Harmony;
@@ -8,8 +7,8 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class IngameMenu_OnSelect_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(IngameMenu);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnSelect");
+        public static readonly MethodInfo TARGET_METHOD = typeof(IngameMenu).GetMethod("OnSelect");
+
         public static readonly MethodInfo GAMEMODEUTILS_ISPERMADEATH_METHOD = typeof(GameModeUtils).GetMethod("IsPermadeath", BindingFlags.Public | BindingFlags.Static);
 
         public static void Postfix()

--- a/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGameAsync_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGameAsync_Patch.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class IngameMenu_QuitGameAsync_Patch : NitroxPatch, IDynamicPatch
+    public class IngameMenu_QuitGameAsync_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(IngameMenu);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("QuitGameAsync");
+        public static readonly MethodInfo TARGET_METHOD = typeof(IngameMenu).GetMethod("QuitGameAsync");
 
         public static bool Prefix(bool quitToDesktop)
         {

--- a/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGame_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGame_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Core;
@@ -9,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class IngameMenu_QuitGame_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(IngameMenu);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("QuitGame");
+        public static readonly MethodInfo TARGET_METHOD = typeof(IngameMenu).GetMethod("QuitGame");
 
         public static void Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitSubscreen_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitSubscreen_Patch.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
     public class IngameMenu_QuitSubscreen_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(IngameMenu);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("QuitSubscreen");
+        public static readonly MethodInfo TARGET_METHOD = typeof(IngameMenu).GetMethod("QuitSubscreen");
 
         public static bool Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyAddItem_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class ItemsContainer_NotifyAddItem_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ItemsContainer).GetMethod("NotifyAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_NotifyRemoveItem_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class ItemsContainer_NotifyRemoveItem_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ItemsContainer);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(InventoryItem) }, null);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ItemsContainer).GetMethod("NotifyRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(InventoryItem) }, null);
 
         public static void Postfix(ItemsContainer __instance, InventoryItem item)
         {

--- a/NitroxPatcher/Patches/Dynamic/KeypadDoorConsole_AcceptNumberField_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/KeypadDoorConsole_AcceptNumberField_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class KeypadDoorConsole_AcceptNumberField_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(KeypadDoorConsole);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("AcceptNumberField", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(KeypadDoorConsole).GetMethod("AcceptNumberField", BindingFlags.NonPublic | BindingFlags.Instance);
         
         public static void Postfix(KeypadDoorConsole __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/KnownTech_NotifyAdd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/KnownTech_NotifyAdd_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class KnownTech_NotifyAdd_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(KnownTech);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(KnownTech).GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(TechType techType, bool verbose)
         {

--- a/NitroxPatcher/Patches/Dynamic/MedicalCabinet_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MedicalCabinet_OnHandClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class MedicalCabinet_OnHandClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(MedicalCabinet);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(MedicalCabinet).GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(MedicalCabinet __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Openable_PlayOpenAnimation_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Openable_PlayOpenAnimation_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Openable_PlayOpenAnimation_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Openable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("PlayOpenAnimation", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Openable).GetMethod("PlayOpenAnimation", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(Openable __instance, bool openState, float duration)
         {

--- a/NitroxPatcher/Patches/Dynamic/PDAEncyclopedia_Add_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAEncyclopedia_Add_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PDAEncyclopedia_Add_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PDAEncyclopedia);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PDAEncyclopedia).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(string key)
         {

--- a/NitroxPatcher/Patches/Dynamic/PDALog_NotifyAdd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDALog_NotifyAdd_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PDALog_NotifyAdd_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PDALog);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PDALog).GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(PDALog.Entry entry)
         {

--- a/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyAdd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyAdd_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PDAScanner_NotifyAdd_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PDAScanner);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PDAScanner).GetMethod("NotifyAdd", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(PDAScanner.Entry entry)
         {

--- a/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyProgress_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyProgress_Patch.cs
@@ -8,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PDAScanner_NotifyProgress_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PDAScanner);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyProgress", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PDAScanner).GetMethod("NotifyProgress", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(PDAScanner.Entry entry)
         {

--- a/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyRemove_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAScanner_NotifyRemove_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PDAScanner_NotifyRemove_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PDAScanner);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("NotifyRemove", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PDAScanner).GetMethod("NotifyRemove", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Prefix(PDAScanner.Entry entry)
         {

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
@@ -9,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Pickupable_Drop_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Pickupable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Drop", BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(Vector3), typeof(Vector3), typeof(bool) }, null);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Pickupable).GetMethod("Drop", BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(Vector3), typeof(Vector3), typeof(bool) }, null);
 
         public static void Postfix(Pickupable __instance, Vector3 dropPosition)
         {

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_Pickup_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_Pickup_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Pickupable_Pickup_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Pickupable);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Pickup");
+        public static readonly MethodInfo TARGET_METHOD = typeof(Pickupable).GetMethod("Pickup");
 
         public static bool Prefix(Pickupable __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/PilotingChair_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PilotingChair_OnHandClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.HUD;
@@ -13,8 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PilotingChair_OnHandClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PilotingChair);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PilotingChair).GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
 
         private static PilotingChair pilotingChair;
         private static GUIHand guiHand;

--- a/NitroxPatcher/Patches/Dynamic/PilotingChair_OnPlayerDeath_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PilotingChair_OnPlayerDeath_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PilotingChair_OnPlayerDeath_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PilotingChair);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPlayerDeath", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PilotingChair).GetMethod("OnPlayerDeath", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(PilotingChair __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/PilotingChair_ReleaseBy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PilotingChair_ReleaseBy_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class PilotingChair_ReleaseBy_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PilotingChair);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ReleaseBy", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PilotingChair).GetMethod("ReleaseBy", BindingFlags.Public | BindingFlags.Instance);
         
         public static void Postfix(PilotingChair __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/PingManager_NotifyRename_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PingManager_NotifyRename_Patch.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.Helper;
 using NitroxClient.MonoBehaviours;
-using NitroxClient.Unity.Helper;
 using NitroxModel.Core;
-using NitroxModel.DataStructures;
-using NitroxModel.Logger;
 using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
     public class PingManager_NotifyRename_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(PingManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod(nameof(PingManager.NotifyRename), BindingFlags.Public | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(PingManager).GetMethod(nameof(PingManager.NotifyRename), BindingFlags.Public | BindingFlags.Static);
 
         public static void Postfix(PingInstance instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Player_SetCurrentSub_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_SetCurrentSub_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Player_SetCurrentSub_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Player);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SetCurrentSub", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Player).GetMethod("SetCurrentSub", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Prefix(SubRoot sub)
         {

--- a/NitroxPatcher/Patches/Dynamic/Player_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_Update_Patch.cs
@@ -9,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Player_Update_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Player);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Update", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Player).GetMethod("Update", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(Player __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Radio_OnRepair_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Radio_OnRepair_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Radio_OnRepair_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Radio);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Radio).GetMethod("OnRepair", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(Radio __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Radio_PlayRadioMessage_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Radio_PlayRadioMessage_Patch.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Core;
@@ -9,8 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Radio_PlayRadioMessage_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Radio);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("PlayRadioMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Radio).GetMethod("PlayRadioMessage", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Prefix()
         {

--- a/NitroxPatcher/Patches/Dynamic/SeaMoth_OnUpgradeModuleUse_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaMoth_OnUpgradeModuleUse_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication;
 using NitroxClient.Communication.Abstract;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class SeaMoth_OnUpgradeModuleUse_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SeaMoth);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnUpgradeModuleUse", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SeaMoth).GetMethod("OnUpgradeModuleUse", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(SeaMoth __instance, TechType techType, int slotID, PacketSuppressor<ItemContainerRemove> __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/Sealed_Weld_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Sealed_Weld_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,8 +10,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Sealed_Weld_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Sealed);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Weld", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Sealed).GetMethod("Weld", BindingFlags.Public | BindingFlags.Instance);
         
         public static bool Prefix(Sealed __instance, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/Seamoth_SubConstructionComplete_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Seamoth_SubConstructionComplete_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,10 +10,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class Seamoth_SubConstructionComplete_Patch : NitroxPatch, IDynamicPatch
+    public class Seamoth_SubConstructionComplete_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SeaMoth);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SubConstructionComplete", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SeaMoth).GetMethod("SubConstructionComplete", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(SeaMoth __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Stalker_CheckLoseTooth_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Stalker_CheckLoseTooth_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxModel.Helper;
 using UnityEngine;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Stalker_CheckLoseTooth_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Stalker);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("CheckLoseTooth", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Stalker).GetMethod("CheckLoseTooth", BindingFlags.NonPublic | BindingFlags.Instance);
 
         //GetComponent<HardnessMixin> was returning null for everything instead of a HardnessMixin with a hardness value. Since this component 
         //isn't used for anything else than the stalker teeth drop, we hard-code the values and bingo.

--- a/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Core;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class StoryGoal_Execute_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(StoryGoal);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Execute", BindingFlags.Public | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(StoryGoal).GetMethod("Execute", BindingFlags.Public | BindingFlags.Static);
 
         public static void Prefix(string key, Story.GoalType goalType)
         {

--- a/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 
@@ -9,10 +8,9 @@ namespace NitroxPatcher.Patches.Dynamic
     /// Called whenever a Cyclops or Seamoth is spawned. Nitrox already has <see cref="Vehicles.CreateVehicle(NitroxModel.DataStructures.GameLogic.VehicleModel)"/> to
     /// spawn vehicles. This patch is only meant to block the method from executing, causing two vehicles to be spawned instead of one
     /// </summary>
-    class SubConsoleCommand_OnConsoleCommand_sub_Patch : NitroxPatch, IDynamicPatch
+    public class SubConsoleCommand_OnConsoleCommand_sub_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SubConsoleCommand);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnConsoleCommand_sub", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SubConsoleCommand).GetMethod("OnConsoleCommand_sub", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(SubConsoleCommand __instance, NotificationCenter.Notification n)
         {

--- a/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
@@ -15,10 +15,9 @@ namespace NitroxPatcher.Patches.Dynamic
     ///     unlike <see cref="SubRoot.OnTakeDamage(DamageInfo)" />, fires
     ///     can be created outside of <see cref="SubFire.OnTakeDamage(DamageInfo)" />
     /// </summary>
-    internal class SubFire_CreateFire_Patch : NitroxPatch, IDynamicPatch
+    public class SubFire_CreateFire_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SubFire);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("CreateFire", BindingFlags.Instance | BindingFlags.Public);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SubFire).GetMethod("CreateFire", BindingFlags.Instance | BindingFlags.Public);
 
         public static bool Prefix(SubFire __instance, SubFire.RoomFire startInRoom, out bool __state)
         {

--- a/NitroxPatcher/Patches/Dynamic/SubNameInput_OnColorChange_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubNameInput_OnColorChange_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.MonoBehaviours;
@@ -13,8 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class SubNameInput_OnColorChange_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SubNameInput);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnColorChange", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SubNameInput).GetMethod("OnColorChange", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(SubNameInput __instance, ColorChangeEventData eventData)
         {

--- a/NitroxPatcher/Patches/Dynamic/SubNameInput_OnNameChange_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubNameInput_OnNameChange_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.MonoBehaviours;
@@ -13,8 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class SubNameInput_OnNameChange_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SubNameInput);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnNameChange", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SubNameInput).GetMethod("OnNameChange", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(SubNameInput __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/SubRoot_OnPlayerEntered_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubRoot_OnPlayerEntered_Patch.cs
@@ -7,10 +7,11 @@ using Harmony;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class SubRoot_OnPlayerEntered_Patch : NitroxPatch, IDynamicPatch
+    public class SubRoot_OnPlayerEntered_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly Type TARGET_CLASS = typeof(SubRoot);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPlayerEntered", BindingFlags.Public | BindingFlags.Instance);
+        
         public static readonly OpCode START_INJECTION_CODE = OpCodes.Ldarg_0;
         public static readonly OpCode START_INJECTION_CODE_INVINCIBLE = OpCodes.Stfld;
         public static readonly FieldInfo LIVEMIXIN_INVINCIBLE = typeof(LiveMixin).GetField("invincible", BindingFlags.Public | BindingFlags.Instance);

--- a/NitroxPatcher/Patches/Dynamic/SubRoot_OnTakeDamage_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubRoot_OnTakeDamage_Patch.cs
@@ -11,10 +11,9 @@ namespace NitroxPatcher.Patches.Dynamic
     /// Hook onto <see cref="SubRoot.OnTakeDamage(DamageInfo)"/>. It'd be nice if this were the only hook needed, but both damage points and fires are created in a separate
     /// class that doesn't necessarily finish running after OnTakeDamage finishes. Since that's the case, this is used only to stop phantom damage alerts that the owner didn't register
     /// </summary>
-    class SubRoot_OnTakeDamage_Patch : NitroxPatch, IDynamicPatch
+    public class SubRoot_OnTakeDamage_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(SubRoot);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnTakeDamage", BindingFlags.Instance | BindingFlags.Public, null, new Type[] { typeof(DamageInfo) }, null);
+        public static readonly MethodInfo TARGET_METHOD = typeof(SubRoot).GetMethod("OnTakeDamage", BindingFlags.Instance | BindingFlags.Public, null, new Type[] { typeof(DamageInfo) }, null);
 
         public static bool Prefix(SubRoot __instance, DamageInfo damageInfo)
         {

--- a/NitroxPatcher/Patches/Dynamic/ToggleLights_OnPoweredChanged_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ToggleLights_OnPoweredChanged_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,11 +9,9 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class ToggleLights_OnPoweredChanged_Patch : NitroxPatch, IDynamicPatch
+    public class ToggleLights_OnPoweredChanged_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ToggleLights);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPoweredChanged", BindingFlags.NonPublic | BindingFlags.Instance);
-
+        public static readonly MethodInfo TARGET_METHOD = typeof(ToggleLights).GetMethod("OnPoweredChanged", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(ToggleLights __instance, bool powered)
         {

--- a/NitroxPatcher/Patches/Dynamic/ToggleLights_SetLightsActive_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ToggleLights_SetLightsActive_Patch.cs
@@ -15,8 +15,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class ToggleLights_SetLightsActive_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(ToggleLights);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SetLightsActive", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ToggleLights).GetMethod("SetLightsActive", BindingFlags.Public | BindingFlags.Instance);
 
         private static readonly HashSet<Type> syncedParents = new HashSet<Type>()
         {

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_DockVehicle_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_DockVehicle_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class VehicleDockingBay_DockVehicle_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(VehicleDockingBay);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("DockVehicle");
+        public static readonly MethodInfo TARGET_METHOD = typeof(VehicleDockingBay).GetMethod("DockVehicle");
 
         public static bool Prefix(VehicleDockingBay __instance, Vehicle vehicle)
         {

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_OnHandClick_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.HUD;
@@ -12,8 +11,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Vehicle_OnHandClick_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Vehicle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Vehicle).GetMethod("OnHandClick", BindingFlags.Public | BindingFlags.Instance);
 
         private static Vehicle vehicle;
         private static GUIHand guiHand;

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_OnKill_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_OnKill_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Vehicle_OnKill_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Vehicle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnKill", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Vehicle).GetMethod("OnKill", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Prefix(Vehicle __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeBegin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeBegin_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Vehicle_OnPilotModeBegin_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Vehicle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPilotModeBegin", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Vehicle).GetMethod("OnPilotModeBegin", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Prefix(Vehicle __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeEnd_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -10,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Vehicle_OnPilotModeEnd_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(Vehicle);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnPilotModeEnd", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(Vehicle).GetMethod("OnPilotModeEnd", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Prefix(Vehicle __instance)
         {

--- a/NitroxPatcher/Patches/Dynamic/uGUI_OptionsPanel_AddBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_OptionsPanel_AddBindings_Patch.cs
@@ -9,8 +9,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class uGUI_OptionsPanel_AddBindings_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(uGUI_OptionsPanel);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("AddBindings", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(uGUI_OptionsPanel).GetMethod("AddBindings", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void Postfix(uGUI_OptionsPanel __instance, int tabIndex, GameInput.Device device)
         {

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
@@ -8,8 +7,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class uGUI_SignInput_OnDeselect_Patch : NitroxPatch, IDynamicPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(uGUI_SignInput);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("OnDeselect", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(uGUI_SignInput).GetMethod("OnDeselect", BindingFlags.Public | BindingFlags.Instance);
 
         public static void Postfix(uGUI_SignInput __instance)
         {

--- a/NitroxPatcher/Patches/Persistent/CellManager_GetPrefabForSlot_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/CellManager_GetPrefabForSlot_Patch.cs
@@ -5,10 +5,9 @@ using NitroxClient.MonoBehaviours;
 
 namespace NitroxPatcher.Patches.Persistent
 {
-    internal class CellManager_GetPrefabForSlot_Patch : NitroxPatch, IPersistentPatch
+    public class CellManager_GetPrefabForSlot_Patch : NitroxPatch, IPersistentPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CellManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("GetPrefabForSlot", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CellManager).GetMethod("GetPrefabForSlot", BindingFlags.Public | BindingFlags.Instance);
 
         public static bool Prefix(IEntitySlot slot, out EntitySlot.Filler __result)
         {

--- a/NitroxPatcher/Patches/Persistent/CellManager_TryLoadCacheBatchCells_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/CellManager_TryLoadCacheBatchCells_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,10 +6,9 @@ using System.Reflection.Emit;
 
 namespace NitroxPatcher.Patches.Persistent
 {
-    class CellManager_TryLoadCacheBatchCells_Patch : NitroxPatch, IPersistentPatch
+    public class CellManager_TryLoadCacheBatchCells_Patch : NitroxPatch, IPersistentPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(CellManager);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("TryLoadCacheBatchCells", BindingFlags.Public | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(CellManager).GetMethod("TryLoadCacheBatchCells", BindingFlags.Public | BindingFlags.Instance);
         
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {

--- a/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
@@ -5,10 +5,9 @@ using NitroxClient.MonoBehaviours;
 
 namespace NitroxPatcher.Patches.Persistent
 {
-    class EscapePodFirstUseCinematicsController_Initialize_Patch : NitroxPatch, IPersistentPatch
+    public class EscapePodFirstUseCinematicsController_Initialize_Patch : NitroxPatch, IPersistentPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(EscapePodFirstUseCinematicsController);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Instance);
+        public static readonly MethodInfo TARGET_METHOD = typeof(EscapePodFirstUseCinematicsController).GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool Prefix(EscapePodFirstUseCinematicsController __instance)
         {

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Harmony;
 using NitroxClient.MonoBehaviours.Gui.Input;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
@@ -9,8 +8,7 @@ namespace NitroxPatcher.Patches.Persistent
 {
     public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersistentPatch
     {
-        public static readonly Type TARGET_CLASS = typeof(GameInput);
-        public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("SetupDefaultKeyboardBindings", BindingFlags.NonPublic | BindingFlags.Static);
+        public static readonly MethodInfo TARGET_METHOD = typeof(GameInput).GetMethod("SetupDefaultKeyboardBindings", BindingFlags.NonPublic | BindingFlags.Static);
 
         public static void Postfix()
         {

--- a/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Deserialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Deserialize_Patch.cs
@@ -10,8 +10,8 @@ namespace NitroxPatcher.Patches.Persistent
 {
     public class ProtobufSerializer_Deserialize_Patch : NitroxPatch, IPersistentPatch
     {
-        private static readonly Type TARGET_TYPE = typeof(ProtobufSerializer);
-        private static readonly MethodInfo TARGET_METHOD = TARGET_TYPE.GetMethod("Deserialize", BindingFlags.Instance | BindingFlags.NonPublic);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ProtobufSerializer).GetMethod("Deserialize", BindingFlags.Instance | BindingFlags.NonPublic);
+
         private static readonly NitroxProtobufSerializer serializer = NitroxServiceLocator.LocateServicePreLifetime<NitroxProtobufSerializer>();
 
         public static bool Prefix(Stream stream, object target, Type type)

--- a/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Serialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/ProtobufSerializer_Serialize_Patch.cs
@@ -10,8 +10,7 @@ namespace NitroxPatcher.Patches.Persistent
 {
     public class ProtobufSerializer_Serialize_Patch : NitroxPatch, IPersistentPatch
     {
-        private static readonly Type TARGET_TYPE = typeof(ProtobufSerializer);
-        private static readonly MethodInfo TARGET_METHOD = TARGET_TYPE.GetMethod("Serialize", BindingFlags.Instance | BindingFlags.NonPublic);
+        public static readonly MethodInfo TARGET_METHOD = typeof(ProtobufSerializer).GetMethod("Serialize", BindingFlags.Instance | BindingFlags.NonPublic);
 
         /// <summary>
         ///     This patch is in a hot path so it needs this optimization.


### PR DESCRIPTION
Checked three times in a row :
- Make all class public (some were internal, some public, some without any identifier)
- Removed TARGET_CLASS for classthat doesn't need to keep a static variable
- Removed unused imports

Shouldn't we split this folder into several sub-folders (Cyclops, Prawn, Vehicles, BaseBuilding, ..) to improve readability?