### PR TITLE
VehicleColor logic update

### DIFF
--- a/NitroxClient/GameLogic/NitroxConsole.cs
+++ b/NitroxClient/GameLogic/NitroxConsole.cs
@@ -6,6 +6,7 @@ using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel.Logger;
 using NitroxModel.Packets;
+using NitroxModel_Subnautica.Helper;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic
@@ -32,7 +33,7 @@ namespace NitroxClient.GameLogic
 
             try
             {
-                if (vehicles.IsVehicle(techType))
+                if (VehicleHelper.IsVehicle(techType))
                 {
                     SpawnVehicle(gameObject);
                 }

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/CyclopsModel.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/CyclopsModel.cs
@@ -38,7 +38,7 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic
 
         }
 
-        public CyclopsModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health) : base(techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, colours, health)
+        public CyclopsModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, float health) : base(techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, health)
         {
             FloodLightsOn = true;
             InternalLightsOn = true;

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/ExosuitModel.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/ExosuitModel.cs
@@ -23,7 +23,7 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic
 
         }
 
-        public ExosuitModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health) : base (techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, colours, health)
+        public ExosuitModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb,  float health) : base (techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, health)
         {
             LeftArmId = new NitroxId();
             RightArmId = new NitroxId();

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/SeamothModel.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/SeamothModel.cs
@@ -20,7 +20,7 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic
 
         }
 
-        public SeamothModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health) : base(techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, colours, health)
+        public SeamothModel(NitroxModel.DataStructures.TechType techType, NitroxId id, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, float health) : base(techType, id, position, rotation, interactiveChildIdentifiers, dockingBayId, name, hsb, health)
         {
             LightOn = true;
         }

--- a/NitroxModel-Subnautica/Helper/VehicleConstructionFactory.cs
+++ b/NitroxModel-Subnautica/Helper/VehicleConstructionFactory.cs
@@ -6,7 +6,7 @@ namespace NitroxModel_Subnautica.Helper
 {
     public static class VehicleConstructionFactory
     {
-        public static ConstructorBeginCrafting BuildFrom(VehicleModel vehicleModel, NitroxId constructorId = null, float duration = 0)
+        public static ConstructorBeginCrafting BuildFrom(VehicleModel vehicleModel, NitroxId constructorId = null, float duration = 3f)
         {
             return new ConstructorBeginCrafting(
                     constructorId ?? new NitroxId(),
@@ -18,7 +18,6 @@ namespace NitroxModel_Subnautica.Helper
                     vehicleModel.Rotation,
                     vehicleModel.Name,
                     vehicleModel.HSB,
-                    vehicleModel.Colours,
                     vehicleModel.Health
                 );
         }

--- a/NitroxModel-Subnautica/Helper/VehicleHelper.cs
+++ b/NitroxModel-Subnautica/Helper/VehicleHelper.cs
@@ -1,0 +1,57 @@
+﻿using UnityEngine;
+
+namespace NitroxModel_Subnautica.Helper
+{
+    public static class VehicleHelper
+    {
+        public static Vector3[] GetDefaultColours(TechType techType)
+        {
+            switch (techType)
+            {
+                case TechType.Seamoth:
+                case TechType.Exosuit:
+                    return new Vector3[] {
+                        new Vector3(0f, 0f, 1f),            //_Color
+                        new Vector3(0f, 0f, 0f),            //_Tint
+                        new Vector3(0f, 0f, 1f),            //_Color
+                        new Vector3(0.577f, 0.447f, 0.604f),//_Color2
+                        new Vector3(0.114f, 0.729f, 0.965f) //_Color3
+                    };
+
+                case TechType.Cyclops:
+                    return new Vector3[]
+                    {
+                        new Vector3(1f, 0f, 1f),
+                        new Vector3(0.6f, 0.4f, 0.4f),
+                        new Vector3(0.1f, 0.8f, 1f),
+                        new Vector3(0f, 0f, 0f)
+                    };
+
+                default:
+                    return GetPrimalDefaultColours();
+            }
+        }
+
+        public static Vector3[] GetPrimalDefaultColours()
+        {
+            return new Vector3[]
+            {
+                new Vector3(0f, 0f, 1f)
+            };
+        }
+
+        public static bool IsVehicle(TechType techtype)
+        {
+            switch (techtype)
+            {
+                case TechType.Seamoth:
+                case TechType.Exosuit:
+                case TechType.Cyclops:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/NitroxModel-Subnautica/Helper/VehicleModelFactory.cs
+++ b/NitroxModel-Subnautica/Helper/VehicleModelFactory.cs
@@ -17,11 +17,11 @@ namespace NitroxModel_Subnautica.Helper
             switch (packet.TechType.Enum())
             {
                 case TechType.Seamoth:
-                    return new SeamothModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Colours, packet.Health);
+                    return new SeamothModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Health);
                 case TechType.Exosuit:
-                    return new ExosuitModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Colours, packet.Health);
+                    return new ExosuitModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Health);
                 case TechType.Cyclops:
-                    return new CyclopsModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Colours, packet.Health);
+                    return new CyclopsModel(packet.TechType, packet.ConstructedItemId, packet.Position, packet.Rotation, packet.InteractiveChildIdentifiers, Optional.Empty, packet.Name, packet.HSB, packet.Health);
                 case TechType.RocketBase:
                     return null;
                 default:
@@ -29,16 +29,16 @@ namespace NitroxModel_Subnautica.Helper
             }
         }
 
-        public static VehicleModel BuildFrom(NitroxTechType techType, NitroxId ConstructedItemId, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, Vector3[] colours, float health)
+        public static VehicleModel BuildFrom(NitroxTechType techType, NitroxId ConstructedItemId, Vector3 position, Quaternion rotation, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, float health)
         {
             switch (techType.Enum())
             {
                 case TechType.Seamoth:
-                    return new SeamothModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, colours, health);
+                    return new SeamothModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, health);
                 case TechType.Exosuit:
-                    return new ExosuitModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, colours, health);
+                    return new ExosuitModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, health);
                 case TechType.Cyclops:
-                    return new CyclopsModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, colours, health);
+                    return new CyclopsModel(techType, ConstructedItemId, position, rotation, interactiveChildIdentifiers, Optional.Empty, name, hsb, health);
                 case TechType.RocketBase:
                     return null;
                 default:

--- a/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
+++ b/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Helper\SubnauticaMap.cs" />
     <Compile Include="Helper\Int3Converter.cs" />
     <Compile Include="Helper\TechTypeConverter.cs" />
+    <Compile Include="Helper\VehicleHelper.cs" />
     <Compile Include="Helper\VehicleModelComparer.cs" />
     <Compile Include="Helper\VehicleModelFactory.cs" />
     <Compile Include="Helper\VehicleMovementFactory.cs" />

--- a/NitroxModel/DataStructures/GameLogic/VehicleModel.cs
+++ b/NitroxModel/DataStructures/GameLogic/VehicleModel.cs
@@ -34,21 +34,18 @@ namespace NitroxModel.DataStructures.GameLogic
         [ProtoMember(8)]
         public Vector3[] HSB { get; set; }
 
-        [ProtoMember(9)]
-        public Vector3[] Colours { get; set; }
 
-        [ProtoMember(10)]
+        [ProtoMember(9)]
         public float Health { get; set; } = 1;
 
         public VehicleModel()
         {
+            // For serialization purposes
             InteractiveChildIdentifiers = new ThreadSafeCollection<InteractiveChildObjectIdentifier>();
             DockingBayId = Optional.Empty;
         }
 
-        public VehicleModel(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb,
-            Vector3[] colours,
-            float health)
+        public VehicleModel(TechType techType, NitroxId id, Vector3 position, Quaternion rotation, IEnumerable<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Optional<NitroxId> dockingBayId, string name, Vector3[] hsb, float health)
         {
             TechType = techType;
             Id = id;
@@ -58,13 +55,12 @@ namespace NitroxModel.DataStructures.GameLogic
             DockingBayId = dockingBayId;
             Name = name;
             HSB = hsb;
-            Colours = colours;
             Health = health;
         }
 
         public override string ToString()
         {
-            return $"{nameof(TechType)}: {TechType}, {nameof(Id)}: {Id}, {nameof(Position)}: {Position}, {nameof(Name)}: {Name}";
+            return $"[TechType: {TechType}, Id: {Id}, Position: {Position}, Rotation: {Rotation}, Name: {Name}, Health: {Health}, DockingBayId: {DockingBayId}";
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/VehicleMovementData.cs
+++ b/NitroxModel/DataStructures/GameLogic/VehicleMovementData.cs
@@ -56,5 +56,10 @@ namespace NitroxModel.DataStructures.GameLogic
             AppliedThrottle = appliedThrottle;
             Health = health;
         }
+
+        public override string ToString()
+        {
+            return $"[TechType: {TechType}, Id: {Id}, Position: {Position}, Rotation: {Rotation}, Velocity: {Velocity}, AngularVelocity: {AngularVelocity}, SteeringWheelYaw: {SteeringWheelYaw}, SteeringWheelPitch: {SteeringWheelPitch}, AppliedThrottle: {AppliedThrottle}, Health: {Health}]";
+        }
     }
 }

--- a/NitroxModel/Packets/ConstructorBeginCrafting.cs
+++ b/NitroxModel/Packets/ConstructorBeginCrafting.cs
@@ -19,11 +19,10 @@ namespace NitroxModel.Packets
         public Quaternion Rotation { get; }
         public string Name { get; }
         public Vector3[] HSB { get; }
-        public Vector3[] Colours { get; }
         public float Health { get; }
 
         public ConstructorBeginCrafting(NitroxId constructorId, NitroxId constructeditemId, TechType techType, float duration, List<InteractiveChildObjectIdentifier> interactiveChildIdentifiers, Vector3 position, Quaternion rotation, 
-            string name, Vector3[] hsb, Vector3[] colours, float health)
+            string name, Vector3[] hsb, float health)
         {
             ConstructorId = constructorId;
             ConstructedItemId = constructeditemId;
@@ -34,7 +33,6 @@ namespace NitroxModel.Packets
             Rotation = rotation;
             Name = name;
             HSB = hsb;
-            Colours = colours;
             Health = health;
         }
 

--- a/NitroxServer/Communication/Packets/Processors/VehicleColorChangeProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/VehicleColorChangeProcessor.cs
@@ -19,7 +19,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(VehicleColorChange packet, Player player)
         {
-            vehicleManager.UpdateVehicleColours(packet.Index, packet.Id, packet.HSB, packet.Color);
+            vehicleManager.UpdateVehicleColours(packet.Index, packet.Id, packet.HSB);
             playerManager.SendPacketToOtherPlayers(packet, player);
 
             Log.Info(packet);

--- a/NitroxServer/ConsoleCommands/BackCommand.cs
+++ b/NitroxServer/ConsoleCommands/BackCommand.cs
@@ -15,11 +15,13 @@ namespace NitroxServer.ConsoleCommands
         {
             Validate.IsTrue(args.Sender.HasValue, "This command can't be used by CONSOLE");
             Player player = args.Sender.Value;
+
             if (player.LastStoredPosition == null)
             {
-                Log.InGame("No previous location...");
+                SendMessage(args.Sender, "No previous location...");
                 return;
             }
+
             player.Teleport(player.LastStoredPosition.Value);
             SendMessage(args.Sender, $"Teleported back {player.LastStoredPosition.Value}");
         }

--- a/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
+++ b/NitroxServer/GameLogic/Vehicles/VehicleManager.cs
@@ -51,12 +51,10 @@ namespace NitroxServer.GameLogic.Vehicles
             }
         }
 
-        public void UpdateVehicleColours(int index, NitroxId id, Vector3 hsb, Color colour)
+        public void UpdateVehicleColours(int index, NitroxId id, Vector3 hsb)
         {
             if (vehiclesById.ContainsKey(id))
             {
-                Vector4 tmpVect = colour;
-                vehiclesById[id].Colours[index] = tmpVect;
                 vehiclesById[id].HSB[index] = hsb;
             }
         }


### PR DESCRIPTION
- Fix a bug where _ExoSuit_ colors where not initialized causing **NRE** at initial syncing and also when trying to change colors inside a moonpool terminal _(Because exosuits SubName colors aren't defined yet for odd reasons)_
- Fix a bug where _Exosuit_ colors wheren't updated in live for players
- Removed Colours field for VehicleModel (Just redundant informations since colors are computed by Subnautica throught HSB field)