### PR TITLE
Nitrox Public API v0

### DIFF
--- a/Nitrox.Bootloader/Nitrox.Bootloader.csproj
+++ b/Nitrox.Bootloader/Nitrox.Bootloader.csproj
@@ -1,34 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{E4226522-9189-410B-93B2-792942FBD588}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Nitrox.Bootloader</RootNamespace>
-        <AssemblyName>Nitrox.Bootloader</AssemblyName>
-        <FileAlignment>512</FileAlignment>
-        <NitroxLibrary>false</NitroxLibrary>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-      <Compile Include="Main.cs" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E4226522-9189-410B-93B2-792942FBD588}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nitrox.Bootloader</RootNamespace>
+    <AssemblyName>Nitrox.Bootloader</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <NitroxLibrary>false</NitroxLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -237,10 +237,7 @@
       <Name>LiteNetLib</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="OS\MacOS\" />
-    <Folder Include="OS\Unix\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <PackageReference Include="Autofac">
       <Version>4.9.4</Version>

--- a/NitroxServer/API/APIServer.cs
+++ b/NitroxServer/API/APIServer.cs
@@ -22,8 +22,10 @@ namespace NitroxServer.PublicAPI
             rawServer.UseCorsPolicy();
             rawServer.Prefixes.Clear();
             rawServer.Prefixes.Add($"http://localhost:{Port}/");
-            WebHeaderCollection defaultHeaders = new WebHeaderCollection();
-            defaultHeaders.Add("Content-Type", "application/json");
+            WebHeaderCollection defaultHeaders = new WebHeaderCollection
+            {
+                { "Content-Type", "application/json" }
+            };
             rawServer.ApplyGlobalResponseHeaders(defaultHeaders);
             Instance = this;
             rawServer.Start();

--- a/NitroxServer/API/APIServer.cs
+++ b/NitroxServer/API/APIServer.cs
@@ -13,27 +13,31 @@ namespace NitroxServer.API
     {
         public int Port;
         public static APIServer Instance { get; private set; }
-        private readonly IRestServer rawServer;
+        public readonly IRestServer RawServer;
 
         public APIServer()
         {
             Port = 3000;
-            rawServer = RestServerBuilder.UseDefaults().Build();
-            rawServer.UseCorsPolicy();
-            rawServer.Prefixes.Clear();
-            rawServer.Prefixes.Add($"http://localhost:{Port}/");
+            RawServer = RestServerBuilder.UseDefaults().Build();
+            RawServer.UseCorsPolicy();
+            RawServer.Prefixes.Clear();
+            RawServer.Prefixes.Add($"http://localhost:{Port}/");
             WebHeaderCollection defaultHeaders = new WebHeaderCollection
             {
                 { "Content-Type", "application/json" }
             };
-            rawServer.ApplyGlobalResponseHeaders(defaultHeaders);
+            RawServer.ApplyGlobalResponseHeaders(defaultHeaders);
             Instance = this;
-            rawServer.Start();
+        }
+
+        public void Start()
+        {
+            RawServer.Start();
         }
 
         public void Stop()
         {
-            rawServer.Stop();
+            RawServer.Stop();
         }
     }
 }

--- a/NitroxServer/API/APIServer.cs
+++ b/NitroxServer/API/APIServer.cs
@@ -1,0 +1,37 @@
+﻿using System.Net;
+using Grapevine;
+
+namespace NitroxServer.PublicAPI
+{
+    /**
+     * <summary>
+     * The central method for all APIServers, always runs on an ajacent port to the Nitrox Server allowing multiple instances to be live.
+     * It can be disabled in-game or in-console using the /api command
+     * </summary>
+     */
+    public class APIServer
+    {
+        public int Port;
+        public static APIServer Instance { get; private set; }
+        private readonly IRestServer rawServer;
+
+        public APIServer()
+        {
+            Port = 3000;
+            rawServer = RestServerBuilder.UseDefaults().Build();
+            rawServer.UseCorsPolicy();
+            rawServer.Prefixes.Clear();
+            rawServer.Prefixes.Add($"http://localhost:{Port}/");
+            WebHeaderCollection defaultHeaders = new WebHeaderCollection();
+            defaultHeaders.Add("Content-Type", "application/json");
+            rawServer.ApplyGlobalResponseHeaders(defaultHeaders);
+            Instance = this;
+            rawServer.Start();
+        }
+
+        public void Stop()
+        {
+            rawServer.Stop();
+        }
+    }
+}

--- a/NitroxServer/API/APIServer.cs
+++ b/NitroxServer/API/APIServer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using Grapevine;
 
-namespace NitroxServer.PublicAPI
+namespace NitroxServer.API
 {
     /**
      * <summary>

--- a/NitroxServer/API/CommonResponses/PlayerCountResponse.cs
+++ b/NitroxServer/API/CommonResponses/PlayerCountResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class PlayerCountResponse

--- a/NitroxServer/API/CommonResponses/PlayerCountResponse.cs
+++ b/NitroxServer/API/CommonResponses/PlayerCountResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class PlayerCountResponse
+    {
+        public int Count;
+        public int Max;
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerAlreadyResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerAlreadyResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class ServerAlreadyResponse
+    {
+        public string Status;
+        public ServerAlreadyResponse(string Status) { this.Status = Status; }
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerAlreadyResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerAlreadyResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class ServerAlreadyResponse

--- a/NitroxServer/API/CommonResponses/ServerPausedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerPausedResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class ServerPausedResponse
+    {
+        public string Status = "Server Paused";
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerPausedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerPausedResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class ServerPausedResponse

--- a/NitroxServer/API/CommonResponses/ServerResumedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerResumedResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class ServerResumedResponse
+    {
+        public string Status = "Server Resumed";
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerResumedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerResumedResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class ServerResumedResponse

--- a/NitroxServer/API/CommonResponses/ServerStatusResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerStatusResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class ServerStatusResponse
+    {
+        public string Status;
+        public int PlayersOnline;
+        public int MaxPlayers;
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerStatusResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerStatusResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class ServerStatusResponse

--- a/NitroxServer/API/CommonResponses/ServerStoppedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerStoppedResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [Serializable]
+    public class ServerStoppedResponse
+    {
+        public string Status = "Server Stopped";
+    }
+}
+

--- a/NitroxServer/API/CommonResponses/ServerStoppedResponse.cs
+++ b/NitroxServer/API/CommonResponses/ServerStoppedResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class ServerStoppedResponse

--- a/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
+++ b/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NitroxPublic.API.CommonResponses
 {
+    [Serializable]
     public class UnauthorizedResponse
     {
         public string Message;

--- a/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
+++ b/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NitroxPublic.API.CommonResponses
+namespace NitroxServer.API.CommonResponses
 {
     [Serializable]
     public class UnauthorizedResponse

--- a/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
+++ b/NitroxServer/API/CommonResponses/UnauthorizedResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NitroxPublic.API.CommonResponses
+{
+    public class UnauthorizedResponse
+    {
+        public string Message;
+        public UnauthorizedResponse(string Message) { this.Message = Message; }
+    }
+}

--- a/NitroxServer/API/Routes/ServerRelated.cs
+++ b/NitroxServer/API/Routes/ServerRelated.cs
@@ -1,14 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Grapevine;
 using Newtonsoft.Json;
 using NitroxModel.MultiplayerSession;
-using NitroxPublic.API.CommonResponses;
-using NitroxServer.Serialization;
+using NitroxServer.API.CommonResponses;
 
-namespace NitroxServer.PublicAPI.Routes
+namespace NitroxServer.API.Routes
 {
     [RestResource]
     public class ServerRelated
@@ -30,18 +28,19 @@ namespace NitroxServer.PublicAPI.Routes
                 response.PlayersOnline = srv.GetNitroxServer().GetPlayerCount();
                 response.MaxPlayers = srv.GetServerConfig().MaxConnections;
             }
-                
+
 
             await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(response, Formatting.Indented));
         }
         [RestRoute("Get", "/server/ping")]
         public async Task pingServer(IHttpContext ctx)
         {
-            if(Server.Instance.IsRunning)
+            if (Server.Instance.IsRunning)
             {
                 ctx.Response.StatusCode = 200;
                 await ctx.Response.SendResponseAsync("{}");
-            } else
+            }
+            else
             {
                 ctx.Response.StatusCode = 400;
                 await ctx.Response.SendResponseAsync("{}");
@@ -54,11 +53,12 @@ namespace NitroxServer.PublicAPI.Routes
         public async Task stopServer(IHttpContext ctx)
         {
             Server srv = Server.Instance;
-            if(ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
+            if (ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
             {
                 ctx.Response.StatusCode = 401;
                 await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
-            } else
+            }
+            else
             {
                 await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerStoppedResponse(), Formatting.Indented));
                 srv.Stop();

--- a/NitroxServer/API/Routes/ServerRelated.cs
+++ b/NitroxServer/API/Routes/ServerRelated.cs
@@ -1,0 +1,144 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Grapevine;
+using Newtonsoft.Json;
+using NitroxModel.MultiplayerSession;
+using NitroxPublic.API.CommonResponses;
+using NitroxServer.Serialization;
+
+namespace NitroxServer.PublicAPI.Routes
+{
+    [RestResource]
+    public class ServerRelated
+    {
+        #region Server Status
+        [RestRoute("Get", "/server/status")]
+        public async Task getServerStatus(IHttpContext ctx)
+        {
+            ServerStatusResponse response = new ServerStatusResponse();
+            Server srv = Server.Instance;
+
+            if (!srv.IsRunning)
+            {
+                response.Status = "OFFLINE";
+            }
+            else
+            {
+                response.Status = "ONLINE";
+                response.PlayersOnline = srv.GetNitroxServer().GetPlayerCount();
+                response.MaxPlayers = srv.GetServerConfig().MaxConnections;
+            }
+                
+
+            await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(response, Formatting.Indented));
+        }
+        [RestRoute("Get", "/server/ping")]
+        public async Task pingServer(IHttpContext ctx)
+        {
+            if(Server.Instance.IsRunning)
+            {
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.SendResponseAsync("{}");
+            } else
+            {
+                ctx.Response.StatusCode = 400;
+                await ctx.Response.SendResponseAsync("{}");
+            }
+        }
+        #endregion
+        #region Server Control
+
+        [RestRoute("Delete", "/server/stop")]
+        public async Task stopServer(IHttpContext ctx)
+        {
+            Server srv = Server.Instance;
+            if(ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
+            {
+                ctx.Response.StatusCode = 401;
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
+            } else
+            {
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerStoppedResponse(), Formatting.Indented));
+                srv.Stop();
+
+            }
+        }
+        [RestRoute("POST", "/server/pause")]
+        public async Task pauseServer(IHttpContext ctx)
+        {
+            Server srv = Server.Instance;
+            if (ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
+            {
+                ctx.Response.StatusCode = 401;
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
+            }
+            else
+            {
+                if (srv.Paused)
+                {
+                    ctx.Response.StatusCode = 500;
+                    await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerAlreadyResponse("The server is already paused!"), Formatting.Indented));
+                    return;
+                }
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerPausedResponse(), Formatting.Indented));
+                srv.PauseServer();
+            }
+        }
+        [RestRoute("POST", "/server/resume")]
+        public async Task resumeServer(IHttpContext ctx)
+        {
+            Server srv = Server.Instance;
+            if (ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
+            {
+                ctx.Response.StatusCode = 401;
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
+            }
+            else
+            {
+                if (!srv.Paused)
+                {
+                    ctx.Response.StatusCode = 500;
+                    await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerAlreadyResponse("The server isn't paused!"), Formatting.Indented));
+                    return;
+                }
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerResumedResponse(), Formatting.Indented));
+                srv.ResumeServer();
+            }
+        }
+        #endregion
+        #region Player Management
+        [RestRoute("Get", "/server/players")]
+        public async Task getPlayers(IHttpContext ctx)
+        {
+            Server srv = Server.Instance;
+            if (ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword)
+            {
+                ctx.Response.StatusCode = 401;
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
+            }
+            else
+            {
+                IEnumerable<Player> players = srv.GetNitroxServer().GetPlayerManager().GetAllPlayers();
+                List<PlayerContext> playerInfos = new List<PlayerContext>();
+                foreach (Player player in players)
+                {
+                    playerInfos.Add(player.PlayerContext);
+                }
+                await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(playerInfos, Formatting.Indented));
+            }
+        }
+        [RestRoute("Get", "/server/players/count")]
+        public async Task getPlayerCount(IHttpContext ctx)
+        {
+            Server srv = Server.Instance;
+            PlayerCountResponse res = new PlayerCountResponse();
+            res.Count = srv.GetNitroxServer().GetPlayerManager().GetAllPlayers().Count();
+            res.Max = srv.GetServerConfig().MaxConnections;
+            await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(res, Formatting.Indented));
+        }
+        #endregion
+    }
+}
+

--- a/NitroxServer/API/Routes/ServerRelated.cs
+++ b/NitroxServer/API/Routes/ServerRelated.cs
@@ -62,7 +62,6 @@ namespace NitroxServer.PublicAPI.Routes
             {
                 await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerStoppedResponse(), Formatting.Indented));
                 srv.Stop();
-
             }
         }
         [RestRoute("POST", "/server/pause")]

--- a/NitroxServer/Communication/NetworkingLayer/NitroxServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/NitroxServer.cs
@@ -74,6 +74,15 @@ namespace NitroxServer.Communication.NetworkingLayer
             NatUtility.StartDiscovery();
         }
 
+        public PlayerManager GetPlayerManager()
+        {
+            return playerManager;
+        }
+        public int GetPlayerCount()
+        {
+            return playerManager.GetConnectedPlayers().Count;
+        }
+
         private async void DeviceFound(object sender, DeviceEventArgs args)
         {
             try

--- a/NitroxServer/ConsoleCommands/APICommand.cs
+++ b/NitroxServer/ConsoleCommands/APICommand.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxServer.ConsoleCommands.Abstract;
+using NitroxServer.ConsoleCommands.Abstract.Type;
+
+namespace NitroxServer.ConsoleCommands
+{
+    public class APICommand : Command
+    {
+        private string GetIPAddress()
+        {
+            string address = "";
+            WebRequest request = WebRequest.Create("http://checkip.dyndns.org/");
+            using (WebResponse response = request.GetResponse())
+            using (StreamReader stream = new StreamReader(response.GetResponseStream()))
+            {
+                address = stream.ReadToEnd();
+            }
+
+            int first = address.IndexOf("Address: ") + 9;
+            int last = address.LastIndexOf("</body>");
+            address = address.Substring(first, last - first);
+
+            return address;
+        }
+
+        public APICommand() : base("api", Perms.ADMIN, "Manage the NPAPI connected to this server. Valid actions: start, stop, enable, disable")
+        {
+            AddParameter(new TypeString("action", true));
+        }
+        protected override void Execute(CallArgs args)
+        {
+            string action = args.Get(0);
+            switch (action)
+            {
+                case "start":
+                    if (Server.Instance.API.RawServer.IsListening)
+                    {
+                        SendMessage(args.Sender, "The NAPI is already active and listening!");
+                    } else
+                    {
+                        Server.Instance.API.Start();
+                        SendMessage(args.Sender, $"The NAPI is now listening on http://localhost:3000/, you can forward the port TCP 3000 manually if you want outside connections to be able to use NPAPI");
+                    }
+                    break;
+                case "stop":
+                    if (!Server.Instance.API.RawServer.IsListening)
+                    {
+                        SendMessage(args.Sender, "The NAPI is already inactive!");
+                        break;
+                    } else
+                    {
+                        Server.Instance.API.Stop();
+                        SendMessage(args.Sender, $"The NAPI is now inactive and has stopped listening.");
+                    }
+                    break;
+                case "enable":
+                    if(Server.Instance.GetServerConfig().EnablePublicAPI)
+                    {
+                        SendMessage(args.Sender, "NAPI is already enabled.");
+                        break;
+                    }
+                    Server.Instance.GetServerConfig().EnablePublicAPI = true;
+                    Server.Instance.Save();
+                    SendMessage(args.Sender, $"The NAPI will now automatically start when the server is started. You can stop NAPI using /api stop");
+                    break;
+                case "disable":
+                    if (!Server.Instance.GetServerConfig().EnablePublicAPI)
+                    {
+                        SendMessage(args.Sender, "NAPI is already disabled.");
+                        break;
+                    }
+                    Server.Instance.GetServerConfig().EnablePublicAPI = false;
+                    Server.Instance.Save();
+                    SendMessage(args.Sender, $"The NAPI will not be started when the server is started. You can manually start NAPI using /api start");
+                    break;
+                default:
+                    break;
+            } 
+        }
+    }
+}

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -63,6 +63,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\APIServer.cs" />
+    <Compile Include="API\CommonResponses\UnauthorizedResponse.cs" />
+    <Compile Include="API\Routes\ServerRelated.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibConnection.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibServer.cs" />
     <Compile Include="Communication\NetworkingLayer\NitroxConnection.cs" />
@@ -247,11 +250,17 @@
     <PackageReference Include="DotNetZip">
       <Version>1.15.0</Version>
     </PackageReference>
+    <PackageReference Include="Grapevine">
+      <Version>5.0.0-rc.3</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Mono.Nat">
       <Version>3.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -65,7 +65,13 @@
   <ItemGroup>
     <Compile Include="API\APIServer.cs" />
     <Compile Include="API\CommonResponses\UnauthorizedResponse.cs" />
+    <Compile Include="API\CommonResponses\ServerAlreadyResponse.cs" />
+    <Compile Include="API\CommonResponses\ServerPausedResponse.cs" />
+    <Compile Include="API\CommonResponses\PlayerCountResponse.cs" />
     <Compile Include="API\Routes\ServerRelated.cs" />
+    <Compile Include="API\CommonResponses\ServerResumedResponse.cs" />
+    <Compile Include="API\CommonResponses\ServerStatusResponse.cs" />
+    <Compile Include="API\CommonResponses\ServerStoppedResponse.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibConnection.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibServer.cs" />
     <Compile Include="Communication\NetworkingLayer\NitroxConnection.cs" />

--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -17,6 +17,8 @@ namespace NitroxServer.Serialization
         private string saveNameSetting = "world";
         public string FileName => "server.cfg";
 
+        public bool EnablePublicAPI { get; set; }
+
         [PropertyDescription("Leave blank for a random spawn position")]
         public string Seed { get; set; }
 

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -39,7 +39,11 @@ namespace NitroxServer
             saveTimer.Interval = serverConfig.SaveInterval;
             saveTimer.AutoReset = true;
             saveTimer.Elapsed += delegate { Save(); };
-            API = new API.APIServer();
+            API = new APIServer();
+            if(serverConfig.EnablePublicAPI)
+            {
+                API.Start();
+            }
         }
 
         public string SaveSummary
@@ -57,6 +61,7 @@ namespace NitroxServer
                 builder.AppendLine($" - Inventory items: {world.InventoryManager.GetAllInventoryItems().Count}");
                 builder.AppendLine($" - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}");
                 builder.AppendLine($" - Vehicles: {world.VehicleManager.GetVehicles().Count()}");
+                builder.AppendLine($" - NPAPI Enabled: {serverConfig.EnablePublicAPI}");
 
                 return builder.ToString();
             }
@@ -119,12 +124,21 @@ namespace NitroxServer
         public void Stop()
         {
             Log.Info("Nitrox Server Stopping...");
+
             DisablePeriodicSaving();
             Save();
             server.Stop();
+
+            if (API != null)
+            {
+                API.Stop();
+            }
+
             Log.Info("Nitrox Server Stopped");
+
             IsRunning = false;
-            Environment.Exit(0);
+
+            Environment.Exit(0); // Fixes the launcher not realising the server has stopped by closing the server executable.
         }
 
         public void EnablePeriodicSaving()

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using NitroxServer.Serialization;
 using NitroxModel.Serialization;
 using System;
-using NitroxServer.PublicAPI;
+using NitroxServer.API;
 
 namespace NitroxServer
 {
@@ -39,7 +39,7 @@ namespace NitroxServer
             saveTimer.Interval = serverConfig.SaveInterval;
             saveTimer.AutoReset = true;
             saveTimer.Elapsed += delegate { Save(); };
-            API = new PublicAPI.APIServer();
+            API = new API.APIServer();
         }
 
         public string SaveSummary

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -122,7 +122,7 @@
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.1.2</Version>
-	  <GeneratePathProperty>true</GeneratePathProperty>
+      <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.2</Version>


### PR DESCRIPTION
This puts down the infrastructure of the Nitrox Public API.

## Infomation

The Nitrox Public API is a public API that runs on `http://{NitroxServerIP}:3000/` and includes various endpoints to collect data or interact with your Nitrox Server.

## Spec

The NPAPI is built using Grapevine, a not very well known library that uses Attributes to register methods.

Example:

```cs
[RestRoute("Delete", "/server/stop")]
public async Task stopServer(IHttpContext ctx) {
    Server srv = Server.Instance;
    if (ctx.Request.Headers.Get("Auth") != srv.GetServerConfig().AdminPassword) {
        ctx.Response.StatusCode = 401;
        await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new UnauthorizedResponse("Please pass your ADMIN PASSWORD through the Auth header to access this endpoint."), Formatting.Indented));
    } else {
        await ctx.Response.SendResponseAsync(JsonConvert.SerializeObject(new ServerStoppedResponse(), Formatting.Indented));
        srv.Stop();
    }
}
```

These Attributes allow easy addition of more methods, allowing the API to be updated easily.

## Usages

Although you may not be able to think of many usages, here is a wide range:

- Discord Bots
- Website Integrations 
	+ Show currently online players on your website or etc.
- Future Nitrox Usages
	+ Public serverlist?
	+ Paid Hosting?
	+ Web Admin Panels?

## Documentation and Access

The server can be automatically ran when the server is started using the command `/api enable/disable`. It can be stopped using the `/api stop` and restarted using the `/api start` commands.

Documentation: https://documenter.getpostman.com/view/9952152/TVzSmJ8j