### PR TITLE
CyclopsInitialSync fix (again)

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace NitroxClient.GameLogic.InitialSync
 {
-    class CyclopsInitialAsyncProcessor : InitialSyncProcessor
+    public class CyclopsInitialAsyncProcessor : InitialSyncProcessor
     {
         private readonly Vehicles vehicles;
         private WaitScreen.ManualWaitItem waitScreenItem;

--- a/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
@@ -13,9 +13,10 @@ namespace NitroxClient.GameLogic.InitialSync
 {
     public class CyclopsInitialAsyncProcessor : InitialSyncProcessor
     {
+        private int cyclopsLoaded;
+        private int totalCyclopsToLoad;
         private readonly Vehicles vehicles;
         private WaitScreen.ManualWaitItem waitScreenItem;
-        private int cyclopsLoaded = 0, totalCyclopsToLoad = 0;
 
         public CyclopsInitialAsyncProcessor(Vehicles vehicles)
         {
@@ -24,8 +25,8 @@ namespace NitroxClient.GameLogic.InitialSync
 
         public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
         {
-            IEnumerable<VehicleModel> cyclops = packet.Vehicles.Where(v => v.TechType.Enum() == TechType.Cyclops);
-            totalCyclopsToLoad = cyclops.Count();
+            IList<VehicleModel> cyclopses = packet.Vehicles.Where(v => v.TechType.Enum() == TechType.Cyclops).ToList();
+            totalCyclopsToLoad = cyclopses.Count;
 
             this.waitScreenItem = waitScreenItem;
 
@@ -33,7 +34,7 @@ namespace NitroxClient.GameLogic.InitialSync
             {
                 vehicles.VehicleCreated += OnVehicleCreated;
 
-                foreach (VehicleModel vehicle in cyclops)
+                foreach (VehicleModel vehicle in cyclopses)
                 {
                     Log.Debug($"Trying to spawn {vehicle}");
                     vehicles.CreateVehicle(vehicle);

--- a/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/CyclopsInitialAsyncProcessor.cs
@@ -25,16 +25,19 @@ namespace NitroxClient.GameLogic.InitialSync
         public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
         {
             this.waitScreenItem = waitScreenItem;
-            vehicles.VehicleCreated += OnVehicleCreated;
-
             totalCyclopsToLoad = packet.Vehicles.Where(v => v.TechType.Enum() == TechType.Cyclops).Count();
 
-            foreach (VehicleModel vehicle in packet.Vehicles)
+            if (totalCyclopsToLoad > 0)
             {
-                if (vehicle.TechType.Enum() == TechType.Cyclops)
+                vehicles.VehicleCreated += OnVehicleCreated;
+
+                foreach (VehicleModel vehicle in packet.Vehicles)
                 {
-                    Log.Debug($"Trying to spawn {vehicle}");
-                    vehicles.CreateVehicle(vehicle);
+                    if (vehicle.TechType.Enum() == TechType.Cyclops)
+                    {
+                        Log.Debug($"Trying to spawn {vehicle}");
+                        vehicles.CreateVehicle(vehicle);
+                    }
                 }
             }
 
@@ -44,16 +47,17 @@ namespace NitroxClient.GameLogic.InitialSync
         private void OnVehicleCreated(GameObject gameObject)
         {
             cyclopsLoaded++;
+            Log.Debug($"Spawned cyclops {NitroxEntity.GetId(gameObject)}");
             waitScreenItem.SetProgress(cyclopsLoaded, totalCyclopsToLoad);
 
             // After all cyclops are created
             if (cyclopsLoaded == totalCyclopsToLoad)
             {
                 vehicles.VehicleCreated -= OnVehicleCreated;
-                Log.Debug($"Spawned cyclops {NitroxEntity.GetId(gameObject)}");
+            } else
+            {
+                Log.Debug($"We still need to load {totalCyclopsToLoad - cyclopsLoaded} cyclops");
             }
-
-            Log.Debug($"We still need to load {totalCyclopsToLoad - cyclopsLoaded} cyclops");
         }
     }
 }


### PR DESCRIPTION
Fix a bug where we were still listening to OnVehicleCreated event forever if we had 0 cyclops to spawn