### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/buildingPullRequest.yml
+++ b/.github/workflows/buildingPullRequest.yml
@@ -1,12 +1,8 @@
 name: Building Nitrox Pull Request
-
 on: pull_request
-
 jobs:
   build:
     runs-on: windows-latest
-    if: github.event.pull_request.draft == false
-    
     steps:
     - name: Checking out repository
       uses: actions/checkout@v2
@@ -15,15 +11,15 @@ jobs:
     - name: Download Subnautica files
       run: ./.github/depotDownloader/QXCTF.exe
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
     - name: Restore packages
       run: nuget restore Nitrox.sln
     - name: Setup MSBuild
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Build with MSBuild
       run: msbuild Nitrox.sln -p:Configuration=Release
     - name: Uploading zipped launcher
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: release
         path: ./NitroxLauncher/bin/Release/

--- a/.github/workflows/buildingRelease.yml
+++ b/.github/workflows/buildingRelease.yml
@@ -1,11 +1,8 @@
 name: Building Nitrox Release
-
 on: push
-
 jobs:
   build:
     runs-on: windows-latest
-    
     steps:
     - name: Checking out repository
       uses: actions/checkout@v2
@@ -15,10 +12,10 @@ jobs:
       run: |
           ./.github/depotDownloader/QXCTF.exe
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
     - name: Restore packages
       run: nuget restore Nitrox.sln
     - name: Setup MSBuild
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Build with MSBuild
       run: msbuild Nitrox.sln -p:Configuration=Release

--- a/.github/workflows/buildingRelease.yml
+++ b/.github/workflows/buildingRelease.yml
@@ -9,8 +9,7 @@ jobs:
       with:
         submodules: 'true'
     - name: Download Subnautica files
-      run: |
-          ./.github/depotDownloader/QXCTF.exe
+      run: ./.github/depotDownloader/QXCTF.exe
     - name: Setup Nuget.exe
       uses: nuget/setup-nuget@v1
     - name: Restore packages


### PR DESCRIPTION
Warrenbuckley's action aren't supported no more, since he contributed to create official actions with Microsoft.

* [warrenbuckley/Setup-MSBuild](https://github.com/warrenbuckley/Setup-MSBuild)-> [Nuget/Setup-nuget](https://github.com/NuGet/setup-nuget)
* [ warrenbuckley/Setup-MSBuild](https://github.com/warrenbuckley/Setup-MSBuild)-> [Microsoft/Setup-msbuild](https://github.com/microsoft/setup-msbuild)

* actions/upload-artifact@v1 -> [actions/upload-artifact@v2](https://github.com/actions/upload-artifact)