### PR TITLE
Added unique user identification token usage to Nitrox.

### DIFF
--- a/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
+++ b/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
@@ -3,6 +3,7 @@ using NitroxModel.Helper;
 using NitroxModel.Logger;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using System;
 
 namespace NitroxClient.MonoBehaviours.DiscordRP
 {
@@ -41,7 +42,7 @@ namespace NitroxClient.MonoBehaviours.DiscordRP
                 string[] splitSecret = secret.Split(':');
                 string ip = splitSecret[0];
                 string port = splitSecret[1];
-                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port);
+                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port, Guid.NewGuid()); //FIXME: Actually persist this in the server.cfg with this GUID.
             }
             else
             {

--- a/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
+++ b/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
@@ -4,6 +4,7 @@ using NitroxModel.Logger;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using System;
+using NitroxClient.Persistence;
 
 namespace NitroxClient.MonoBehaviours.DiscordRP
 {
@@ -42,7 +43,13 @@ namespace NitroxClient.MonoBehaviours.DiscordRP
                 string[] splitSecret = secret.Split(':');
                 string ip = splitSecret[0];
                 string port = splitSecret[1];
-                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port, Guid.NewGuid()); //FIXME: Actually persist this in the server.cfg with this GUID.
+                Guid token = PersistedClientData.GetToken(ip, port);
+                if(token == Guid.Empty)
+                {
+                    token = Guid.NewGuid();
+                    PersistedClientData.EmplaceServer("Discord added server", ip, port, token);
+                }
+                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port, token);
             }
             else
             {

--- a/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
+++ b/NitroxClient/MonoBehaviours/DiscordRP/DiscordRPController.cs
@@ -43,13 +43,13 @@ namespace NitroxClient.MonoBehaviours.DiscordRP
                 string[] splitSecret = secret.Split(':');
                 string ip = splitSecret[0];
                 string port = splitSecret[1];
-                Guid token = PersistedClientData.GetToken(ip, port);
-                if(token == Guid.Empty)
+                Guid authToken = PersistedClientData.GetAuthToken(ip, port);
+                if(authToken == Guid.Empty)
                 {
-                    token = Guid.NewGuid();
-                    PersistedClientData.EmplaceServer("Discord added server", ip, port, token);
+                    authToken = Guid.NewGuid();
+                    PersistedClientData.EmplaceServer("Discord added server", ip, port, authToken);
                 }
-                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port, token);
+                MainMenuMultiplayerPanel.OpenJoinServerMenu(ip, port, authToken);
             }
             else
             {

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -41,7 +41,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 
         private string serverIp;
         private int serverPort;
-        private Guid token;
+        private Guid authToken;
 
         private bool isSubscribed;
         private bool shouldFocus;
@@ -58,7 +58,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             Hide();
         }
 
-        public void Show(string ip, int port, Guid token)
+        public void Show(string ip, int port, Guid authToken)
         {
             NitroxServiceLocator.BeginNewLifetimeScope();
             multiplayerSession = NitroxServiceLocator.LocateService<IMultiplayerSession>();
@@ -67,7 +67,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             gameObject.SetActive(true);
             serverIp = ip;
             serverPort = port;
-            this.token = token;
+            this.authToken = authToken;
 
             //Set Server IP in info label
             lowerDetailTextGameObject.GetComponent<Text>().text = $"{Language.main.Get("Nitrox_JoinServerIpAddress")}\n{serverIp}";
@@ -216,7 +216,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             }
             preferencesManager.SetPreference(serverIp, new PlayerPreference(playerName, colorPicker.currentColor));
 
-            AuthenticationContext authenticationContext = passwordEntered ? new AuthenticationContext(token, playerName, serverPassword) : new AuthenticationContext(token, playerName);
+            AuthenticationContext authenticationContext = passwordEntered ? new AuthenticationContext(authToken, playerName, serverPassword) : new AuthenticationContext(authToken, playerName);
 
             multiplayerSession.RequestSessionReservation(new PlayerSettings(colorPicker.currentColor.ToDto()), authenticationContext);
         }

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -41,6 +41,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 
         private string serverIp;
         private int serverPort;
+        private Guid token;
 
         private bool isSubscribed;
         private bool shouldFocus;
@@ -57,7 +58,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             Hide();
         }
 
-        public void Show(string ip, int port)
+        public void Show(string ip, int port, Guid token)
         {
             NitroxServiceLocator.BeginNewLifetimeScope();
             multiplayerSession = NitroxServiceLocator.LocateService<IMultiplayerSession>();
@@ -66,6 +67,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             gameObject.SetActive(true);
             serverIp = ip;
             serverPort = port;
+            this.token = token;
 
             //Set Server IP in info label
             lowerDetailTextGameObject.GetComponent<Text>().text = $"{Language.main.Get("Nitrox_JoinServerIpAddress")}\n{serverIp}";
@@ -214,7 +216,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             }
             preferencesManager.SetPreference(serverIp, new PlayerPreference(playerName, colorPicker.currentColor));
 
-            AuthenticationContext authenticationContext = passwordEntered ? new AuthenticationContext(playerName, serverPassword) : new AuthenticationContext(playerName);
+            AuthenticationContext authenticationContext = passwordEntered ? new AuthenticationContext(token, playerName, serverPassword) : new AuthenticationContext(token, playerName);
 
             multiplayerSession.RequestSessionReservation(new PlayerSettings(colorPicker.currentColor.ToDto()), authenticationContext);
         }

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
@@ -66,7 +66,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             multiplayerButtonButton.onClick.AddListener(clickEvent);
         }
 
-        private void CreateServerButton(string text, string joinIp, string joinPort, Guid token)
+        private void CreateServerButton(string text, string joinIp, string joinPort, Guid authToken)
         {
             GameObject multiplayerButtonInst = Instantiate(multiplayerButton, savedGameAreaContent, false);
             multiplayerButtonInst.name = (savedGameAreaContent.childCount - 1).ToString();
@@ -79,7 +79,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             multiplayerButtonButton.onClick.AddListener(() =>
             {
                 txt.GetComponent<Text>().color = prevTextColor; // Visual fix for black text after click (hover state still active)
-                OpenJoinServerMenu(joinIp, joinPort, token);
+                OpenJoinServerMenu(joinIp, joinPort, authToken);
             });
 
             GameObject delete = Instantiate(deleteButtonRef, multiplayerButtonInst.transform, false);
@@ -92,9 +92,9 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             });
         }
 
-        private void AddServer(string name, string ip, string port, Guid token)
+        private void AddServer(string name, string ip, string port, Guid authToken)
         {
-            PersistedClientData.EmplaceServer(name, ip, port, token);
+            PersistedClientData.EmplaceServer(name, ip, port, authToken);
         }
 
         private void RemoveServer(int index)
@@ -102,7 +102,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             PersistedClientData.RemoveServerByIndex(index);
         }
 
-        public static void OpenJoinServerMenu(string serverIp, string serverPort, Guid token)
+        public static void OpenJoinServerMenu(string serverIp, string serverPort, Guid authToken)
         {
             if (main == null)
             {
@@ -116,7 +116,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
                 return;
             }
 
-            main.joinServer.Show(endpoint.Address.ToString(), endpoint.Port, token);
+            main.joinServer.Show(endpoint.Address.ToString(), endpoint.Port, authToken);
         }
 
         private void ShowAddServerWindow()
@@ -146,7 +146,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         {
             foreach(SavedServer server in PersistedClientData.GetServers())
             {
-                CreateServerButton($"{Language.main.Get("Nitrox_ConnectTo")} <b>{server.Name}</b>\n{server.Ip}:{server.Port}", server.Ip, server.Port, new Guid(server.Token));
+                CreateServerButton($"{Language.main.Get("Nitrox_ConnectTo")} <b>{server.Name}</b>\n{server.Ip}:{server.Port}", server.Ip, server.Port, new Guid(server.AuthToken));
             }
         }
 
@@ -193,9 +193,9 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             serverNameInput = serverNameInput.Trim();
             serverHostInput = serverHostInput.Trim();
             serverPortInput = serverPortInput.Trim();
-            Guid token = Guid.NewGuid();
-            AddServer(serverNameInput, serverHostInput, serverPortInput, token);
-            CreateServerButton($"{Language.main.Get("Nitrox_ConnectTo")} <b>{serverNameInput}</b>\n{serverHostInput}:{serverPortInput}", serverHostInput, serverPortInput, token);
+            Guid authToken = Guid.NewGuid();
+            AddServer(serverNameInput, serverHostInput, serverPortInput, authToken);
+            CreateServerButton($"{Language.main.Get("Nitrox_ConnectTo")} <b>{serverNameInput}</b>\n{serverHostInput}:{serverPortInput}", serverHostInput, serverPortInput, authToken);
             HideAddServerWindow();
         }
 

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -75,6 +75,9 @@
     <Compile Include="GameLogic\Containers\NoOpContainerAddItemPostProcessor.cs" />
     <Compile Include="GameLogic\InitialSync\SimulationOwnershipInitialSyncProcessor.cs" />
     <Compile Include="GameLogic\LiveMixinManager.cs" />
+    <Compile Include="Persistence\Model\SavedServer.cs" />
+    <Compile Include="Persistence\PersistedClientData.cs" />
+    <Compile Include="Persistence\Model\PersistedClientDataModel.cs" />
     <Compile Include="GameLogic\Rockets.cs" />
     <Compile Include="GameLogic\Simulation\LockRequestBase.cs" />
     <Compile Include="GameLogic\Simulation\PropulsionGrab.cs" />

--- a/NitroxClient/Persistence/Model/PersistedClientDataModel.cs
+++ b/NitroxClient/Persistence/Model/PersistedClientDataModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NitroxClient.Persistence.Model
+{
+    [Serializable]
+    class PersistedClientDataModel
+    {
+        public List<SavedServer> SavedServers { get; set; } = new List<SavedServer>();
+    }
+}

--- a/NitroxClient/Persistence/Model/SavedServer.cs
+++ b/NitroxClient/Persistence/Model/SavedServer.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NitroxClient.Persistence.Model
+{
+    [Serializable]
+    public class SavedServer
+    {
+        public string Name;
+
+        public string Ip;
+
+        public string Port;
+
+        public string Token;
+    }
+}

--- a/NitroxClient/Persistence/Model/SavedServer.cs
+++ b/NitroxClient/Persistence/Model/SavedServer.cs
@@ -11,6 +11,6 @@ namespace NitroxClient.Persistence.Model
 
         public string Port;
 
-        public string Token;
+        public string AuthToken;
     }
 }

--- a/NitroxClient/Persistence/PersistedClientData.cs
+++ b/NitroxClient/Persistence/PersistedClientData.cs
@@ -22,24 +22,24 @@ namespace NitroxClient.Persistence
             }
         }
 
-        public static Guid GetToken(string ip, string port)
+        public static Guid GetAuthToken(string ip, string port)
         {
             CheckSingleton();
             foreach (SavedServer pair in model.SavedServers)
             {
                 if (pair.Ip.Equals(ip) && pair.Port.Equals(port)) //Always use trusted members to the left a .Equals call. Don't compare potentially unsafe data; assume parameters might be null.
                 {
-                    return new Guid(pair.Token);
+                    return new Guid(pair.AuthToken);
                 }
             }
             return Guid.Empty;
         }
 
-        public static void EmplaceServer(string name, string ip, string port, Guid token)
+        public static void EmplaceServer(string name, string ip, string port, Guid authToken)
         {
             CheckSingleton();
-            SavedServer savedServer = new SavedServer() { Name = name, Ip = ip, Port = port, Token = token.ToString() };
-            if(GetToken(savedServer.Ip, savedServer.Port) != Guid.Empty) //Some validation is better than no validation.
+            SavedServer savedServer = new SavedServer() { Name = name, Ip = ip, Port = port, AuthToken = authToken.ToString() };
+            if(GetAuthToken(savedServer.Ip, savedServer.Port) != Guid.Empty) //Some validation is better than no validation.
             {
                 throw new Exception($"Failed to add '{ip}':'{port}' because there is already an entry for it.");
             }
@@ -80,14 +80,14 @@ namespace NitroxClient.Persistence
                                 serverIp = match.Groups[1].Value;
                                 serverPort = match.Groups[2].Success ? match.Groups[2].Value : "11000";
                             }
-                            model.SavedServers.Add(new SavedServer() { Name = serverName, Ip = serverIp, Port = serverPort, Token = Guid.NewGuid().ToString() });
+                            model.SavedServers.Add(new SavedServer() { Name = serverName, Ip = serverIp, Port = serverPort, AuthToken = Guid.NewGuid().ToString() });
                         }
                     }
                     File.Delete(".\\servers");
                 }
                 else
                 {
-                    model.SavedServers.Add(new SavedServer() { Name = "local server", Ip = "127.0.0.1", Port = "11000", Token = Guid.NewGuid().ToString() });
+                    model.SavedServers.Add(new SavedServer() { Name = "local server", Ip = "127.0.0.1", Port = "11000", AuthToken = Guid.NewGuid().ToString() });
                 }
                 File.WriteAllText(FILE_NAME, JsonMapper.ToJson(model));
             }

--- a/NitroxClient/Persistence/PersistedClientData.cs
+++ b/NitroxClient/Persistence/PersistedClientData.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.IO;
+using NitroxClient.Persistence.Model;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using LitJson;
+
+namespace NitroxClient.Persistence
+{
+    public static class PersistedClientData
+    {
+        private static PersistedClientDataModel model = null;
+
+        private const string FILE_NAME = ".\\client.json";
+
+        private static void CheckSingleton()
+        {
+            if (model == null)
+            {
+                string text = File.ReadAllText(FILE_NAME);
+                model = JsonMapper.ToObject<PersistedClientDataModel>(text);
+            }
+        }
+
+        public static Guid GetToken(string ip, string port)
+        {
+            CheckSingleton();
+            foreach (SavedServer pair in model.SavedServers)
+            {
+                if (pair.Ip.Equals(ip) && pair.Port.Equals(port)) //Always use trusted members to the left a .Equals call. Don't compare potentially unsafe data; assume parameters might be null.
+                {
+                    return new Guid(pair.Token);
+                }
+            }
+            return Guid.Empty;
+        }
+
+        public static void EmplaceServer(string name, string ip, string port, Guid token)
+        {
+            CheckSingleton();
+            SavedServer savedServer = new SavedServer() { Name = name, Ip = ip, Port = port, Token = token.ToString() };
+            if(GetToken(savedServer.Ip, savedServer.Port) != Guid.Empty) //Some validation is better than no validation.
+            {
+                throw new Exception($"Failed to add '{ip}':'{port}' because there is already an entry for it.");
+            }
+            model.SavedServers.Add(savedServer);
+            File.WriteAllText(FILE_NAME, JsonMapper.ToJson(model));
+        }
+
+        public static List<SavedServer> GetServers()
+        {
+            CheckSingleton();
+            return model.SavedServers;
+        }
+
+        public static void InitalizeServerList()
+        {
+            if (!File.Exists(FILE_NAME))
+            {
+                model = new PersistedClientDataModel();
+                //Remove this regression scenario in later releases.
+                if(File.Exists(".\\servers"))
+                {
+                    using (StreamReader sr = new StreamReader(".\\servers"))
+                    {
+                        string line;
+                        while ((line = sr.ReadLine()) != null)
+                        {
+                            string[] lineData = line.Split('|');
+                            string serverName = lineData[0];
+                            string serverIp = lineData[1];
+                            string serverPort;
+                            if (lineData.Length == 3)
+                            {
+                                serverPort = lineData[2];
+                            }
+                            else
+                            {
+                                Match match = Regex.Match(serverIp, @"^(.*?)(?::(\d{3,5}))?$");
+                                serverIp = match.Groups[1].Value;
+                                serverPort = match.Groups[2].Success ? match.Groups[2].Value : "11000";
+                            }
+                            model.SavedServers.Add(new SavedServer() { Name = serverName, Ip = serverIp, Port = serverPort, Token = Guid.NewGuid().ToString() });
+                        }
+                    }
+                    File.Delete(".\\servers");
+                }
+                else
+                {
+                    model.SavedServers.Add(new SavedServer() { Name = "local server", Ip = "127.0.0.1", Port = "11000", Token = Guid.NewGuid().ToString() });
+                }
+                File.WriteAllText(FILE_NAME, JsonMapper.ToJson(model));
+            }
+        }
+
+        public static void RemoveServerByIndex(int index)
+        {
+            CheckSingleton();
+            if(model.SavedServers.Count > index)
+            {
+                model.SavedServers.RemoveAt(index);
+                File.WriteAllText(FILE_NAME, JsonMapper.ToJson(model));
+            }
+        }
+    }
+}

--- a/NitroxModel/MultiplayerSession/AuthenticationContext.cs
+++ b/NitroxModel/MultiplayerSession/AuthenticationContext.cs
@@ -6,19 +6,19 @@ namespace NitroxModel.MultiplayerSession
     [Serializable]
     public class AuthenticationContext
     {
-        public Guid Token { get; }
+        public Guid AuthToken { get; }
 
         public String Username { get; }
         public Optional<string> ServerPassword { get; }
 
-        public AuthenticationContext(Guid token, string username) : this(token, username, null)
+        public AuthenticationContext(Guid authToken, string username) : this(authToken, username, null)
         {
         }
 
-        public AuthenticationContext(Guid token, string username, string serverPassword)
+        public AuthenticationContext(Guid authToken, string username, string serverPassword)
         {
             Username = username;
-            Token = token;
+            AuthToken = authToken;
             ServerPassword = Optional.OfNullable(serverPassword);
         }
     }

--- a/NitroxModel/MultiplayerSession/AuthenticationContext.cs
+++ b/NitroxModel/MultiplayerSession/AuthenticationContext.cs
@@ -6,16 +6,19 @@ namespace NitroxModel.MultiplayerSession
     [Serializable]
     public class AuthenticationContext
     {
-        public string Username { get; }
+        public Guid Token { get; }
+
+        public String Username { get; }
         public Optional<string> ServerPassword { get; }
 
-        public AuthenticationContext(string username) : this(username, null)
+        public AuthenticationContext(Guid token, string username) : this(token, username, null)
         {
         }
 
-        public AuthenticationContext(string username, string serverPassword)
+        public AuthenticationContext(Guid token, string username, string serverPassword)
         {
             Username = username;
+            Token = token;
             ServerPassword = Optional.OfNullable(serverPassword);
         }
     }

--- a/NitroxModel/MultiplayerSession/MultiplayerSessionReservationState.cs
+++ b/NitroxModel/MultiplayerSession/MultiplayerSessionReservationState.cs
@@ -22,6 +22,9 @@ namespace NitroxModel.MultiplayerSession
 
         [Description("The server is using hardcore gamemode, player is dead.")]
         HARDCORE_PLAYER_DEAD = 1 << 4,
+
+        [Description("This username is already taken.")]
+        AUTHENTICATION_TOKEN_REJECTED = 1 << 5,
     }
 
     public static class MultiplayerSessionReservationStateExtensions

--- a/NitroxModel/MultiplayerSession/PlayerContext.cs
+++ b/NitroxModel/MultiplayerSession/PlayerContext.cs
@@ -9,15 +9,15 @@ namespace NitroxModel.MultiplayerSession
         public string PlayerName { get; }
         public bool WasBrandNewPlayer { get; }
         public PlayerSettings PlayerSettings { get; }
-        public Guid Token { get; }
+        public Guid AuthToken { get; }
 
-        public PlayerContext(string playerName, ushort playerId, bool wasBrandNewPlayer, PlayerSettings playerSettings, Guid token)
+        public PlayerContext(string playerName, ushort playerId, bool wasBrandNewPlayer, PlayerSettings playerSettings, Guid authToken)
         {
             PlayerId = playerId;
             PlayerName = playerName;
             WasBrandNewPlayer = wasBrandNewPlayer;
             PlayerSettings = playerSettings;
-            Token = token;
+            AuthToken = authToken;
         }
     }
 }

--- a/NitroxModel/MultiplayerSession/PlayerContext.cs
+++ b/NitroxModel/MultiplayerSession/PlayerContext.cs
@@ -9,13 +9,15 @@ namespace NitroxModel.MultiplayerSession
         public string PlayerName { get; }
         public bool WasBrandNewPlayer { get; }
         public PlayerSettings PlayerSettings { get; }
+        public Guid Token { get; }
 
-        public PlayerContext(string playerName, ushort playerId, bool wasBrandNewPlayer, PlayerSettings playerSettings)
+        public PlayerContext(string playerName, ushort playerId, bool wasBrandNewPlayer, PlayerSettings playerSettings, Guid token)
         {
             PlayerId = playerId;
             PlayerName = playerName;
             WasBrandNewPlayer = wasBrandNewPlayer;
             PlayerSettings = playerSettings;
+            Token = token;
         }
     }
 }

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -73,7 +73,7 @@ namespace NitroxServer.GameLogic
             }
 
             bool hasSeenPlayerBefore = player != null;
-            if (serverConfig.UseToken && hasSeenPlayerBefore && player.Token != authenticationContext.Token)
+            if (serverConfig.UseToken && hasSeenPlayerBefore && player.AuthToken != authenticationContext.AuthToken)
             {
                 MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.AUTHENTICATION_TOKEN_REJECTED;
                 return new MultiplayerSessionReservation(correlationId, rejectedState);
@@ -95,7 +95,7 @@ namespace NitroxServer.GameLogic
 
             ushort playerId = hasSeenPlayerBefore ? player.Id : ++currentPlayerId;
 
-            PlayerContext playerContext = new PlayerContext(playerName, playerId, !hasSeenPlayerBefore, playerSettings, authenticationContext.Token);
+            PlayerContext playerContext = new PlayerContext(playerName, playerId, !hasSeenPlayerBefore, playerSettings, authenticationContext.AuthToken);
             string reservationKey = Guid.NewGuid().ToString();
 
             reservations.Add(reservationKey, playerContext);
@@ -129,7 +129,7 @@ namespace NitroxServer.GameLogic
                     defaultPlayerStats,
                     new List<EquippedItemData>(),
                     new List<EquippedItemData>(),
-                    playerContext.Token);
+                    playerContext.AuthToken);
                 allPlayersByName[playerContext.PlayerName] = player;
             }
 

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -73,13 +73,11 @@ namespace NitroxServer.GameLogic
             }
 
             bool hasSeenPlayerBefore = player != null;
-//#if RELEASE
-            if (hasSeenPlayerBefore && player.Token != authenticationContext.Token)
+            if (serverConfig.UseToken && hasSeenPlayerBefore && player.Token != authenticationContext.Token)
             {
                 MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.AUTHENTICATION_TOKEN_REJECTED;
                 return new MultiplayerSessionReservation(correlationId, rejectedState);
             }
-//#endif
 
             if (reservedPlayerNames.Contains(playerName))
             {

--- a/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
@@ -42,7 +42,7 @@ namespace NitroxServer.GameLogic.Players
         public bool IsPermaDeath { get; set; }
 
         [JsonProperty, ProtoMember(11)]
-        public Guid Token { get; set; }
+        public Guid AuthToken { get; set; }
 
         public Player ToPlayer()
         {
@@ -58,7 +58,7 @@ namespace NitroxServer.GameLogic.Players
                               CurrentStats,
                               EquippedItems,
                               Modules,
-                              Token);
+                              AuthToken);
         }
 
         public static PersistedPlayerData FromPlayer(Player player)
@@ -75,7 +75,7 @@ namespace NitroxServer.GameLogic.Players
                 Permissions = player.Permissions,
                 NitroxId = player.GameObjectId,
                 IsPermaDeath = player.IsPermaDeath,
-                Token = player.Token
+                AuthToken = player.AuthToken
             };
         }
     }

--- a/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
@@ -40,6 +41,9 @@ namespace NitroxServer.GameLogic.Players
         [JsonProperty, ProtoMember(10)]
         public bool IsPermaDeath { get; set; }
 
+        [JsonProperty, ProtoMember(11)]
+        public Guid Token { get; set; }
+
         public Player ToPlayer()
         {
             return new Player(Id,
@@ -53,7 +57,8 @@ namespace NitroxServer.GameLogic.Players
                               Permissions,
                               CurrentStats,
                               EquippedItems,
-                              Modules);
+                              Modules,
+                              Token);
         }
 
         public static PersistedPlayerData FromPlayer(Player player)
@@ -69,7 +74,8 @@ namespace NitroxServer.GameLogic.Players
                 SubRootId = player.SubRootId.OrElse(null),
                 Permissions = player.Permissions,
                 NitroxId = player.GameObjectId,
-                IsPermaDeath = player.IsPermaDeath
+                IsPermaDeath = player.IsPermaDeath,
+                Token = player.Token
             };
         }
     }

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
@@ -27,9 +28,10 @@ namespace NitroxServer
         public Perms Permissions { get; set; }
         public PlayerStatsData Stats { get; set; }
         public NitroxVector3? LastStoredPosition { get; set; }
+        public Guid Token { get; set; }
 
         public Player(ushort id, string name, bool isPermaDeath, PlayerContext playerContext, NitroxConnection connection, NitroxVector3 position, NitroxId playerId, Optional<NitroxId> subRootId, Perms perms, PlayerStatsData stats, IEnumerable<EquippedItemData> equippedItems,
-                      IEnumerable<EquippedItemData> modules)
+                      IEnumerable<EquippedItemData> modules, Guid token)
         {
             Id = id;
             Name = name;
@@ -45,6 +47,7 @@ namespace NitroxServer
             this.equippedItems = new ThreadSafeCollection<EquippedItemData>(equippedItems);
             this.modules = new ThreadSafeCollection<EquippedItemData>(modules);
             visibleCells = new ThreadSafeCollection<AbsoluteEntityCell>(new HashSet<AbsoluteEntityCell>(), false);
+            Token = token;
         }
 
         public static bool operator ==(Player left, Player right)

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -28,10 +28,10 @@ namespace NitroxServer
         public Perms Permissions { get; set; }
         public PlayerStatsData Stats { get; set; }
         public NitroxVector3? LastStoredPosition { get; set; }
-        public Guid Token { get; set; }
+        public Guid AuthToken { get; set; }
 
         public Player(ushort id, string name, bool isPermaDeath, PlayerContext playerContext, NitroxConnection connection, NitroxVector3 position, NitroxId playerId, Optional<NitroxId> subRootId, Perms perms, PlayerStatsData stats, IEnumerable<EquippedItemData> equippedItems,
-                      IEnumerable<EquippedItemData> modules, Guid token)
+                      IEnumerable<EquippedItemData> modules, Guid authToken)
         {
             Id = id;
             Name = name;
@@ -47,7 +47,7 @@ namespace NitroxServer
             this.equippedItems = new ThreadSafeCollection<EquippedItemData>(equippedItems);
             this.modules = new ThreadSafeCollection<EquippedItemData>(modules);
             visibleCells = new ThreadSafeCollection<AbsoluteEntityCell>(new HashSet<AbsoluteEntityCell>(), false);
-            Token = token;
+            AuthToken = authToken;
         }
 
         public static bool operator ==(Player left, Player right)

--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -90,6 +90,12 @@ namespace NitroxServer.Serialization
         [PropertyDescription("Recommended to keep at 0.1f which is the default starting value. If set to 0 then new players are cured by default.")]
         public float DefaultInfectionValue { get; set; } = 0.1f;
 
+#if RELEASE
+        public bool UseToken { get; set; } = true;
+#else
+        public bool UseToken { get; set; } = false;
+#endif
+
         public bool IsHardcore => GameMode == ServerGameMode.HARDCORE;
         public bool IsPasswordRequired => ServerPassword != string.Empty;
         public PlayerStatsData DefaultPlayerStats => new PlayerStatsData(DefaultOxygenValue, DefaultMaxOxygenValue, DefaultHealthValue, DefaultHungerValue, DefaultThirstValue, DefaultInfectionValue);

--- a/NitroxTest/Client/Communication/MultiplayerSessionTests/TestConstants.cs
+++ b/NitroxTest/Client/Communication/MultiplayerSessionTests/TestConstants.cs
@@ -15,7 +15,7 @@ namespace NitroxTest.Client.Communication.MultiplayerSessionTests
         public const string TEST_CORRELATION_ID = "CORRELATED";
         public const int TEST_MAX_PLAYER_CONNECTIONS = 100;
         public const MultiplayerSessionReservationState TEST_REJECTION_STATE = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.UNIQUE_PLAYER_NAME_CONSTRAINT_VIOLATED;
-        public static readonly AuthenticationContext TEST_AUTHENTICATION_CONTEXT = new AuthenticationContext(TEST_PLAYER_NAME);
+        public static readonly AuthenticationContext TEST_AUTHENTICATION_CONTEXT = new AuthenticationContext(new System.Guid(), TEST_PLAYER_NAME);
         public static readonly MultiplayerSessionPolicy TEST_SESSION_POLICY = new MultiplayerSessionPolicy(TEST_CORRELATION_ID, false, TEST_MAX_PLAYER_CONNECTIONS, false);
         public static readonly PlayerSettings TEST_PLAYER_SETTINGS = new PlayerSettings(RandomColorGenerator.GenerateColor());
         public static readonly IMultiplayerSessionConnectionState TEST_CONNECTION_STATE = Substitute.For<IMultiplayerSessionConnectionState>();

--- a/NitroxTest/Serialization/WorldPersistenceTest.cs
+++ b/NitroxTest/Serialization/WorldPersistenceTest.cs
@@ -301,7 +301,7 @@ namespace NitroxTest.Serialization
                     Assert.AreEqual(playerData.Permissions, playerDataAfter.Permissions, "PlayerData.Players.Permissions is not equal");
                     Assert.AreEqual(playerData.NitroxId, playerDataAfter.NitroxId, "PlayerData.Players.NitroxId is not equal");
                     Assert.AreEqual(playerData.IsPermaDeath, playerDataAfter.IsPermaDeath, "PlayerData.Players.IsFurniture is not equal");
-                    Assert.AreEqual(playerData.Token, playerDataAfter.Token, "PlayerData.Players.Token is not equal");
+                    Assert.AreEqual(playerData.AuthToken, playerDataAfter.AuthToken, "PlayerData.Players.Token is not equal");
                 }
             }
         }
@@ -386,7 +386,8 @@ namespace NitroxTest.Serialization
                             SubRootId = null,
                             CurrentStats = new PlayerStatsData(45, 45, 40, 39, 28, 1),
                             EquippedItems = new List<EquippedItemData>(0),
-                            Modules = new List<EquippedItemData>(0)
+                            Modules = new List<EquippedItemData>(0),
+                            AuthToken = Guid.NewGuid()
                         },
                         new PersistedPlayerData()
                         {
@@ -406,7 +407,8 @@ namespace NitroxTest.Serialization
                             Modules = new List<EquippedItemData>()
                             {
                                 new EquippedItemData(new NitroxId(), new NitroxId(), new byte[]{0x35, 0xD0}, "Module1", new NitroxTechType("Compass"))
-                            }
+                            },
+                            AuthToken = Guid.NewGuid()
                         }
                     }
                 },

--- a/NitroxTest/Serialization/WorldPersistenceTest.cs
+++ b/NitroxTest/Serialization/WorldPersistenceTest.cs
@@ -301,6 +301,7 @@ namespace NitroxTest.Serialization
                     Assert.AreEqual(playerData.Permissions, playerDataAfter.Permissions, "PlayerData.Players.Permissions is not equal");
                     Assert.AreEqual(playerData.NitroxId, playerDataAfter.NitroxId, "PlayerData.Players.NitroxId is not equal");
                     Assert.AreEqual(playerData.IsPermaDeath, playerDataAfter.IsPermaDeath, "PlayerData.Players.IsFurniture is not equal");
+                    Assert.AreEqual(playerData.Token, playerDataAfter.Token, "PlayerData.Players.Token is not equal");
                 }
             }
         }


### PR DESCRIPTION
I need the team's help to address the FIXME and regression issue in ShowAddServerWindow(). The regression issue is that users who have the 3 piped or 2 piped format will not store the token subsequently.