### PR TITLE
Initial Infection not set to Cured by default.

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
@@ -66,17 +66,14 @@ namespace NitroxClient.GameLogic.InitialSync
         {
             if (statsData != null)
             {
-                using (packetSender.Suppress<PlayerStats>())
+                Player.main.oxygenMgr.AddOxygen(statsData.Oxygen);
+                Player.main.liveMixin.health = statsData.Health;
+                Player.main.GetComponent<Survival>().food = statsData.Food;
+                Player.main.GetComponent<Survival>().water = statsData.Water;
+                Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
+                if (statsData.InfectionAmount > 0f)
                 {
-                    Player.main.oxygenMgr.AddOxygen(statsData.Oxygen);
-                    Player.main.liveMixin.health = statsData.Health;
-                    Player.main.GetComponent<Survival>().food = statsData.Food;
-                    Player.main.GetComponent<Survival>().water = statsData.Water;
-                    Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
-                    if (statsData.InfectionAmount > 0f)
-                    {
-                        Player.main.infectionRevealed = true;
-                    }
+                    Player.main.infectionRevealed = true;
                 }
             }
         }

--- a/NitroxModel/Server/ServerConfig.cs
+++ b/NitroxModel/Server/ServerConfig.cs
@@ -47,6 +47,7 @@ namespace NitroxModel.Server
             healthSetting = new ServerConfigItem<float>("StartHealth", 80);
             foodSetting = new ServerConfigItem<float>("StartFood", 50.5f);
             waterSetting = new ServerConfigItem<float>("StartWater", 90.5f);
+            //Infection level of 0f will make it so everyone starts the game cured. 0.1f is the default starting value. Also set in NitroxServer-Subnautica App.config
             infectionSetting = new ServerConfigItem<float>("StartInfection", 0.1f);
         }
 

--- a/NitroxModel/Server/ServerConfig.cs
+++ b/NitroxModel/Server/ServerConfig.cs
@@ -47,7 +47,7 @@ namespace NitroxModel.Server
             healthSetting = new ServerConfigItem<float>("StartHealth", 80);
             foodSetting = new ServerConfigItem<float>("StartFood", 50.5f);
             waterSetting = new ServerConfigItem<float>("StartWater", 90.5f);
-            infectionSetting = new ServerConfigItem<float>("StartInfection", 0);
+            infectionSetting = new ServerConfigItem<float>("StartInfection", 0.1f);
         }
 
         #region Properties

--- a/NitroxServer-Subnautica/App.config
+++ b/NitroxServer-Subnautica/App.config
@@ -16,7 +16,7 @@
         <add key="StartHealth" value="80" />
         <add key="StartFood" value="50.5" />
         <add key="StartWater" value="90.5" />
-        <add key="StartInfection" value="0" />
+        <add key="StartInfection" value="0.1" />
     </appSettings>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />


### PR DESCRIPTION
Set the default infection level to 0.1f to match the value set by vanilla game on first launch.

End result:

New players now start the game as NOT Infected but also Not Cured as in the vanilla game.