### PR TITLE
Fixed multi instance not working

### DIFF
--- a/Nitrox.Bootloader/Main.cs
+++ b/Nitrox.Bootloader/Main.cs
@@ -10,6 +10,17 @@ namespace Nitrox.Bootloader
     {
         private static readonly Lazy<string> nitroxLauncherDir = new Lazy<string>(() =>
         {
+            // Get path from command args.
+            string[] args = Environment.GetCommandLineArgs();
+            for (var i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i].Equals("-nitrox", StringComparison.OrdinalIgnoreCase) && Directory.Exists(args[i + 1]))
+                {
+                    return Path.GetFullPath(args[i + 1]);
+                }
+            }
+
+            // Get path from AppData file.
             string nitroxAppData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
             if (!Directory.Exists(nitroxAppData))
             {
@@ -44,7 +55,7 @@ namespace Nitrox.Bootloader
             }
             return null;
         });
-        
+
         public static void Execute()
         {
             string error = ValidateNitroxSetup();
@@ -61,7 +72,7 @@ namespace Nitrox.Bootloader
 
             BootstrapNitrox();
         }
-        
+
         private static void BootstrapNitrox()
         {
             Assembly core = Assembly.Load(new AssemblyName("NitroxPatcher"));
@@ -69,7 +80,6 @@ namespace Nitrox.Bootloader
             mainType.InvokeMember("Execute", BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod, null, null, null);
         }
 
-        
         private static string ValidateNitroxSetup()
         {
             if (nitroxLauncherDir.Value == null)
@@ -98,7 +108,7 @@ namespace Nitrox.Bootloader
             {
                 dllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), dllFileName);
             }
-            
+
             if (!File.Exists(dllPath))
             {
                 Console.WriteLine($"Nitrox dll missing: {dllPath}");

--- a/NitroxLauncher/LauncherLogic.cs
+++ b/NitroxLauncher/LauncherLogic.cs
@@ -209,7 +209,14 @@ namespace NitroxLauncher
             
             // TODO: The launcher should override FileRead win32 API for the Subnautica process to give it the modified Assembly-CSharp from memory 
             string bootloaderName = "Nitrox.Bootloader.dll";
-            File.Copy(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), bootloaderName), Path.Combine(subnauticaPath, "Subnautica_Data", "Managed", bootloaderName), true);
+            try
+            {
+                File.Copy(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), bootloaderName), Path.Combine(subnauticaPath, "Subnautica_Data", "Managed", bootloaderName), true);
+            }
+            catch (IOException)
+            {
+                // ignored
+            }
             
             nitroxEntryPatch.Remove(); // Remove any previous instances first.
             nitroxEntryPatch.Apply();


### PR DESCRIPTION
 - Added arg option to Subnautica.exe for providing launcher path so multiple instances can be started. (previously impossible due to removing the appdata file that has the launcher path on every start).
![image](https://user-images.githubusercontent.com/1107063/86384266-caadff00-bc8e-11ea-8c85-878f69e62cda.png)

`"F:\Steam Games\steamapps\common\Subnautica\Subnautica.exe" -nitrox "E:\Programming\GitHub\Nitrox\NitroxLauncher\bin\Debug"`