### PR TITLE
Fixed warp command when inside cyclops

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/PlayerTeleportedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerTeleportedProcessor.cs
@@ -1,21 +1,32 @@
-﻿using NitroxClient.Communication.Abstract;
-using NitroxClient.Communication.Packets.Processors.Abstract;
-using NitroxClient.GameLogic;
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.MonoBehaviours;
 using NitroxModel.Packets;
 using NitroxModel_Subnautica.DataStructures;
+using UnityEngine;
 
 namespace NitroxClient.Communication.Packets.Processors
 {
     public class PlayerTeleportedProcessor : ClientPacketProcessor<PlayerTeleported>
     {
-        public PlayerTeleportedProcessor()
-        {
-        }
-
         public override void Process(PlayerTeleported packet)
         {
-            Player.main.SetPosition(packet.DestinationTo.ToUnity());
             Player.main.OnPlayerPositionCheat();
+
+            if (packet.SubRootID.HasValue)
+            {
+                if (NitroxEntity.TryGetComponentFrom(packet.SubRootID.Value, out SubRoot subRoot))
+                {
+                    //Reversing calculations from PlayerMovement.Update()
+                    Vector3 position = subRoot.transform.rotation * packet.DestinationTo.ToUnity();
+                    position += subRoot.transform.position;
+
+                    Player.main.SetPosition(position);
+                    Player.main.SetCurrentSub(subRoot);
+                    return;
+                }
+            }
+
+            Player.main.SetPosition(packet.DestinationTo.ToUnity());
         }
     }
 }

--- a/NitroxClient/MonoBehaviours/NitroxEntity.cs
+++ b/NitroxClient/MonoBehaviours/NitroxEntity.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
-using NitroxModel.Logger;
 using ProtoBuf;
 using UnityEngine;
 
@@ -49,6 +48,19 @@ namespace NitroxClient.MonoBehaviours
 
             // Nullable incase game object is marked as destroyed
             return Optional.OfNullable(gameObject);
+        }
+
+        public static bool TryGetObjectFrom(NitroxId id, out GameObject gameObject)
+        {
+            gameObject = null;
+            return id != null && gameObjectsById.TryGetValue(id, out gameObject);
+        }
+
+        public static bool TryGetComponentFrom<T>(NitroxId id, out T component) where T : Component
+        {
+            component = null;
+            return id != null && gameObjectsById.TryGetValue(id, out GameObject gameObject) &&
+                   gameObject.TryGetComponent(out component);
         }
 
         public static void SetNewId(GameObject gameObject, NitroxId id)

--- a/NitroxModel/Packets/PlayerTeleported.cs
+++ b/NitroxModel/Packets/PlayerTeleported.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
 
 namespace NitroxModel.Packets
 {
@@ -9,12 +11,19 @@ namespace NitroxModel.Packets
         public string PlayerName { get; }
         public NitroxVector3 DestinationFrom { get; }
         public NitroxVector3 DestinationTo { get; }
+        public Optional<NitroxId> SubRootID { get; }
 
-        public PlayerTeleported(string playerName, NitroxVector3 destinationFrom, NitroxVector3 destinationTo)
+        public PlayerTeleported(string playerName, NitroxVector3 destinationFrom, NitroxVector3 destinationTo, Optional<NitroxId> subRootID)
         {
             PlayerName = playerName;
             DestinationFrom = destinationFrom;
             DestinationTo = destinationTo;
+            SubRootID = subRootID;
+        }
+
+        public override string ToString()
+        {
+            return $"[PlayerTeleported: PlayerName: {PlayerName}, DestinationFrom: {DestinationFrom}, DestinationTo: {DestinationTo}, SubRootID: {SubRootID}";
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/DefaultServerPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DefaultServerPacketProcessor.cs
@@ -18,7 +18,11 @@ namespace NitroxServer.Communication.Packets.Processors
             typeof(ItemPosition),
             typeof(PlayerStats),
             typeof(VehicleColorChange),
-            typeof(StoryEventSend)
+            typeof(StoryEventSend),
+            typeof(PlayFMODAsset),
+            typeof(PlayFMODCustomEmitter),
+            typeof(PlayFMODCustomLoopingEmitter),
+            typeof(PlayFMODStudioEmitter)
         };
 
         public DefaultServerPacketProcessor(PlayerManager playerManager)
@@ -30,7 +34,7 @@ namespace NitroxServer.Communication.Packets.Processors
         {
             if (!loggingPacketBlackList.Contains(packet.GetType()))
             {
-                Log.Debug("Using default packet processor for: " + packet.ToString() + " and player " + player.Id);
+                Log.Debug($"Using default packet processor for: {packet} and player {player.Id}");
             }
 
             playerManager.SendPacketToOtherPlayers(packet, player);

--- a/NitroxServer/Communication/Packets/Processors/PlayerDeathEventProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerDeathEventProcessor.cs
@@ -20,7 +20,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(PlayerDeathEvent packet, Player player)
         {
-            if(serverConfig.IsHardcore)
+            if (serverConfig.IsHardcore)
             {
                 player.IsPermaDeath = true;
                 PlayerKicked playerKicked = new PlayerKicked("Permanent death from hardcore mode");
@@ -28,6 +28,7 @@ namespace NitroxServer.Communication.Packets.Processors
             }
 
             player.LastStoredPosition = packet.DeathPosition;
+            player.LastStoredSubRootID = player.SubRootId;
 
             if (player.Permissions > Perms.MODERATOR)
             {

--- a/NitroxServer/ConsoleCommands/BackCommand.cs
+++ b/NitroxServer/ConsoleCommands/BackCommand.cs
@@ -21,7 +21,7 @@ namespace NitroxServer.ConsoleCommands
                 return;
             }
 
-            player.Teleport(player.LastStoredPosition.Value);
+            player.Teleport(player.LastStoredPosition.Value, player.LastStoredSubRootID);
             SendMessage(args.Sender, $"Teleported back to {player.LastStoredPosition.Value}");
         }
     }

--- a/NitroxServer/ConsoleCommands/TeleportCommand.cs
+++ b/NitroxServer/ConsoleCommands/TeleportCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.ConsoleCommands.Abstract.Type;
@@ -22,7 +23,7 @@ namespace NitroxServer.ConsoleCommands
             Validate.IsTrue(args.Sender.HasValue, "This command can't be used by CONSOLE");
 
             NitroxVector3 position = new NitroxVector3(args.Get<int>(0), args.Get<int>(1), args.Get<int>(2));
-            args.Sender.Value.Teleport(position);
+            args.Sender.Value.Teleport(position, Optional.Empty);
 
             SendMessage(args.Sender, $"Teleported to {position}");
         }

--- a/NitroxServer/ConsoleCommands/WarpCommand.cs
+++ b/NitroxServer/ConsoleCommands/WarpCommand.cs
@@ -30,7 +30,7 @@ namespace NitroxServer.ConsoleCommands
                 sender = args.Sender.Value;
             }
 
-            sender.Teleport(destination.Position);
+            sender.Teleport(destination.Position, destination.SubRootId);
             SendMessage(sender, $"Teleported to {destination.Name}");
         }
     }

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -14,7 +14,7 @@ namespace NitroxServer
         private readonly ThreadSafeCollection<EquippedItemData> equippedItems;
         private readonly ThreadSafeCollection<EquippedItemData> modules;
         private readonly ThreadSafeCollection<AbsoluteEntityCell> visibleCells;
-        
+
         public NitroxConnection connection { get; set; }
         public PlayerSettings PlayerSettings => PlayerContext.PlayerSettings;
         public PlayerContext PlayerContext { get; set; }
@@ -27,6 +27,7 @@ namespace NitroxServer
         public Perms Permissions { get; set; }
         public PlayerStatsData Stats { get; set; }
         public NitroxVector3? LastStoredPosition { get; set; }
+        public Optional<NitroxId> LastStoredSubRootID { get; set; }
 
         public Player(ushort id, string name, bool isPermaDeath, PlayerContext playerContext, NitroxConnection connection, NitroxVector3 position, NitroxId playerId, Optional<NitroxId> subRootId, Perms perms, PlayerStatsData stats, IEnumerable<EquippedItemData> equippedItems,
                       IEnumerable<EquippedItemData> modules)
@@ -42,6 +43,7 @@ namespace NitroxServer
             Permissions = perms;
             Stats = stats;
             LastStoredPosition = null;
+            LastStoredSubRootID = Optional.Empty;
             this.equippedItems = new ThreadSafeCollection<EquippedItemData>(equippedItems);
             this.modules = new ThreadSafeCollection<EquippedItemData>(modules);
             visibleCells = new ThreadSafeCollection<AbsoluteEntityCell>(new HashSet<AbsoluteEntityCell>(), false);
@@ -140,13 +142,14 @@ namespace NitroxServer
             connection.SendPacket(packet);
         }
 
-        public void Teleport(NitroxVector3 destination)
+        public void Teleport(NitroxVector3 destination, Optional<NitroxId> subRootID)
         {
-            PlayerTeleported playerTeleported = new PlayerTeleported(Name, Position, destination);
+            PlayerTeleported playerTeleported = new PlayerTeleported(Name, Position, destination, subRootID);
 
-            SendPacket(playerTeleported);
             Position = playerTeleported.DestinationTo;
             LastStoredPosition = playerTeleported.DestinationFrom;
+            LastStoredSubRootID = subRootID;
+            SendPacket(playerTeleported);
         }
 
         public override string ToString()


### PR DESCRIPTION
Fixes #1414

- Fixed `warp`-command when destination player is inside cyclops 
- Added lastSubRootID for `back`-command
- Removed FMOD debug logging on server