### PR TITLE
Dropping Autofac.Configuration dependency

### DIFF
--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -30,9 +30,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="iTween">
       <HintPath>$(SubnauticaManaged)\iTween.dll</HintPath>
       <Private>false</Private>

--- a/NitroxClient/packages.config
+++ b/NitroxClient/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
 </packages>

--- a/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
+++ b/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
@@ -30,9 +30,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="LitJSON, Version=0.16.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\LitJson.0.16.0\lib\net40\LitJSON.dll</HintPath>
       <Private>True</Private>

--- a/NitroxModel-Subnautica/packages.config
+++ b/NitroxModel-Subnautica/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="LitJson" version="0.16.0" targetFramework="net40" />
 </packages>

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -30,9 +30,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="LZ4">
       <HintPath>..\Nitrox.Subnautica.Assets\LZ4.dll</HintPath>
     </Reference>

--- a/NitroxModel/packages.config
+++ b/NitroxModel/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="NLog" version="4.7.2" targetFramework="net40" />
 </packages>

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -36,9 +36,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/NitroxPatcher/packages.config
+++ b/NitroxPatcher/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net40" />
 </packages>

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -38,9 +38,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/NitroxServer-Subnautica/packages.config
+++ b/NitroxServer-Subnautica/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="AssetsTools.NET" version="2.0.4" targetFramework="net40" />
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="Mono.Cecil" version="0.11.2" targetFramework="net40" />
 </packages>

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -54,9 +54,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="DotNetZip, Version=1.13.8.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.13.8\lib\net40\DotNetZip.dll</HintPath>
     </Reference>

--- a/NitroxServer/packages.config
+++ b/NitroxServer/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="DotNetZip" version="1.13.8" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
 </packages>

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -38,9 +38,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.Configuration.3.3.0\lib\net40\Autofac.Configuration.dll</HintPath>
-    </Reference>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.19.4\lib\net40\FluentAssertions.dll</HintPath>
       <Private>True</Private>

--- a/NitroxTest/packages.config
+++ b/NitroxTest/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Autofac.Configuration" version="3.3.0" targetFramework="net40" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net40" />
   <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net40" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net40" />


### PR DESCRIPTION
Since we're not using xml/json custom config for Autofac, this nugget is not necessary

[Autofac doc](https://autofaccn.readthedocs.io/en/latest/configuration/xml.html#configuring-with-application-configuration-legacy-pre-4-0)