### PR TITLE
Launcher Tweaks

### DIFF
--- a/NitroxLauncher/Controls/FaderFrame.cs
+++ b/NitroxLauncher/Controls/FaderFrame.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Controls;
+using System.Diagnostics;
+using System.Windows.Navigation;
+using System.Windows.Media.Animation;
+using System.Windows;
+using System.Windows.Threading;
+using System.Threading;
+
+namespace NitroxLauncher.Controls
+{
+    public class FaderFrame : Frame
+    {
+        #region FadeDuration
+
+        public static readonly DependencyProperty FadeDurationProperty =
+            DependencyProperty.Register("FadeDuration", typeof(Duration), typeof(FaderFrame),
+                new FrameworkPropertyMetadata(new Duration(TimeSpan.FromMilliseconds(300))));
+
+        /// <summary>
+        /// FadeDuration will be used as the duration for Fade Out and Fade In animations
+        /// </summary>
+        public Duration FadeDuration
+        {
+            get { return (Duration)GetValue(FadeDurationProperty); }
+            set { SetValue(FadeDurationProperty, value); }
+        }
+
+        #endregion
+
+        public FaderFrame()
+            : base()
+        {
+            Navigating += OnNavigating;
+        }
+
+        public override void OnApplyTemplate()
+        {
+            _contentPresenter = GetTemplateChild("PART_FrameCP") as ContentPresenter;
+            base.OnApplyTemplate();
+        }
+
+        protected void OnNavigating(object sender, NavigatingCancelEventArgs e)
+        {
+            // if we did not internally initiate the navigation:
+            //   1. cancel the navigation,
+            //   2. cache the target,
+            //   3. disable hittesting during the fade, and
+            //   4. fade out the current content
+            if (Content != null && !_allowDirectNavigation && _contentPresenter != null)
+            {
+                e.Cancel = true;
+                _navArgs = e;
+                _contentPresenter.IsHitTestVisible = false;
+                DoubleAnimation da = new DoubleAnimation(0.0d, FadeDuration);
+                da.DecelerationRatio = 1.0d;
+                da.Completed += FadeOutCompleted;
+                _contentPresenter.BeginAnimation(OpacityProperty, da);
+            }
+            _allowDirectNavigation = false;
+        }
+
+        private void FadeOutCompleted(object sender, EventArgs e)
+        {
+            // after the fade out
+            //   1. re-enable hittesting
+            //   2. initiate the delayed navigation
+            //   3. invoke the FadeIn animation at Loaded priority
+            (sender as AnimationClock).Completed -= FadeOutCompleted;
+            if (_contentPresenter != null)
+            {
+                _contentPresenter.IsHitTestVisible = true;
+
+                _allowDirectNavigation = true;
+                switch (_navArgs.NavigationMode)
+                {
+                    case NavigationMode.New:
+                        if (_navArgs.Uri == null)
+                        {
+                            NavigationService.Navigate(_navArgs.Content);
+                        }
+                        else
+                        {
+                            NavigationService.Navigate(_navArgs.Uri);
+                        }
+                        break;
+
+                    case NavigationMode.Back:
+                        NavigationService.GoBack();
+                        break;
+
+                    case NavigationMode.Forward:
+                        NavigationService.GoForward();
+                        break;
+
+                    case NavigationMode.Refresh:
+                        NavigationService.Refresh();
+                        break;
+                }
+
+                Dispatcher.BeginInvoke(DispatcherPriority.Loaded,
+                    (ThreadStart)delegate ()
+                    {
+                        DoubleAnimation da = new DoubleAnimation(1.0d, FadeDuration);
+                        da.AccelerationRatio = 1.0d;
+                        _contentPresenter.BeginAnimation(OpacityProperty, da);
+                    });
+            }
+        }
+
+        private bool _allowDirectNavigation = false;
+        private ContentPresenter _contentPresenter = null;
+        private NavigatingCancelEventArgs _navArgs = null;
+    }
+}

--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -41,7 +41,7 @@
             <Setter Property="Width" Value="6"/>
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type ScrollBar}"> 
+                    <ControlTemplate TargetType="{x:Type ScrollBar}">
                         <Grid x:Name="GridRoot" Width="6" Background="{x:Null}">
                             <Track x:Name="PART_Track" Grid.Row="0" IsDirectionReversed="true" Focusable="False">
                                 <Track.Thumb>
@@ -216,7 +216,7 @@
                         <TextBlock Margin="0,0,0,8" FontSize="10" Foreground="#7FFFFFFF">NITROX RELEASE</TextBlock>
                         <TextBlock Margin="0,0,3,0" x:Name="NitroxVersionLabel" Foreground="White" Text="{Binding Version}" />
                     </StackPanel>
-
+                    <TextBlock Margin="115,555,75,-34" FontSize="10" Foreground="Purple" x:Name="DebugModeLabel" Text="Debug Mode" Visibility="Hidden" RenderTransformOrigin="0.5,0.5" />
                 </Grid>
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
                     <Frame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />

--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:NitroxLauncher"
+        xmlns:ntrx="clr-namespace:NitroxLauncher.Controls"
         mc:Ignorable="d"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         Title="Nitrox Launcher" Height="623" MinHeight="642" MaxHeight="642" Width="1024" MinWidth="1024" MaxWidth="946"
@@ -219,7 +220,7 @@
                     <TextBlock Margin="115,555,75,-34" FontSize="10" Foreground="Purple" x:Name="DebugModeLabel" Text="Debug Mode" Visibility="Hidden" RenderTransformOrigin="0.5,0.5" />
                 </Grid>
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
-                    <Frame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />
+                    <ntrx:FaderFrame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />
                 </ScrollViewer>
             </Grid>
         </Grid>

--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -219,8 +219,8 @@
                     </StackPanel>
                     <TextBlock Margin="115,555,75,-34" FontSize="10" Foreground="Purple" x:Name="DebugModeLabel" Text="Debug Mode" Visibility="Hidden" RenderTransformOrigin="0.5,0.5" />
                 </Grid>
-                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
-                    <ntrx:FaderFrame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />
+                <ScrollViewer Background="#28292C" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
+                    <ntrx:FaderFrame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" FadeDuration="0:0:0.15" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
                 </ScrollViewer>
             </Grid>
         </Grid>

--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -148,75 +148,80 @@
             GlassFrameThickness="3" />
     </WindowChrome.WindowChrome>
 
-    <Grid Margin="0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="22" />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-
-
-
-        <Grid Grid.Row="0" Background="#1F1F22" >
+    <Border BorderBrush="Purple"
+             BorderThickness="0"
+             x:Name="DebugBorderHint"
+             Background="White">
+        <Grid Margin="0">
             <Grid.RowDefinitions>
-                <RowDefinition/>
+                <RowDefinition Height="22" />
+                <RowDefinition />
             </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition  />
-            </Grid.ColumnDefinitions>
 
-            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,437,0"/>
-            <Button Margin="0,0,34,0" HorizontalAlignment="Right" VerticalAlignment="Stretch" Click="Minimze_Click" WindowChrome.IsHitTestVisibleInChrome="True" Width="32">
-                <Image Height="16" Width="16" Source="{StaticResource MinimizeImage}" Stretch="None" />
-            </Button>
-            <Button HorizontalAlignment="Right" VerticalAlignment="Stretch" Click="Close_Click" WindowChrome.IsHitTestVisibleInChrome="True" Width="32" Style="{DynamicResource CloseButton}">
-                <Image Source="{StaticResource ExitImage}" Stretch="None" />
-            </Button>
-        </Grid>
 
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="250" />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
 
-            <Grid HorizontalAlignment="Stretch" Background="#1F1F22" Style="{StaticResource MainNavigationGrid}"  >
-
+            <Grid Grid.Row="0" Background="#1F1F22" >
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="533" />
+                    <RowDefinition/>
                 </Grid.RowDefinitions>
-                <!-- Make sure the navigation items align vertically with the "NITROX" header. -->
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition  />
+                </Grid.ColumnDefinitions>
 
-                <Image Margin="32,32,131,483" Source="nitroxLogo.png" Stretch="Fill"/>
-
-                <StackPanel Margin="32,82,0,286" x:Name="SideBarPanel" HorizontalAlignment="Left" Width="196">
-                    <Button Click="ButtonNavigation_Click" Tag="{StaticResource LaunchGamePage}" ToolTip="Play the game" BorderBrush="#00000000" >
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <Image Source="{DynamicResource SideBarPlayIcon}" Width="24px" Height="24px" />
-                            <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Play game</TextBlock>
-                        </StackPanel>
-                    </Button>
-                    <Button Click="ButtonNavigation_Click" Tag="{StaticResource ServerPage}" ToolTip="Configure server options" BorderBrush="#00000000">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <Image Source="{DynamicResource SideBarServerIcon}" Width="24px" Height="24px" />
-                            <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Server</TextBlock>
-                        </StackPanel>
-                    </Button>
-                    <Button Click="ButtonNavigation_Click" Tag="{StaticResource OptionPage}" ToolTip="Launcher settings" BorderBrush="#00000000">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <Image Source="{DynamicResource SideBarOptionsIcon}" Width="24px" Height="24px" />
-                            <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Settings</TextBlock>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-                <StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="32,555,0,-60" Height="39" Width="196">
-                    <TextBlock Margin="0,0,0,8" FontSize="10" Foreground="#7FFFFFFF">NITROX RELEASE</TextBlock>
-                    <TextBlock Margin="0,0,3,0" x:Name="NitroxVersionLabel" Foreground="White" Text="{Binding Version}" />
-                </StackPanel>
-
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,437,0"/>
+                <Button Margin="0,0,34,0" HorizontalAlignment="Right" VerticalAlignment="Stretch" Click="Minimze_Click" WindowChrome.IsHitTestVisibleInChrome="True" Width="32">
+                    <Image Height="16" Width="16" Source="{StaticResource MinimizeImage}" Stretch="None" />
+                </Button>
+                <Button HorizontalAlignment="Right" VerticalAlignment="Stretch" Click="Close_Click" WindowChrome.IsHitTestVisibleInChrome="True" Width="32" Style="{DynamicResource CloseButton}">
+                    <Image Source="{StaticResource ExitImage}" Stretch="None" />
+                </Button>
             </Grid>
-            <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
-                <Frame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />
-            </ScrollViewer>
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="250" />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+
+                <Grid HorizontalAlignment="Stretch" Background="#1F1F22" Style="{StaticResource MainNavigationGrid}"  >
+
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="533" />
+                    </Grid.RowDefinitions>
+                    <!-- Make sure the navigation items align vertically with the "NITROX" header. -->
+
+                    <Image Margin="32,32,131,483" Source="nitroxLogo.png" Stretch="Fill"/>
+
+                    <StackPanel Margin="32,82,0,286" x:Name="SideBarPanel" HorizontalAlignment="Left" Width="196">
+                        <Button Click="ButtonNavigation_Click" Tag="{StaticResource LaunchGamePage}" ToolTip="Play the game" BorderBrush="#00000000" >
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <Image Source="{DynamicResource SideBarPlayIcon}" Width="24px" Height="24px" />
+                                <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Play game</TextBlock>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="ButtonNavigation_Click" Tag="{StaticResource ServerPage}" ToolTip="Configure server options" BorderBrush="#00000000">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <Image Source="{DynamicResource SideBarServerIcon}" Width="24px" Height="24px" />
+                                <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Server</TextBlock>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="ButtonNavigation_Click" Tag="{StaticResource OptionPage}" ToolTip="Launcher settings" BorderBrush="#00000000">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <Image Source="{DynamicResource SideBarOptionsIcon}" Width="24px" Height="24px" />
+                                <TextBlock FontSize="16" Margin="12,0,0,0" VerticalAlignment="Center">Settings</TextBlock>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="32,555,0,-60" Height="39" Width="196">
+                        <TextBlock Margin="0,0,0,8" FontSize="10" Foreground="#7FFFFFFF">NITROX RELEASE</TextBlock>
+                        <TextBlock Margin="0,0,3,0" x:Name="NitroxVersionLabel" Foreground="White" Text="{Binding Version}" />
+                    </StackPanel>
+
+                </Grid>
+                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Column="1" Template="{DynamicResource ScrollViewerMainframe}" x:Name="ScrollViewerMainframe">
+                    <Frame Grid.Column="1" Background="#28292C" x:Name="MainFrame" NavigationUIVisibility="Hidden" Content="{Binding FrameContent}" Width="766" />
+                </ScrollViewer>
+            </Grid>
         </Grid>
-    </Grid>
+    </Border>
 </Window>

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using NitroxLauncher.AttachedProperties;
 using NitroxLauncher.Events;
 using NitroxLauncher.Pages;

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -21,6 +21,12 @@ namespace NitroxLauncher
         private bool isServerEmbedded;
 
         public string Version => $"{LauncherLogic.RELEASE_PHASE} {LauncherLogic.Version}";
+        public bool DebugMode = false;
+        public Visibility DebugLabelVisibility { get
+            {
+                return DebugMode ? Visibility.Visible : Visibility.Hidden;
+            } 
+        }
 
         public object FrameContent
         {
@@ -51,9 +57,9 @@ namespace NitroxLauncher
             {
                 // Highlight the window border purple if ran with DEBUG
                 #if DEBUG
-                DebugBorderHint.BorderThickness = new Thickness(1.5D);
+                DebugBorderHint.BorderThickness = new Thickness(4.5D);
+                DebugModeLabel.Visibility = Visibility.Visible;
                 #endif
-
                 // This pirate detection subscriber is immediately invoked if pirate has been detected right now.
                 PirateDetection.PirateDetected += (o, eventArgs) =>
                 {

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -23,11 +23,6 @@ namespace NitroxLauncher
 
         public string Version => $"{LauncherLogic.RELEASE_PHASE} {LauncherLogic.Version}";
         public bool DebugMode = false;
-        public Visibility DebugLabelVisibility { get
-            {
-                return DebugMode ? Visibility.Visible : Visibility.Hidden;
-            } 
-        }
 
         public object FrameContent
         {

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -49,6 +49,11 @@ namespace NitroxLauncher
             // Pirate trigger should happen after UI is loaded.
             Loaded += (sender, args) =>
             {
+                // Highlight the window border purple if ran with DEBUG
+                #if DEBUG
+                DebugBorderHint.BorderThickness = new Thickness(1.5D);
+                #endif
+
                 // This pirate detection subscriber is immediately invoked if pirate has been detected right now.
                 PirateDetection.PirateDetected += (o, eventArgs) =>
                 {

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -68,6 +68,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="AttachedProperties\ButtonProperties.cs" />
+    <Compile Include="Controls\FaderFrame.cs" />
     <Compile Include="DependencyObjectExtensions.cs" />
     <Compile Include="Events\ServerStartEventArgs.cs" />
     <Compile Include="LauncherLogic.cs" />


### PR DESCRIPTION
# Fade between pages.

Feel free to modify the speed if it doesn't feel correct.

![gif](https://iili.io/KZruTX.gif)

# Debug Mode

Can be built onto, currently it shows a border and label when the application is ran in the DEBUG configuration.

![Screenshot](https://iili.io/KZrRQs.png)

Currently, the variable stating that debug mode is enabled can be found in `NitroxLauncher.MainWindow.DebugMode`, however, in the future it may be saved as a setting so it can be used in RELEASE configuration to reproduce bugs. That is an entirely different PR though.

