### PR TITLE
Changed File.Move usages to FileSystem.ReplaceFile because it can move files/directories between drives

### DIFF
--- a/NitroxLauncher/Patching/NitroxEntryPatch.cs
+++ b/NitroxLauncher/Patching/NitroxEntryPatch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;
+using NitroxModel.OS;
 using FileAttributes = System.IO.FileAttributes;
 
 namespace NitroxLauncher.Patching
@@ -66,7 +67,7 @@ namespace NitroxLauncher.Patching
             {
                 throw error;
             }
-            File.Move(modifiedAssemblyCSharp, assemblyCSharp);
+            FileSystem.Instance.ReplaceFile(modifiedAssemblyCSharp, assemblyCSharp);
         }
 
         private Exception RetryWait(Action action, int interval, int retries = 0)
@@ -112,9 +113,8 @@ namespace NitroxLauncher.Patching
 
                 File.SetAttributes(assemblyCSharp, FileAttributes.Normal);
             }
-
-            File.Delete(assemblyCSharp);
-            File.Move(modifiedAssemblyCSharp, assemblyCSharp);
+            
+            FileSystem.Instance.ReplaceFile(modifiedAssemblyCSharp, assemblyCSharp);
         }
 
         private static int FindNitroxExecuteInstructionIndex(IList<Instruction> methodInstructions)

--- a/NitroxLauncher/Patching/QModHelper.cs
+++ b/NitroxLauncher/Patching/QModHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using NitroxModel.Logger;
+using NitroxModel.OS;
 
 namespace NitroxLauncher.Patching
 {
@@ -42,7 +43,7 @@ namespace NitroxLauncher.Patching
             try
             {
                 string newFilePath = Path.Combine(subnauticaBasePath, newFileName);
-                File.Move(fileToRenamePath, newFilePath);
+                FileSystem.Instance.ReplaceFile(fileToRenamePath, newFilePath);
                 qModPatched = !qModPatched;
                 Log.Info("Removing/Restoring QMod initialisation has been successful");
             }

--- a/NitroxModel/OS/FileSystem.cs
+++ b/NitroxModel/OS/FileSystem.cs
@@ -14,14 +14,11 @@ namespace NitroxModel.OS
 {
     public class FileSystem
     {
-        private static readonly Lazy<FileSystem> instance = new(() =>
+        private static readonly Lazy<FileSystem> instance = new(() => Environment.OSVersion.Platform switch
                                                                 {
-                                                                    return Environment.OSVersion.Platform switch
-                                                                    {
-                                                                        PlatformID.Unix => new UnixFileSystem(),
-                                                                        PlatformID.MacOSX => new MacFileSystem(),
-                                                                        _ => new WinFileSystem()
-                                                                    };
+                                                                    PlatformID.Unix => new UnixFileSystem(),
+                                                                    PlatformID.MacOSX => new MacFileSystem(),
+                                                                    _ => new WinFileSystem()
                                                                 },
                                                                 LazyThreadSafetyMode.ExecutionAndPublication);
 
@@ -187,10 +184,12 @@ namespace NitroxModel.OS
 
         /// <summary>
         ///     Replaces target file with source file. If target file does not exist then it moves the file.
+        ///     This falls back to a copy if the target is on a different drive.
+        ///     The source file will always be deleted.
         /// </summary>
         /// <param name="source">Source file to replace with.</param>
         /// <param name="target">Target file to replace.</param>
-        /// <returns>True if file was moved or replaced.</returns>
+        /// <returns>True if file was moved or replaced successfully.</returns>
         public bool ReplaceFile(string source, string target)
         {
             if (!File.Exists(source))
@@ -210,6 +209,7 @@ namespace NitroxModel.OS
             }
             catch (IOException ex)
             {
+                // TODO: Need to test on Linux because the ex.HResult will likely not work or be different number cross-platform.
                 switch ((uint)ex.HResult)
                 {
                     case 0x80070498:

--- a/NitroxModel/OS/FileSystem.cs
+++ b/NitroxModel/OS/FileSystem.cs
@@ -222,8 +222,17 @@ namespace NitroxModel.OS
                             Log.Debug($"Renaming file '{target}' to '{backupFileName}' as backup plan if file replace fails");
                             File.Move(target, backupFileName);
                             File.Copy(source, target);
-                            File.Delete(source);
-                            File.Delete(backupFileName);
+                            
+                            // Cleanup redundant files, ignoring errors.
+                            try
+                            {
+                                File.Delete(source);
+                                File.Delete(backupFileName);
+                            }
+                            catch (Exception)
+                            {
+                                // ignored
+                            }
                         }
                         catch (Exception ex2)
                         {


### PR DESCRIPTION
On `MoveFile` win32 function:
> The MoveFile function will move (rename) either a file or a directory (including its children) either in the same directory or across directories. The one caveat is that the MoveFile function will fail on directory moves when the destination is on a different volume.

https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefile

This function is used by `File.Move` in .NET Framework 4.8 or lower.

Unfortunately we can't use .NET Core or .NET 5+ which use a different function that can copy files/directories between drives:
https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw