### PR TITLE
Fixed non fully charged vehicle in cyclops bay would drain all energy without getting charged

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_ModifyCharge_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_ModifyCharge_Patch.cs
@@ -16,7 +16,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static readonly Type TARGET_CLASS = typeof(EnergyMixin);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ModifyCharge", BindingFlags.Public | BindingFlags.Instance);
 
-        public static void Postfix(float __result, EnergyMixin __instance)
+        public static void Postfix(EnergyMixin __instance, float __result)
         {
             GameObject battery = __instance.GetBattery();
             if (battery)

--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_ModifyCharge_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_ModifyCharge_Patch.cs
@@ -16,12 +16,12 @@ namespace NitroxPatcher.Patches.Dynamic
         public static readonly Type TARGET_CLASS = typeof(EnergyMixin);
         public static readonly MethodInfo TARGET_METHOD = TARGET_CLASS.GetMethod("ModifyCharge", BindingFlags.Public | BindingFlags.Instance);
 
-        public static void Postfix(EnergyMixin __instance, float amount)
+        public static void Postfix(float __result, EnergyMixin __instance)
         {
             GameObject battery = __instance.GetBattery();
             if (battery)
             {
-                if (Math.Abs(Math.Floor(__instance.charge + amount) - Math.Floor(__instance.charge)) > 0.005f) //Send package if power changed to next natural number
+                if (Math.Abs(Math.Floor(__instance.charge) - Math.Floor(__instance.charge - __result)) > 0.0) //Send package if power changed to next natural number
                 {
                     NitroxId instanceId = NitroxEntity.GetId(__instance.gameObject);
                     ItemData batteryData = new ItemData(instanceId, NitroxEntity.GetId(battery), SerializationHelper.GetBytes(battery));


### PR DESCRIPTION
This is a fix for the bug that a Prawn Suit that is not fully charged is docked into the cyclops it would drain all power from the cyclops trying to charge itself but never getting any power.
The bug is also mentioned in this issue: #1359 

It did happen because the patched ModifyCharge method checked if the modification did a change to a different natural number before sending a sync packet. The problem was that this check did not compare the old charge with the new charge value but the new charge value with a value applying the modification again.
The Prawn Suit was draining 1 energy per second (normal power cells) and distribute it to it's 2 power cells. Each got 0.5 energy. The patched method now checked newCharge against newCharge + 0.5 and detected a natural number change although no change occurred. After that the current charge was floored removing all added power again and sending this to the other clients. As all clients simulate the recharging inside the cyclops they would override each other with the wrong floored values never being able to add any energy to the PrawnSuit but still consuming from the Cyclops. 

This change does not solve the problem that energy consumption inside the cyclops is simulated by all player also mentioned in this issue #1293 
This is also noticeable as recharging a vehicle inside the cyclops takes more energy from the cyclops than what is added to the vehicle but with this change the vehicle will still properly charge and the cyclops won't leak all energy.