### PR TITLE
Added nullchecks to quickslots postfix

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/QuickSlots_SelectInternal_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/QuickSlots_SelectInternal_Patch.cs
@@ -28,6 +28,10 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(InventoryItem ____heldItem, NitroxTechType __state)
         {
+            if (____heldItem == null)
+            {
+                return;
+            }
             Pickupable pickupable = ____heldItem.item;
             NitroxId itemId = NitroxEntity.GetId(pickupable.gameObject);
             PlayerTool component = pickupable.GetComponent<PlayerTool>();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1107063/124632690-dc6b4900-de84-11eb-905e-f0bf897812d2.png)

Code did null check but postfix runs always. So it also runs if item is null, hence the NRE spam in logs.