### PR TITLE
Fixed loading of missing translation

### DIFF
--- a/NitroxPatcher/Patches/Persistent/Language_LoadLanguageFile_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/Language_LoadLanguageFile_Patch.cs
@@ -17,7 +17,7 @@ namespace NitroxPatcher.Patches.Persistent
         public static void Postfix(string language, Dictionary<string, string> ___strings)
         {
             string[] files = {
-                Path.Combine(NitroxAppData.Instance.LauncherPath, "LanguageFiles", "English.json"), //Using English as fallback.
+                Path.Combine(NitroxAppData.Instance.LauncherPath, "LanguageFiles", "English.json"), // Using English as fallback.
                 Path.Combine(NitroxAppData.Instance.LauncherPath, "LanguageFiles", language + ".json")
             };
 
@@ -26,6 +26,7 @@ namespace NitroxPatcher.Patches.Persistent
                 if (!File.Exists(file))
                 {
                     Log.Warn($"No language file was found for at {file}. Using English as fallback");
+                    continue;
                 }
 
                 JsonData json;


### PR DESCRIPTION
This commit aims to fix blank menu in Subnautica

![immagine](https://user-images.githubusercontent.com/8330294/104071222-9e0c0e80-5200-11eb-973f-317cf6f21025.png)

