### PR TITLE
Fixed seed loading from config file in production environments

### DIFF
--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -159,6 +159,9 @@ namespace NitroxServer.Serialization.World
 #if DEBUG
                     Seed = "TCCBIBZXAB"
 #endif
+#if (!DEBUG)
+                    Seed = config.Seed
+#endif
                 }
             };
 

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -158,8 +158,7 @@ namespace NitroxServer.Serialization.World
                     ServerStartTime = DateTime.UtcNow,
 #if DEBUG
                     Seed = "TCCBIBZXAB"
-#endif
-#if (!DEBUG)
+#else
                     Seed = config.Seed
 #endif
                 }


### PR DESCRIPTION
The seed from the server config file wasn't actually being used anywhere, so I implemented it into the world generation for production environments.