### PR TITLE
Added UnityEngine.Object alive check to Optional indirectly

### DIFF
--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -5,6 +5,7 @@ using Harmony;
 using NitroxClient;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.Core;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel.Logger;
 using NitroxPatcher.Modules;
@@ -26,6 +27,7 @@ namespace NitroxPatcher
         public static void Execute()
         {
             Log.EnableInGameMessages();
+            Optional.ApplyHasValueCondition<Object>(o => (bool)o);
 
             if (container != null)
             {

--- a/NitroxTest/Model/OptionalTest.cs
+++ b/NitroxTest/Model/OptionalTest.cs
@@ -109,5 +109,30 @@ namespace NitroxTest.Model
             Optional<int> op = Optional.Empty;
             op.HasValue.Should().BeFalse();
         }
+
+        [TestMethod]
+        public void OptionalHasValueDynamicChecks()
+        {
+            Optional.ApplyHasValueCondition<A>(v => v.Threshold <= 200);
+            
+            Optional<A> a = Optional.Of(new A());
+            a.HasValue.Should().BeTrue();
+            
+            Optional<A> actuallyB = Optional.Of<A>(new B());
+            actuallyB.HasValue.Should().BeFalse();
+            
+            Optional<B> b = Optional.Of(new B());
+            b.HasValue.Should().BeFalse();
+        }
+
+        private class A
+        {
+            public virtual int Threshold => 200;
+        }
+
+        private class B : A
+        {
+            public override int Threshold => 201;
+        }
     }
 }


### PR DESCRIPTION
NitroxPatcher now adds a new HasValue check at runtime for types of UnityEngine.Object to check if the object is alive before returning true.

Every time a new type is given to `Optional<TheType>` then it'll loop through the registered global conditions for HasValue and fetch all conditions that are assignable to the given type. This means that `Optional<GameObject>` will also have (at least) the checks that `Optional<UnityEngine.Object>` has.

Atm it won't refetch and cache the hasvalue conditions for a type if they change due to `Optional.AddHasValueCondition<T>()` calls. These calls should be done before the first Optional<T> is created where T is a type assignable to any condition types. As done here: https://github.com/SubnauticaNitrox/Nitrox/pull/1086/files#diff-4e5e5240065741957a35125a1975652eR30