### PR TITLE
Moved global modules to sync for all players

### DIFF
--- a/NitroxClient/GameLogic/EquipmentSlots.cs
+++ b/NitroxClient/GameLogic/EquipmentSlots.cs
@@ -10,13 +10,23 @@ using NitroxModel.Helper;
 using NitroxModel.Logger;
 using NitroxModel.Packets;
 using NitroxModel_Subnautica.DataStructures;
-using NitroxModel_Subnautica.Helper;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic
 {
     public class EquipmentSlots
     {
+        private List<EquipmentType> ApplicableEquipmentTypes { get; } = new List<EquipmentType>()
+        {
+            EquipmentType.CyclopsModule,
+            EquipmentType.SeamothModule,
+            EquipmentType.ExosuitModule,
+            EquipmentType.ExosuitArm,
+            EquipmentType.NuclearReactor,
+            EquipmentType.BatteryCharger,
+            EquipmentType.PowerCellCharger,
+            EquipmentType.DecoySlot
+        };
         private readonly IPacketSender packetSender;
 
         public EquipmentSlots(IPacketSender packetSender)
@@ -53,7 +63,13 @@ namespace NitroxClient.GameLogic
                 return;
             }
 
-            ModuleAdded moduleAdded = new ModuleAdded(equippedItem);
+            bool playerModule = true;
+            if (ApplicableEquipmentTypes.Contains(Equipment.GetSlotType(slot)))
+            {
+                playerModule = false;
+            }
+
+            ModuleAdded moduleAdded = new ModuleAdded(equippedItem, playerModule);
             packetSender.Send(moduleAdded);
             pickupable.gameObject.transform.SetParent(parent);
         }
@@ -80,7 +96,13 @@ namespace NitroxClient.GameLogic
                 packetSender.Send(vehicleChildInteractiveData);
             }
 
-            ModuleRemoved moduleRemoved = new ModuleRemoved(ownerId, slot, itemId);
+            bool playerModule = true;
+            if (ApplicableEquipmentTypes.Contains(Equipment.GetSlotType(slot)))
+            {
+                playerModule = false;
+            }
+
+            ModuleRemoved moduleRemoved = new ModuleRemoved(ownerId, slot, itemId, playerModule);
             packetSender.Send(moduleRemoved);
         }
 

--- a/NitroxModel/Packets/ModuleAdded.cs
+++ b/NitroxModel/Packets/ModuleAdded.cs
@@ -7,15 +7,17 @@ namespace NitroxModel.Packets
     public class ModuleAdded : Packet
     {
         public EquippedItemData EquippedItemData { get; }
+        public bool PlayerModule { get; }
 
-        public ModuleAdded(EquippedItemData equippedItemData)
+        public ModuleAdded(EquippedItemData equippedItemData, bool playerModule)
         {
             EquippedItemData = equippedItemData;
+            PlayerModule = playerModule;
         }
 
         public override string ToString()
         {
-            return "[ModuleAdded EquippedItemData: " + EquippedItemData + " ]";
+            return $"[ModuleAdded EquippedItemData: {EquippedItemData}, PlayerModule: {PlayerModule}]";
         }
     }
 }

--- a/NitroxModel/Packets/ModuleRemoved.cs
+++ b/NitroxModel/Packets/ModuleRemoved.cs
@@ -9,17 +9,19 @@ namespace NitroxModel.Packets
         public NitroxId OwnerId { get; }
         public string Slot { get; }
         public NitroxId ItemId { get; }
+        public bool PlayerModule { get; }
 
-        public ModuleRemoved(NitroxId ownerId, string slot, NitroxId itemId)
+        public ModuleRemoved(NitroxId ownerId, string slot, NitroxId itemId, bool playerModule)
         {
             OwnerId = ownerId;
             Slot = slot;
             ItemId = itemId;
+            PlayerModule = playerModule;
         }
 
         public override string ToString()
         {
-            return "[ModuleRemoved ownerId: " + OwnerId + " Slot: " + Slot + " itemId: " + ItemId + "]";
+            return $"[ModuleRemoved OwnerId: {OwnerId}, Slot: {Slot}, ItemId: {ItemId}, PlayerModule: {PlayerModule}]";
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/ModuleAddedProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ModuleAddedProcessor.cs
@@ -1,21 +1,31 @@
 ﻿using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Items;
 
 namespace NitroxServer.Communication.Packets.Processors
 {
     class ModuleAddedProcessor : AuthenticatedPacketProcessor<ModuleAdded>
     {
         private readonly PlayerManager playerManager;
+        private readonly InventoryManager inventoryManager;
 
-        public ModuleAddedProcessor(PlayerManager playerManager)
+        public ModuleAddedProcessor(PlayerManager playerManager, InventoryManager inventoryManager)
         {
             this.playerManager = playerManager;
+            this.inventoryManager = inventoryManager;
         }
 
         public override void Process(ModuleAdded packet, Player player)
         {
-            player.AddModule(packet.EquippedItemData);
+            if (packet.PlayerModule)
+            {
+                player.AddModule(packet.EquippedItemData);
+            }
+            else
+            {
+                inventoryManager.ModuleAdded(packet.EquippedItemData);
+            }
             playerManager.SendPacketToOtherPlayers(packet, player);
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/ModuleRemovedProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ModuleRemovedProcessor.cs
@@ -1,21 +1,32 @@
-﻿using NitroxModel.Packets;
+﻿using System;
+using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Items;
 
 namespace NitroxServer.Communication.Packets.Processors
 {
     class ModuleRemovedProcessor : AuthenticatedPacketProcessor<ModuleRemoved>
     {
         private readonly PlayerManager playerManager;
+        private readonly InventoryManager inventoryManager;
 
-        public ModuleRemovedProcessor(PlayerManager playerManager)
+        public ModuleRemovedProcessor(PlayerManager playerManager, InventoryManager inventoryManager)
         {
             this.playerManager = playerManager;
+            this.inventoryManager = inventoryManager;
         }
 
         public override void Process(ModuleRemoved packet, Player player)
         {
-            player.RemoveModule(packet.ItemId);
+            if (packet.PlayerModule)
+            {
+                player.RemoveModule(packet.ItemId);
+            }
+            else
+            {
+                inventoryManager.ModuleRemoved(packet.ItemId);
+            }
             playerManager.SendPacketToOtherPlayers(packet, player);
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -67,7 +67,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 world.EscapePodManager.GetEscapePods(),
                 assignedEscapePodId,
                 equippedItems,
-                GetModulesToSync(world.InventoryManager.GetAllModules(), player.GetModules()),
+                GetAllModules(world.InventoryManager.GetAllModules(), player.GetModules()),
                 world.BaseManager.GetBasePiecesForNewlyConnectedPlayer(),
                 vehicles,
                 world.InventoryManager.GetAllInventoryItems(),
@@ -105,7 +105,7 @@ namespace NitroxServer.Communication.Packets.Processors
             return playerData;
         }
 
-        private List<EquippedItemData> GetModulesToSync(ICollection<EquippedItemData> globalModules, List<EquippedItemData> playerModules)
+        private List<EquippedItemData> GetAllModules(ICollection<EquippedItemData> globalModules, List<EquippedItemData> playerModules)
         {
             List<EquippedItemData> modulesToSync = new List<EquippedItemData>();
             modulesToSync.AddRange(globalModules);

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -67,7 +67,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 world.EscapePodManager.GetEscapePods(),
                 assignedEscapePodId,
                 equippedItems,
-                player.GetModules(),
+                GetModulesToSync(world.InventoryManager.GetAllModules(), player.GetModules()),
                 world.BaseManager.GetBasePiecesForNewlyConnectedPlayer(),
                 vehicles,
                 world.InventoryManager.GetAllInventoryItems(),
@@ -103,6 +103,14 @@ namespace NitroxServer.Communication.Packets.Processors
             }
 
             return playerData;
+        }
+
+        private List<EquippedItemData> GetModulesToSync(ICollection<EquippedItemData> globalModules, List<EquippedItemData> playerModules)
+        {
+            List<EquippedItemData> modulesToSync = new List<EquippedItemData>();
+            modulesToSync.AddRange(globalModules);
+            modulesToSync.AddRange(playerModules);
+            return modulesToSync;
         }
     }
 }

--- a/NitroxServer/GameLogic/Items/InventoryData.cs
+++ b/NitroxServer/GameLogic/Items/InventoryData.cs
@@ -15,18 +15,22 @@ namespace NitroxServer.GameLogic.Items
         [JsonProperty, ProtoMember(2)]
         public List<ItemData> StorageSlotItems = new List<ItemData>();
 
-        public static InventoryData From(IEnumerable<ItemData> inventoryItems, IEnumerable<ItemData> storageSlotItems)
+        [JsonProperty, ProtoMember(3)]
+        public List<EquippedItemData> Modules { get; set; } = new List<EquippedItemData>();
+
+        public static InventoryData From(IEnumerable<ItemData> inventoryItems, IEnumerable<ItemData> storageSlotItems, IEnumerable<EquippedItemData> modules)
         {
             return new InventoryData
             {
                 InventoryItems = inventoryItems.ToList(),
-                StorageSlotItems = storageSlotItems.ToList()
+                StorageSlotItems = storageSlotItems.ToList(),
+                Modules = modules.ToList()
             };
         }
 
         public override string ToString()
         {
-            return $"[{nameof(InventoryData)} - {nameof(InventoryItems)}: {InventoryItems.Count}, {nameof(StorageSlotItems)}: {StorageSlotItems.Count}]";
+            return $"[{nameof(InventoryData)} - {nameof(InventoryItems)}: {InventoryItems.Count}, {nameof(StorageSlotItems)}: {StorageSlotItems.Count}, {nameof(Modules)}: {Modules.Count}]";
         }
     }
 }

--- a/NitroxServer/GameLogic/Items/InventoryManager.cs
+++ b/NitroxServer/GameLogic/Items/InventoryManager.cs
@@ -10,11 +10,13 @@ namespace NitroxServer.GameLogic.Items
     {
         private readonly ThreadSafeDictionary<NitroxId, ItemData> inventoryItemsById;
         private readonly ThreadSafeDictionary<NitroxId, ItemData> storageSlotItemsByContainerId;
+        private readonly ThreadSafeDictionary<NitroxId, EquippedItemData> modulesByContainerId;
 
-        public InventoryManager(List<ItemData> inventoryItems, List<ItemData> storageSlotItems)
+        public InventoryManager(List<ItemData> inventoryItems, List<ItemData> storageSlotItems, List<EquippedItemData> modules)
         {
             inventoryItemsById = new ThreadSafeDictionary<NitroxId, ItemData>(inventoryItems.ToDictionary(item => item.ItemId), false);
             storageSlotItemsByContainerId = new ThreadSafeDictionary<NitroxId, ItemData>(storageSlotItems.ToDictionary(item => item.ContainerId), false);
+            modulesByContainerId = new ThreadSafeDictionary<NitroxId, EquippedItemData>(modules.ToDictionary(module => module.ContainerId), false);
         }
 
         public void ItemAdded(ItemData itemData)
@@ -46,6 +48,21 @@ namespace NitroxServer.GameLogic.Items
         public ICollection<ItemData> GetAllStorageSlotItems()
         {
             return storageSlotItemsByContainerId.Values;
+        }
+
+        public void ModuleAdded(EquippedItemData itemData)
+        {
+            modulesByContainerId[itemData.ContainerId] = itemData;
+        }
+
+        public bool ModuleRemoved(NitroxId ownerId)
+        {
+            return modulesByContainerId.Remove(ownerId);
+        }
+
+        public ICollection<EquippedItemData> GetAllModules()
+        {
+            return modulesByContainerId.Values;
         }
     }
 }

--- a/NitroxServer/Serialization/World/PersistedWorldData.cs
+++ b/NitroxServer/Serialization/World/PersistedWorldData.cs
@@ -36,7 +36,7 @@ namespace NitroxServer.Serialization.World
                     ParsedBatchCells = world.BatchEntitySpawner.SerializableParsedBatches,
                     ServerStartTime = world.TimeKeeper.ServerStartTime,
                     VehicleData = VehicleData.From(world.VehicleManager.GetVehicles()),
-                    InventoryData = InventoryData.From(world.InventoryManager.GetAllInventoryItems(), world.InventoryManager.GetAllStorageSlotItems()),
+                    InventoryData = InventoryData.From(world.InventoryManager.GetAllInventoryItems(), world.InventoryManager.GetAllStorageSlotItems(), world.InventoryManager.GetAllModules()),
                     GameData = GameData.From(world.GameData.PDAState, world.GameData.StoryGoals, world.EventTriggerer),
                     EscapePodData = EscapePodData.From(world.EscapePodManager.GetEscapePods()),
                     Seed = world.Seed

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -150,7 +150,7 @@ namespace NitroxServer.Serialization.World
                         StoryGoals = new StoryGoalData(),
                         StoryTiming = new StoryTimingData()
                     },
-                    InventoryData = InventoryData.From(new List<ItemData>(), new List<ItemData>()),
+                    InventoryData = InventoryData.From(new List<ItemData>(), new List<ItemData>(), new List<EquippedItemData>()),
                     VehicleData = VehicleData.From(new List<VehicleModel>()),
                     ParsedBatchCells = new List<NitroxInt3>(),
                     ServerStartTime = DateTime.Now
@@ -183,7 +183,7 @@ namespace NitroxServer.Serialization.World
 
                 BaseManager = new BaseManager(pWorldData.BaseData.PartiallyConstructedPieces, pWorldData.BaseData.CompletedBasePieceHistory),
 
-                InventoryManager = new InventoryManager(pWorldData.WorldData.InventoryData.InventoryItems, pWorldData.WorldData.InventoryData.StorageSlotItems),
+                InventoryManager = new InventoryManager(pWorldData.WorldData.InventoryData.InventoryItems, pWorldData.WorldData.InventoryData.StorageSlotItems, pWorldData.WorldData.InventoryData.Modules),
 
                 EscapePodManager = new EscapePodManager(pWorldData.WorldData.EscapePodData.EscapePods, randomStart, seed),
 

--- a/NitroxTest/Serialization/WorldPersistenceTest.cs
+++ b/NitroxTest/Serialization/WorldPersistenceTest.cs
@@ -127,6 +127,17 @@ namespace NitroxTest.Serialization
                     Assert.AreEqual(itemData.ItemId, itemDataAfter.ItemId, "WorldData.InventoryData.StorageSlotItems.ItemId is not equal");
                     Assert.IsTrue(itemData.SerializedData.SequenceEqual(itemDataAfter.SerializedData), "WorldData.InventoryData.StorageSlotItems.SerializedData is not equal");
                 }
+
+                Assert.AreEqual(worldData.WorldData.InventoryData.Modules.Count, worldDataAfter.WorldData.InventoryData.Modules.Count, "WorldData.InventoryData.Modules.Count is not equal");
+                for (int index = 0; index < worldData.WorldData.InventoryData.Modules.Count; index++)
+                {
+                    EquippedItemData equippedItemData = worldData.WorldData.InventoryData.Modules[index];
+                    EquippedItemData equippedItemDataAfter = worldDataAfter.WorldData.InventoryData.Modules[index];
+
+                    Assert.AreEqual(equippedItemData.ContainerId, equippedItemDataAfter.ContainerId, "WorldData.InventoryData.Modules.ContainerId is not equal");
+                    Assert.AreEqual(equippedItemData.ItemId, equippedItemDataAfter.ItemId, "WorldData.InventoryData.Modules.ItemId is not equal");
+                    Assert.IsTrue(equippedItemData.SerializedData.SequenceEqual(equippedItemDataAfter.SerializedData), "WorldData.InventoryData.Modules.SerializedData is not equal");
+                }
             }
         }
 


### PR DESCRIPTION
Partly fixez #1406

Moves module tracking to global level so all players sync the same modules
Hopefully this will also help reduce the depth explosion issues people were having.

In theory I believe that a player module should never be added as they are tracked as PlayerEquipment but I thought I would leave it in just in case I had missed some edge case during testing, happy to remove if others believe this is also the case.