### PR TITLE
Changed port availability check to not bind to UDP port itself

### DIFF
--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -102,39 +104,30 @@ namespace NitroxServer_Subnautica
 
             DateTimeOffset time = DateTimeOffset.UtcNow;
             bool first = true;
-            using CancellationTokenSource source = new CancellationTokenSource(timeoutInSeconds * 1000);
-            using Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.IP);
+            using CancellationTokenSource source = new(timeoutInSeconds * 1000);
 
             try
             {
                 while (true)
                 {
                     source.Token.ThrowIfCancellationRequested();
-                    try
+                    if (IPGlobalProperties.GetIPGlobalProperties().GetActiveUdpListeners().All(ip => ip.Port != 11000))
                     {
-                        socket.Bind(new IPEndPoint(IPAddress.Any, port));
                         break;
                     }
-                    catch (SocketException ex)
+                    
+                    if (first)
                     {
-                        if (ex.SocketErrorCode != SocketError.AddressAlreadyInUse)
-                        {
-                            throw;
-                        }
-
-                        if (first)
-                        {
-                            first = false;
-                            PrintPortWarn(timeoutInSeconds);
-                        }
-                        else if (Environment.UserInteractive)
-                        {
-                            Console.CursorTop--;
-                            Console.CursorLeft = 0;
-                            PrintPortWarn(timeoutInSeconds - (DateTimeOffset.UtcNow - time).Seconds);
-                        }
-                        await Task.Delay(500, source.Token);
+                        first = false;
+                        PrintPortWarn(timeoutInSeconds);
                     }
+                    else if (Environment.UserInteractive)
+                    {
+                        Console.CursorTop--;
+                        Console.CursorLeft = 0;
+                        PrintPortWarn(timeoutInSeconds - (DateTimeOffset.UtcNow - time).Seconds);
+                    }
+                    await Task.Delay(500, source.Token);
                 }
             }
             catch (OperationCanceledException ex)

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -108,7 +108,7 @@ namespace NitroxServer_Subnautica
                 while (true)
                 {
                     source.Token.ThrowIfCancellationRequested();
-                    if (IPGlobalProperties.GetIPGlobalProperties().GetActiveUdpListeners().All(ip => ip.Port != 11000))
+                    if (IPGlobalProperties.GetIPGlobalProperties().GetActiveUdpListeners().All(ip => ip.Port != port))
                     {
                         break;
                     }

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -17,7 +15,6 @@ using NitroxModel.Discovery;
 using NitroxModel.Helper;
 using NitroxModel.Logger;
 using NitroxModel.OS;
-using NitroxModel_Subnautica.Helper;
 using NitroxServer;
 using NitroxServer.ConsoleCommands.Processor;
 


### PR DESCRIPTION
Might fix #1505

Nitrox used to bind a socket to the port (usually 11000) to test if it is available.
But apparently on some systems it will take too long to unbind the socket and will lead to error when server starts (see linked issue).

So the "fix" is to iterate the network API for all ports currently waiting for incoming packets instead. If one is 11000 (or the user defined port) it waits for it to become available with a timeout of 30 seconds.

### Things to test
 - Verify server can start normally.
 - Verify server waits for port when another server with the same port is already running.
