### PR TITLE
Basic Banning Implementation

### DIFF
--- a/NitroxServer/Banning/IpBanning.cs
+++ b/NitroxServer/Banning/IpBanning.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NitroxServer.Banning
+{
+    public static class IpBanning
+    {
+        public static List<string> BannedIPs = new List<string>();
+        public static string BanFilePath { get; } = Path.GetFullPath(Path.Combine(Environment.GetEnvironmentVariable("NITROX_LAUNCHER_PATH") ?? "", "Player Bans.txt"));
+
+        public static void Load()
+        {
+            if (File.Exists(BanFilePath))
+            {
+                var fileStrings = File.ReadAllLines(BanFilePath);
+                BannedIPs.AddRange(fileStrings);
+
+            }
+        }
+
+        public static void Save()
+        {
+            File.WriteAllLines(BanFilePath, BannedIPs);
+        }
+
+        public static void AddNewBan(System.Net.IPAddress address)
+        {
+            if (!BannedIPs.Contains(address.ToString())){
+                BannedIPs.Add(address.ToString());
+                Save();
+            }
+        }
+
+        public static void AddNewBan(string address)
+        {
+            if (!BannedIPs.Contains(address))
+            {
+                BannedIPs.Add(address);
+                Save();
+            }
+        }
+
+        public static void RemoveBan(System.Net.IPAddress address)
+        {
+            if (BannedIPs.Contains(address.ToString()))
+            {
+                BannedIPs.Remove(address.ToString());
+                Save();
+            }
+        }
+
+        public static void RemoveBan(string address)
+        {
+            if (BannedIPs.Contains(address))
+            {
+                BannedIPs.Remove(address);
+                Save();
+            }
+        }
+    }
+}

--- a/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
+++ b/NitroxServer/Communication/NetworkingLayer/LiteNetLib/LiteNetLibServer.cs
@@ -79,7 +79,7 @@ namespace NitroxServer.Communication.NetworkingLayer.LiteNetLib
 
         public void OnConnectionRequest(ConnectionRequest request)
         {
-            if (server.PeersCount < maxConn)
+            if (server.PeersCount < maxConn && !Banning.IpBanning.BannedIPs.Contains(request.RemoteEndPoint.Address.ToString()))
             {
                 request.AcceptIfKey("nitrox");
             }

--- a/NitroxServer/Communication/Packets/Processors/MultiplayerSessionReservationRequestProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/MultiplayerSessionReservationRequestProcessor.cs
@@ -29,7 +29,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 authenticationContext,
                 correlationId);
 
-            Log.Info($"Reservation processed successfully: Username: {packet.AuthenticationContext.Username} - {reservation}");
+            Log.Info($"Reservation processed successfully: Username: {packet.AuthenticationContext.Username} - {reservation} - IP Address: {connection.Endpoint.Address.ToString()}");
 
             connection.SendPacket(reservation);
         }

--- a/NitroxServer/ConsoleCommands/BanIpCommand.cs
+++ b/NitroxServer/ConsoleCommands/BanIpCommand.cs
@@ -1,0 +1,74 @@
+﻿using System.CodeDom;
+using System.Collections.Generic;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.Packets;
+using NitroxModel.Serialization;
+using NitroxModel.Server;
+using NitroxServer.ConsoleCommands.Abstract;
+using NitroxServer.ConsoleCommands.Abstract.Type;
+using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Entities;
+using NitroxServer.Serialization;
+
+namespace NitroxServer.ConsoleCommands
+{
+    internal class BanIpCommand : Command
+    {
+        private readonly EntitySimulation entitySimulation;
+        private readonly PlayerManager playerManager;
+
+        public BanIpCommand(PlayerManager playerManager, EntitySimulation entitySimulation) : base("ban", Perms.MODERATOR, "ban a player from the server", true)
+        {
+            this.playerManager = playerManager;
+            this.entitySimulation = entitySimulation;
+
+            AddParameter(new TypePlayer("name/ip", true));
+        }
+
+        protected override void Execute(CallArgs args)
+        {
+            System.Net.IPAddress temp;
+            if (!System.Net.IPAddress.TryParse(args.Get(0), out temp))
+            {
+                Player playerToBan = args.Get<Player>(0);
+                playerToBan.SendPacket(new PlayerKicked(args.GetTillEnd(1)));
+                playerManager.PlayerDisconnected(playerToBan.connection);
+
+                List<SimulatedEntity> revokedEntities = entitySimulation.CalculateSimulationChangesFromPlayerDisconnect(playerToBan);
+                if (revokedEntities.Count > 0)
+                {
+                    SimulationOwnershipChange ownershipChange = new SimulationOwnershipChange(revokedEntities);
+                    playerManager.SendPacketToAllPlayers(ownershipChange);
+                }
+
+                Banning.IpBanning.AddNewBan(playerToBan.connection.Endpoint.Address.ToString());
+                playerManager.SendPacketToOtherPlayers(new Disconnect(playerToBan.Id), playerToBan);
+                SendMessage(args.Sender, $"The player {playerToBan.Name} has been banned");
+            }
+            else
+            {
+                foreach (Player playerToBan in playerManager.GetAllPlayers())
+                {
+                    if (playerToBan.connection.Endpoint.Address.ToString() == temp.ToString())
+                    {
+                        playerToBan.SendPacket(new PlayerKicked(args.GetTillEnd(1)));
+                        playerManager.PlayerDisconnected(playerToBan.connection);
+
+                        List<SimulatedEntity> revokedEntities = entitySimulation.CalculateSimulationChangesFromPlayerDisconnect(playerToBan);
+                        if (revokedEntities.Count > 0)
+                        {
+                            SimulationOwnershipChange ownershipChange = new SimulationOwnershipChange(revokedEntities);
+                            playerManager.SendPacketToAllPlayers(ownershipChange);
+                        }
+
+                        Banning.IpBanning.AddNewBan(playerToBan.connection.Endpoint.Address.ToString());
+                        playerManager.SendPacketToOtherPlayers(new Disconnect(playerToBan.Id), playerToBan);
+                    }
+                }
+
+                Banning.IpBanning.AddNewBan(temp.ToString());
+            }
+        }
+    }
+}

--- a/NitroxServer/ConsoleCommands/UnBanPlayer.cs
+++ b/NitroxServer/ConsoleCommands/UnBanPlayer.cs
@@ -1,0 +1,44 @@
+﻿using System.CodeDom;
+using System.Collections.Generic;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.Packets;
+using NitroxModel.Serialization;
+using NitroxModel.Server;
+using NitroxServer.ConsoleCommands.Abstract;
+using NitroxServer.ConsoleCommands.Abstract.Type;
+using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Entities;
+using NitroxServer.Serialization;
+
+namespace NitroxServer.ConsoleCommands
+{
+    internal class UnBanIpCommand : Command
+    {
+        private readonly EntitySimulation entitySimulation;
+        private readonly PlayerManager playerManager;
+
+        public UnBanIpCommand(PlayerManager playerManager, EntitySimulation entitySimulation) : base("unban", Perms.MODERATOR, "unban a player from the server", true)
+        {
+            this.playerManager = playerManager;
+            this.entitySimulation = entitySimulation;
+
+            AddParameter(new TypePlayer("name/ip", true));
+        }
+
+        protected override void Execute(CallArgs args)
+        {
+            System.Net.IPAddress temp;
+            if (!System.Net.IPAddress.TryParse(args.Get(0), out temp))
+            {
+                Player player = args.Get<Player>(0);
+                Banning.IpBanning.RemoveBan(player.connection.Endpoint.Address.ToString());
+                SendMessage(args.Sender, $"The player {player.Name} has been unbanned");
+            }
+            else
+            {
+                Banning.IpBanning.RemoveBan(temp.ToString());
+            }
+        }
+    }
+}

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -63,6 +63,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Banning\IpBanning.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibConnection.cs" />
     <Compile Include="Communication\NetworkingLayer\LiteNetLib\LiteNetLibServer.cs" />
     <Compile Include="Communication\NetworkingLayer\NitroxConnection.cs" />
@@ -138,6 +139,7 @@
     <Compile Include="ConsoleCommands\Abstract\Type\TypeString.cs" />
     <Compile Include="ConsoleCommands\AutosaveCommand.cs" />
     <Compile Include="ConsoleCommands\BackCommand.cs" />
+    <Compile Include="ConsoleCommands\BanIpCommand.cs" />
     <Compile Include="ConsoleCommands\ChangeServerGamemodeCommand.cs" />
     <Compile Include="ConsoleCommands\ChangeServerPasswordCommand.cs" />
     <Compile Include="ConsoleCommands\ConfigCommand.cs" />
@@ -149,6 +151,7 @@
     <Compile Include="ConsoleCommands\RestartCommand.cs" />
     <Compile Include="ConsoleCommands\SwapSerializerCommand.cs" />
     <Compile Include="ConsoleCommands\TeleportCommand.cs" />
+    <Compile Include="ConsoleCommands\UnBanPlayer.cs" />
     <Compile Include="ConsoleCommands\UpgradeCommand.cs" />
     <Compile Include="ConsoleCommands\WarpCommand.cs" />
     <Compile Include="ConsoleCommands\WhoisCommand.cs" />
@@ -258,5 +261,6 @@
       <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Timers;
 using NitroxModel.Logger;
 using NitroxServer.Serialization.World;
@@ -31,7 +31,7 @@ namespace NitroxServer
             this.serverConfig = serverConfig;
             this.server = server;
             this.world = world;
-
+            Banning.IpBanning.Load();
             Instance = this;
 
             saveTimer = new Timer();


### PR DESCRIPTION
Added very basic server banning based off a file in the root directory called "Player Bans.txt" the file can be modified and loaded if the server is closed. Otherwise two commands have been added to manage it "ban" and "unban". The command "ban" can be used if the client is connected or not connected to the server. If connected the server owner can use the command to ban them by username, otherwise they can use the IP. the unban command can only be used with the IP address.



NitroxServer.Communication.Packets.Processors.MultiplayerSessionReservationRequestProcessor
To append the IP to the reservation request.

 NitroxServer.Communication.NetworkingLayer.LiteNetLib.LiteNetLibServer 
 Adds a condtion that checks if the IP Is in the ban list

Added IPBanning.cs
A static class used for managing bans
Runs at NitroxServer.Server construction
-- Banning.IpBanning.Load();


Adds two console commands
Ban (player/IP)
unban (player/ip)

These commands modify a file created at runtime in the root directory
Player bans.txt

