### PR TITLE
Added server restart command and port binding checks

### DIFF
--- a/NitroxServer-Subnautica/AppMutex.cs
+++ b/NitroxServer-Subnautica/AppMutex.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Threading;
+using NitroxModel.Helper;
+
+namespace NitroxServer_Subnautica
+{
+    public static class AppMutex
+    {
+        private static readonly SemaphoreSlim mutexReleaseGate = new SemaphoreSlim(1);
+        private static readonly SemaphoreSlim callerGate = new SemaphoreSlim(1);
+
+        public static void Hold(Action onWaitingForMutex = null, int timeoutInMs = 5000)
+        {
+            Validate.IsTrue(timeoutInMs >= 5000, "Timeout must be at least 5 seconds.");
+
+            using CancellationTokenSource acquireSource = new CancellationTokenSource(timeoutInMs);
+            CancellationToken token = acquireSource.Token;
+            Thread thread = new Thread(o =>
+            {
+                bool first = true;
+                string appGuid = ((GuidAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(GuidAttribute), false).GetValue(0)).Value;
+                string mutexId = $@"Global\{{{appGuid}}}";
+                MutexAccessRule allowEveryoneRule = new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                                                                        MutexRights.FullControl,
+                                                                        AccessControlType.Allow
+                );
+                MutexSecurity securitySettings = new MutexSecurity();
+                securitySettings.AddAccessRule(allowEveryoneRule);
+
+                Mutex mutex = new Mutex(false, mutexId, out bool _, securitySettings);
+                try
+                {
+                    try
+                    {
+                        while (!mutex.WaitOne(100, false))
+                        {
+                            token.ThrowIfCancellationRequested();
+                            if (first)
+                            {
+                                first = false;
+                                onWaitingForMutex?.Invoke();
+                            }
+                        }
+                    }
+                    catch (AbandonedMutexException)
+                    {
+                        // Mutex was abandoned in another process, it will still get acquired
+                    }
+                }
+                finally
+                {
+                    callerGate.Release();
+                    mutexReleaseGate.Wait(-1);
+                    mutex.ReleaseMutex();
+                }
+            });
+            mutexReleaseGate.Wait(-1, token);
+            callerGate.Wait(0, token);
+            thread.Start();
+
+            while (!callerGate.Wait(100, token))
+            {
+            }
+        }
+
+        public static void Release()
+        {
+            mutexReleaseGate.Release();
+        }
+    }
+}

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Serialization\Resources\ResourceAssetsParser.cs" />
     <Compile Include="Serialization\SubnauticaServerJsonSerializer.cs" />
     <Compile Include="Serialization\SubnauticaServerProtoBufSerializer.cs" />
+    <Compile Include="AppMutex.cs" />
     <Compile Include="SubnauticaServerAutoFacRegistrar.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
+++ b/NitroxServer/ConsoleCommands/Processor/ConsoleCommandProcessor.cs
@@ -45,10 +45,7 @@ namespace NitroxServer.ConsoleCommands.Processor
             }
 
             string[] parts = msg.Split(splitChar, StringSplitOptions.RemoveEmptyEntries);
-
-            Command cmd;
-
-            if (!commands.TryGetValue(parts[0], out cmd))
+            if (!commands.TryGetValue(parts[0], out Command cmd))
             {
                 string errorMessage = "Command Not Found: " + parts[0];
                 Log.Info(errorMessage);

--- a/NitroxServer/ConsoleCommands/RestartCommand.cs
+++ b/NitroxServer/ConsoleCommands/RestartCommand.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.Logger;
+using NitroxServer.ConsoleCommands.Abstract;
+
+namespace NitroxServer.ConsoleCommands
+{
+    internal sealed class RestartCommand : Command
+    {
+        private readonly Server server;
+
+        public RestartCommand(Server server) : base("restart", Perms.CONSOLE, "Restarts the server")
+        {
+            this.server = server;
+        }
+
+        protected override void Execute(CallArgs args)
+        {
+            if (Debugger.IsAttached)
+            {
+                Log.Error("Cannot restart server while debugger is attached.");
+                return;
+            }
+            string program = Process.GetCurrentProcess().MainModule?.FileName;
+            if (program == null)
+            {
+                Log.Error("Failed to get location of server.");
+                return;
+            }
+
+            using Process proc = Process.Start(program);
+            server.Stop();
+        }
+    }
+}

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -151,6 +151,7 @@
     <Compile Include="ConsoleCommands\ChangeAdminPasswordCommand.cs" />
     <Compile Include="ConsoleCommands\DirectoryCommand.cs" />
     <Compile Include="ConsoleCommands\HelpCommand.cs" />
+    <Compile Include="ConsoleCommands\RestartCommand.cs" />
     <Compile Include="ConsoleCommands\TeleportCommand.cs" />
     <Compile Include="ConsoleCommands\WarpCommand.cs" />
     <Compile Include="ConsoleCommands\WhoisCommand.cs" />

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -83,7 +83,7 @@ namespace NitroxServer
                 return false;
             }
 
-            Log.Info($"Server is using port {Port} UDP");
+            Log.Info($"Server is listening on port {Port} UDP");
             Log.Info($"Using {serverConfig.SerializerMode} as save file serializer");
             Log.InfoSensitive("Server Password: {password}", string.IsNullOrEmpty(serverConfig.ServerPassword) ? "None. Public Server." : serverConfig.ServerPassword);
             Log.InfoSensitive("Admin Password: {password}", serverConfig.AdminPassword);

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -1,8 +1,6 @@
 ﻿using System.Timers;
 using NitroxModel.Logger;
-using NitroxModel.Server;
 using NitroxServer.Serialization.World;
-using System.Configuration;
 using System.IO;
 using System.Text;
 using System.Linq;
@@ -66,7 +64,11 @@ namespace NitroxServer
                 return;
             }
 
-            PropertiesWriter.Serialize(serverConfig);
+            // Don't overwrite config changes that users made to file
+            if (!File.Exists(serverConfig.FileName))
+            {
+                PropertiesWriter.Serialize(serverConfig);
+            }
             IsSaving = true;
             worldPersistence.Save(world, serverConfig.SaveName);
             IsSaving = false;

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -22,6 +22,8 @@ namespace NitroxServer
         public bool IsRunning { get; private set; }
         public bool IsSaving { get; private set; }
 
+        public int Port => serverConfig?.ServerPort ?? -1;
+
         public Server(WorldPersistence worldPersistence, World world, ServerConfig serverConfig, Communication.NetworkingLayer.NitroxServer server)
         {
             this.worldPersistence = worldPersistence;
@@ -81,16 +83,13 @@ namespace NitroxServer
                 return false;
             }
 
+            Log.Info($"Server is using port {Port} UDP");
             Log.Info($"Using {serverConfig.SerializerMode} as save file serializer");
             Log.InfoSensitive("Server Password: {password}", string.IsNullOrEmpty(serverConfig.ServerPassword) ? "None. Public Server." : serverConfig.ServerPassword);
             Log.InfoSensitive("Admin Password: {password}", serverConfig.AdminPassword);
             Log.Info($"Autosave: {(serverConfig.DisableAutoSave ? "DISABLED" : $"ENABLED ({serverConfig.SaveInterval / 60000} min)")}");
             Log.Info($"World GameMode: {serverConfig.GameMode}");
-
             Log.Info($"Loaded save\n{SaveSummary}");
-
-            Log.Info("Nitrox Server Started");
-            Log.Info("To get help for commands, run help in console or /help in chatbox\n");
 
             PauseServer();
 


### PR DESCRIPTION
 - Fixed issue where server config changes made in the properties file were overwritten on server exit.
 - Added port already in use checks that waits 30 seconds for the port to be available in case users have multiple servers running that try to run on the same port.

Due to the port check I needed to add a mutex so that multiple servers won't race the port and throw exceptions in LiteNetLib.

The mutex needs to run on the same thread so I started a new thread that is purely for that to avoid issues with `async` & `await` throwing exceptions to due context switching when accessing the mutex.