### PR TITLE
Moved screenshots to launcher directory

### DIFF
--- a/NitroxPatcher/Patches/Persistent/ScreenshotManager_Initialise.Path.cs
+++ b/NitroxPatcher/Patches/Persistent/ScreenshotManager_Initialise.Path.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 using Harmony;
 
@@ -11,7 +12,7 @@ namespace NitroxPatcher.Patches.Persistent
 
         public static void Prefix(ScreenshotManager __instance, ref string _savePath)
         {
-            _savePath = "Nitrox Screenshots/";
+            _savePath = Path.GetFullPath(Environment.GetEnvironmentVariable("NITROX_LAUNCHER_PATH") ?? ".");
         }
 
         public override void Patch(HarmonyInstance harmony)


### PR DESCRIPTION
Game saves screenshots to "screenshots" subdir. Can't easily fix to use uppercase S without using transpilers on all places that it is used.