### PR TITLE
Added high timeout-threshold for debug purpose.

### DIFF
--- a/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
@@ -41,9 +41,15 @@ namespace NitroxClient.Communication.NetworkingLayer.LiteNetLib
             listener.PeerDisconnectedEvent += Disconnected;
             listener.NetworkReceiveEvent += ReceivedNetworkData;
 
-            client = new NetManager(listener);
-            client.UpdateTime = 15;
-            client.UnsyncedEvents = true; //experimental feature, may need to replace with calls to client.PollEvents();
+            client = new NetManager(listener)
+            {
+                UpdateTime = 15,
+                UnsyncedEvents = true,  //experimental feature, may need to replace with calls to client.PollEvents();
+#if DEBUG
+                DisconnectTimeout = 300000  //Disables Timeout (for 5 min) for debug purpose (like if you jump though the server code)
+#endif
+            };
+
             client.Start();
             client.Connect(ipAddress, serverPort, "nitrox");
 

--- a/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
@@ -32,11 +32,14 @@ namespace NitroxServer.Communication.NetworkingLayer.LiteNetLib
             server.UnconnectedMessagesEnabled = true;
             server.UpdateTime = 15;
             server.UnsyncedEvents = true;
+#if DEBUG
+            server.DisconnectTimeout = 300000;  //Disables Timeout (for 5 min) for debug purpose (like if you jump though the server code)
+#endif
             if (!server.Start(portNumber))
             {
                 return false;
             }
-            
+
             isStopped = false;
             return true;
         }


### PR DESCRIPTION
Elevated timeout-threshold to 5 min (in `DEBUG` build) to debug server code "live" without disconnecting.