### PR TITLE
Moved from NLog to Serilog

### DIFF
--- a/NitroxModel/Logger/ColoredConsoleSink.cs
+++ b/NitroxModel/Logger/ColoredConsoleSink.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+
+namespace NitroxModel.Logger
+{
+    public class ColoredConsoleSink : ILogEventSink
+    {
+        private readonly ConsoleColor defaultBackground = Console.BackgroundColor;
+        private readonly ConsoleColor defaultForeground = Console.ForegroundColor;
+
+        private readonly ITextFormatter formatter;
+
+        public ColoredConsoleSink(ITextFormatter formatter)
+        {
+            this.formatter = formatter;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            (Console.ForegroundColor, Console.BackgroundColor) = logEvent.Level switch
+            {
+                LogEventLevel.Verbose => (ConsoleColor.DarkGray, defaultBackground),
+                LogEventLevel.Debug => (ConsoleColor.DarkGray, defaultBackground),
+                LogEventLevel.Information => (ConsoleColor.Gray, defaultBackground),
+                LogEventLevel.Warning => (ConsoleColor.Yellow, defaultBackground),
+                LogEventLevel.Error => (ConsoleColor.Red, defaultBackground),
+                LogEventLevel.Fatal => (ConsoleColor.Red, ConsoleColor.Yellow),
+                _ => (defaultForeground, defaultBackground)
+            };
+
+            formatter.Format(logEvent, Console.Out);
+            Console.Out.Flush();
+
+            Console.ForegroundColor = defaultForeground;
+            Console.BackgroundColor = defaultBackground;
+        }
+    }
+
+    public static class ColoredConsoleSinkExtensions
+    {
+        public static LoggerConfiguration ColoredConsole(
+            this LoggerSinkConfiguration loggerConfiguration,
+            LogEventLevel minimumLevel = LogEventLevel.Verbose,
+            string outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+            IFormatProvider formatProvider = null)
+        {
+            return loggerConfiguration.Sink(new ColoredConsoleSink(new MessageTemplateTextFormatter(outputTemplate, formatProvider)), minimumLevel);
+        }
+    }
+}

--- a/NitroxModel/Logger/MessageSink.cs
+++ b/NitroxModel/Logger/MessageSink.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+
+namespace NitroxModel.Logger
+{
+    public class MessageSink : ILogEventSink
+    {
+        private readonly ITextFormatter formatter;
+        private readonly Action<string> writer;
+
+        public MessageSink(ITextFormatter formatter, Action<string> writer)
+        {
+            this.formatter = formatter;
+            this.writer = writer;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            using StringWriter stringWriter = new StringWriter();
+            formatter.Format(logEvent, stringWriter);
+            stringWriter.Flush();
+            writer(stringWriter.GetStringBuilder().ToString());
+        }
+    }
+
+    public static class MessageSinkExtensions
+    {
+        public static LoggerConfiguration Message(
+            this LoggerSinkConfiguration loggerConfiguration,
+            Action<string> writer,
+            LogEventLevel minimumLevel = LogEventLevel.Verbose,
+            string outputTemplate = "{Message}",
+            IFormatProvider formatProvider = null)
+        {
+            return loggerConfiguration.Sink(new MessageSink(new MessageTemplateTextFormatter(outputTemplate, formatProvider), writer), minimumLevel);
+        }
+    }
+}

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -33,11 +33,68 @@
       <HintPath>..\Nitrox.Subnautica.Assets\LZ4.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.7.5\lib\net45\NLog.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Options.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\Nitrox.Subnautica.Assets\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Settings.Configuration, Version=3.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.Settings.Configuration.3.1.0\lib\net461\Serilog.Settings.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.4.0\lib\net461\Serilog.Sinks.Async.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.Sinks.File.4.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -45,6 +102,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.4.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
@@ -109,7 +170,9 @@
     <Compile Include="Helper\PirateDetection.cs" />
     <Compile Include="Helper\StringHelper.cs" />
     <Compile Include="Helper\WebHelper.cs" />
+    <Compile Include="Logger\ColoredConsoleSink.cs" />
     <Compile Include="Logger\InGameLogger.cs" />
+    <Compile Include="Logger\MessageSink.cs" />
     <Compile Include="Logger\Log.cs" />
     <Compile Include="Networking\NitroxDeliveryMethod.cs" />
     <Compile Include="OS\Windows\Native.cs" />

--- a/NitroxModel/packages.config
+++ b/NitroxModel/packages.config
@@ -1,5 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.9.4" targetFramework="net472" />
-  <package id="NLog" version="4.7.5" targetFramework="net472" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.0.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
+  <package id="Serilog" version="2.10.0" targetFramework="net472" />
+  <package id="Serilog.Settings.Configuration" version="3.1.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.4.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net472" />
+  <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.4.0" targetFramework="net472" />
 </packages>

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -30,8 +30,7 @@ namespace NitroxPatcher
 
         public static void Execute()
         {
-            Log.Setup(true);
-            Log.InGameLogger = new SubnauticaInGameLogger();
+            Log.Setup(inGameLogger: new SubnauticaInGameLogger());
             Log.Info($"Using Nitrox version {Assembly.GetExecutingAssembly().GetName().Version} built on {File.GetCreationTimeUtc(Assembly.GetExecutingAssembly().Location)}");
             try
             {

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -183,8 +183,9 @@ namespace NitroxServer_Subnautica
             }
 
             // Load DLLs where this program (exe) is located
-            string dllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "lib", dllFileName);
-            if (!File.Exists(dllPath))
+            string dllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? "", "lib", dllFileName);
+            // Prefer to use Newtonsoft dll from game instead of our own due to protobuf issues. TODO: Remove when we do our own deserialization of game data instead of using the game's protobuf.
+            if (dllPath.IndexOf("Newtonsoft.Json.dll", StringComparison.OrdinalIgnoreCase) >= 0 || !File.Exists(dllPath))
             {
                 // Try find game managed libraries
                 dllPath = Path.Combine(gameInstallDir.Value, "Subnautica_Data", "Managed", dllFileName);

--- a/NitroxServer/Serialization/ServerProtoBufSerializer.cs
+++ b/NitroxServer/Serialization/ServerProtoBufSerializer.cs
@@ -78,7 +78,7 @@ namespace NitroxServer.Serialization
                 }
                 catch (Exception ex)
                 {
-                    if (type.FullName.Contains("Oculus.Platform.Models"))
+                    if (type.FullName?.Contains("Oculus.Platform.Models") ?? false)
                     {
                         ignoredTypeErrors.Add(type.ToString());
                     }


### PR DESCRIPTION
NLog rules and filters were too confusing to use practically for sensitive information logging.

TODO:
 - [x] Use same format and console coloring as before.

Fixes #1313