### PR TITLE
Fixed a little issue with the DiscordRP player count

### DIFF
--- a/NitroxClient/GameLogic/PlayerManager.cs
+++ b/NitroxClient/GameLogic/PlayerManager.cs
@@ -60,9 +60,9 @@ namespace NitroxClient.GameLogic
             GameObject remotePlayerBody = CloneLocalPlayerBodyPrototype();
             RemotePlayer remotePlayer = new RemotePlayer(remotePlayerBody, playerContext, equippedTechTypes, playerModelManager);
 
-            DiscordRPController.Main.UpdatePlayerCount(GetTotalPlayerCount());
-
             playersById.Add(remotePlayer.PlayerId, remotePlayer);
+
+            DiscordRPController.Main.UpdatePlayerCount(GetTotalPlayerCount());
 
             return remotePlayer;
         }


### PR DESCRIPTION
As you can see, the `DiscordRPController.Main.UpdatePlayerCount(GetTotalPlayerCount());` used to be called before the new Player is added to playersById, meaning that DiscordRP doesn't count the new player.