### PR TITLE
Used helper to create vehicleMovementData to remove error message

### DIFF
--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -523,7 +523,18 @@ namespace NitroxClient.GameLogic
         {
             yield return new WaitForSeconds(cooldown);
 
-            VehicleMovementData vehicleMovementData = new VehicleMovementData(vehicleModel.TechType, vehicleModel.Id, gameObject.transform.position.ToDto(), gameObject.transform.rotation.ToDto(), vehicleModel.Health);
+            VehicleMovementData vehicleMovementData = VehicleMovementFactory.GetVehicleMovementData(vehicleModel.TechType.ToUnity(),
+                                                                                                    vehicleModel.Id,
+                                                                                                    gameObject.transform.position,
+                                                                                                    gameObject.transform.rotation,
+                                                                                                    Vector3.zero,
+                                                                                                    Vector3.zero,
+                                                                                                    0f,
+                                                                                                    0f,
+                                                                                                    false,
+                                                                                                    Vector3.zero,
+                                                                                                    Vector3.zero,
+                                                                                                    vehicleModel.Health);
             ushort playerId = ushort.MaxValue;
 
             packetSender.Send(new VehicleMovement(playerId, vehicleMovementData));


### PR DESCRIPTION
Fixes the "Got exosuit vehicle but no ExosuitMovementData" when exosuit is spawned in.

Really not sure if this is something that we want or the right way to approach it. In my mind this is semi not an issue anyway and if we even need to log this as it is an unlikely error and only stops the arm positions from being set.
