### PR TITLE
Fixed serialization error with BasePiece and JSON

### DIFF
--- a/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/AnchoredFaceRotationMetadata.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/AnchoredFaceRotationMetadata.cs
@@ -17,17 +17,17 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation.Met
 
         [ProtoMember(3)]
         public int FaceType { get; set; }
-        
+
         protected AnchoredFaceRotationMetadata() : base(typeof(BaseAddFaceGhost))
         {
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
 
-        public AnchoredFaceRotationMetadata(Int3 cell, int facedirection, int facetype) : base(typeof(BaseAddFaceGhost))
+        public AnchoredFaceRotationMetadata(NitroxInt3 cell, int faceDirection, int faceType) : base(typeof(BaseAddFaceGhost))
         {
-            Cell = cell.ToDto();
-            Direction = facedirection;
-            FaceType = facetype;
+            Cell = cell;
+            Direction = faceDirection;
+            FaceType = faceType;
         }
 
         public override string ToString()

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/BaseModuleRotationMetadata.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/BaseModuleRotationMetadata.cs
@@ -21,9 +21,9 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
 
-        public BaseModuleRotationMetadata(Int3 cell, int direction) : base(typeof(BaseAddModuleGhost))
+        public BaseModuleRotationMetadata(NitroxInt3 cell, int direction) : base(typeof(BaseAddModuleGhost))
         {
-            Cell = cell.ToDto();
+            Cell = cell;
             Direction = direction;
         }
 

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/SubnauticaRotationMetadataFactory.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/SubnauticaRotationMetadataFactory.cs
@@ -31,17 +31,17 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation
                 Int3 cell = module.anchoredFace.Value.cell;
                 int direction = (int)module.anchoredFace.Value.direction;
 
-                rotationMetadata = new BaseModuleRotationMetadata(cell, direction);
+                rotationMetadata = new BaseModuleRotationMetadata(cell.ToDto(), direction);
             }
             else if (baseGhost is BaseAddFaceGhost)
             {
                 BaseAddFaceGhost faceGhost = baseGhost as BaseAddFaceGhost;
 
-                if(faceGhost.anchoredFace.HasValue)
+                if (faceGhost.anchoredFace.HasValue)
                 {
                     Base.Face anchoredFace = faceGhost.anchoredFace.Value;
-                    
-                    rotationMetadata = new AnchoredFaceRotationMetadata(anchoredFace.cell, (int)anchoredFace.direction, (int)faceGhost.faceType);
+
+                    rotationMetadata = new AnchoredFaceRotationMetadata(anchoredFace.cell.ToDto(), (int)anchoredFace.direction, (int)faceGhost.faceType);
                 }
 
             }

--- a/NitroxModel/DataStructures/GameLogic/BasePiece.cs
+++ b/NitroxModel/DataStructures/GameLogic/BasePiece.cs
@@ -77,7 +77,7 @@ namespace NitroxModel.DataStructures.GameLogic
 
         public override string ToString()
         {
-            return "[BasePiece - ItemPosition: " + ItemPosition + " Id: " + Id + " Rotation: " + Rotation + " CameraPosition: " + CameraPosition + "CameraRotation: " + CameraRotation + " TechType: " + TechType + " ParentId: " + ParentId + " ConstructionAmount: " + ConstructionAmount + " IsFurniture: " + IsFurniture + " BaseId: " + BaseId + " RotationMetadata: " + RotationMetadata + " BuildIndex: " + BuildIndex + "]";
+            return $"[BasePiece - ItemPosition: {ItemPosition}, Id: {Id}, Rotation: {Rotation}, CameraPosition: {CameraPosition}, CameraRotation: {CameraRotation}, TechType: {TechType}, ParentId: {ParentId}, ConstructionAmount: {ConstructionAmount}, IsFurniture: {IsFurniture}, BaseId: {BaseId}, RotationMetadata: {RotationMetadata}, BuildIndex: {BuildIndex}]";
         }
     }
 }

--- a/NitroxTest/Serialization/WorldPersistenceTest.cs
+++ b/NitroxTest/Serialization/WorldPersistenceTest.cs
@@ -6,7 +6,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.DataStructures.GameLogic.Buildings.Rotation;
 using NitroxModel.DataStructures.Util;
+using NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation;
+using NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation.Metadata;
 using NitroxServer.GameLogic;
 using NitroxServer.GameLogic.Bases;
 using NitroxServer.GameLogic.Entities;
@@ -211,9 +215,48 @@ namespace NitroxTest.Serialization
                     Assert.AreEqual(basePiece.ConstructionCompleted, basePieceAfter.ConstructionCompleted, "BaseData.CompletedBasePieceHistory.ConstructionCompleted is not equal");
                     Assert.AreEqual(basePiece.IsFurniture, basePieceAfter.IsFurniture, "BaseData.CompletedBasePieceHistory.IsFurniture is not equal");
                     Assert.AreEqual(basePiece.BaseId, basePieceAfter.BaseId, "BaseData.CompletedBasePieceHistory.BaseId is not equal");
-                    Assert.AreEqual(basePiece.RotationMetadata, basePieceAfter.RotationMetadata, "BaseData.CompletedBasePieceHistory.RotationMetadata is not equal");
-                    Assert.AreEqual(basePiece.Metadata, basePieceAfter.Metadata, "BaseData.CompletedBasePieceHistory.Metadata is not equal");
                     Assert.AreEqual(basePiece.BuildIndex, basePieceAfter.BuildIndex, "BaseData.CompletedBasePieceHistory.BuildIndex is not equal");
+
+                    switch (basePiece.RotationMetadata.Value)
+                    {
+                        case AnchoredFaceRotationMetadata anchoredMetadata when basePieceAfter.RotationMetadata.Value is AnchoredFaceRotationMetadata anchoredMetadataAfter:
+                            Assert.AreEqual(anchoredMetadata.Cell, anchoredMetadataAfter.Cell, "BaseData.RotationMetadata.Cell (AnchoredFaceRotationMetadata) is not equal");
+                            Assert.AreEqual(anchoredMetadata.Direction, anchoredMetadataAfter.Direction, "BaseData.RotationMetadata.Direction (AnchoredFaceRotationMetadata) is not equal");
+                            Assert.AreEqual(anchoredMetadata.FaceType, anchoredMetadataAfter.FaceType, "BaseData.RotationMetadata.FaceType (AnchoredFaceRotationMetadata) is not equal");
+                            break;
+                        case BaseModuleRotationMetadata baseModuleMetadata when basePieceAfter.RotationMetadata.Value is BaseModuleRotationMetadata baseModuleMetadataAfter:
+                            Assert.AreEqual(baseModuleMetadata.Cell, baseModuleMetadataAfter.Cell, "BaseData.RotationMetadata.Cell (BaseModuleRotationMetadata) is not equal");
+                            Assert.AreEqual(baseModuleMetadata.Direction, baseModuleMetadataAfter.Direction, "BaseData.RotationMetadata.Direction (BaseModuleRotationMetadata) is not equal");
+                            break;
+                        case CorridorRotationMetadata corridorMetadata when basePieceAfter.RotationMetadata.Value is CorridorRotationMetadata corridorMetadataAfter:
+                            Assert.AreEqual(corridorMetadata.Rotation, corridorMetadataAfter.Rotation, "BaseData.RotationMetadata.Rotation (CorridorRotationMetadata) is not equal");
+                            break;
+                        case MapRoomRotationMetadata mapRoomMetadata when basePieceAfter.RotationMetadata.Value is MapRoomRotationMetadata mapRoomMetadataAfter:
+                            Assert.AreEqual(mapRoomMetadata.CellType, mapRoomMetadataAfter.CellType, "BaseData.RotationMetadata.CellType (MapRoomRotationMetadata) is not equal");
+                            Assert.AreEqual(mapRoomMetadata.ConnectionMask, mapRoomMetadataAfter.ConnectionMask, "BaseData.RotationMetadata.ConnectionMask (MapRoomRotationMetadata) is not equal");
+                            break;
+                        case null when basePieceAfter.RotationMetadata.Value is null:
+                            break;
+                        default:
+                            Assert.Fail("BaseData.RotationMetadata is not equal");
+                            break;
+                    }
+
+                    switch (basePiece.Metadata.Value)
+                    {
+                        case SignMetadata signMetadata when basePieceAfter.Metadata.Value is SignMetadata signMetadataAfter:
+                            Assert.AreEqual(signMetadata.Text, signMetadataAfter.Text, "BaseData.Metadata.Text (SignMetadata) is not equal");
+                            Assert.AreEqual(signMetadata.ColorIndex, signMetadataAfter.ColorIndex, "BaseData.Metadata.ColorIndex (SignMetadata) is not equal");
+                            Assert.AreEqual(signMetadata.ScaleIndex, signMetadataAfter.ScaleIndex, "BaseData.Metadata.ScaleIndex (SignMetadata) is not equal");
+                            Assert.IsTrue(signMetadata.Elements.SequenceEqual(signMetadataAfter.Elements), "BaseData.Metadata.Elements (SignMetadata) is not equal");
+                            Assert.AreEqual(signMetadata.Background, signMetadataAfter.Background, "BaseData.Metadata.Background (SignMetadata) is not equal");
+                            break;
+                        case null when basePieceAfter.Metadata.Value is null:
+                            break;
+                        default:
+                            Assert.Fail("BaseData.Metadata is not equal");
+                            break;
+                    }
                 }
             }
         }
@@ -309,11 +352,14 @@ namespace NitroxTest.Serialization
                 {
                     CompletedBasePieceHistory = new List<BasePiece>()
                     {
-                        new BasePiece(new NitroxId(), NitroxVector3.Zero, NitroxQuaternion.Identity, NitroxVector3.Zero, NitroxQuaternion.Identity, new NitroxTechType("BasePiece1"), Optional.Empty, false, Optional.Empty)
+                        new BasePiece(new NitroxId(), NitroxVector3.Zero, NitroxQuaternion.Identity, NitroxVector3.Zero, NitroxQuaternion.Identity, new NitroxTechType("BasePiece1"), Optional<NitroxId>.Of(new NitroxId()), false, Optional.Empty)
                     },
                     PartiallyConstructedPieces = new List<BasePiece>()
                     {
-                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional.Empty)
+                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<RotationMetadata>.Of(new AnchoredFaceRotationMetadata(new NitroxInt3(1,2,3), 1, 2))),
+                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<RotationMetadata>.Of(new BaseModuleRotationMetadata(new NitroxInt3(1,2,3), 1))),
+                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<RotationMetadata>.Of(new CorridorRotationMetadata(2))),
+                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<RotationMetadata>.Of(new MapRoomRotationMetadata(0x20, 2)))
                     }
                 },
                 EntityData = new EntityData()
@@ -429,7 +475,7 @@ namespace NitroxTest.Serialization
                     {
                         Vehicles = new List<VehicleModel>()
                         {
-                            new VehicleModel(new NitroxTechType("Cyclops"), new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, new InteractiveChildObjectIdentifier[0], Optional.Empty, "Super Duper Cyclops", new []{NitroxVector3.Zero, NitroxVector3.One, NitroxVector3.One}, 100)
+                            new VehicleModel(new NitroxTechType("Cyclops"), new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, new InteractiveChildObjectIdentifier[0], Optional<NitroxId>.Of(new NitroxId()), "Super Duper Cyclops", new []{NitroxVector3.Zero, NitroxVector3.One, NitroxVector3.One}, 100)
                         }
                     }
                 }


### PR DESCRIPTION
The reason behind this error:
Json needs (in our setup with protobuf and old json version from Oculus) a constructor with all fields/properties as parameters. Every parameter has to be the same type as the field/property. Any other constructor (like the parameter-less for protobuf) has to be `protected` or `private`. The Server can reference the new json version and is free from those restrictions because the fields/properties can be flagged with the json attribute (like protobuf with `ProtoMember`).