### PR TITLE
Added error when Nitrox is not able to write/read files

### DIFF
--- a/NitroxLauncher/LauncherLogic.cs
+++ b/NitroxLauncher/LauncherLogic.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using NitroxLauncher.Events;
 using NitroxLauncher.Pages;
 using NitroxLauncher.Patching;
@@ -16,6 +17,7 @@ using NitroxModel;
 using NitroxModel.Discovery;
 using NitroxModel.Helper;
 using NitroxModel.Logger;
+using NitroxModel.OS;
 
 namespace NitroxLauncher
 {
@@ -128,6 +130,18 @@ namespace NitroxLauncher
             lastFindSubnauticaTask = Task.Factory.StartNew(() =>
             {
                 PirateDetection.TriggerOnDirectory(path);
+                
+                // TODO: Move this if block to another place where Nitrox installation is verified (will be clear with new Nitrox Launcher design).
+                if (!FileSystem.Instance.SetFullAccessToCurrentUser(Directory.GetCurrentDirectory()) || !FileSystem.Instance.SetFullAccessToCurrentUser(path))
+                {
+                    Dispatcher.CurrentDispatcher.BeginInvoke(() =>
+                    {
+                        MessageBox.Show(Application.Current.MainWindow!, "Restart Nitrox Launcher as admin to allow Nitrox to change permissions as needed. This is only needed once. Nitrox will close after this message.", "Required file permission error", MessageBoxButton.OK,
+                                        MessageBoxImage.Error);
+                        Environment.Exit(1);
+                    }, DispatcherPriority.ApplicationIdle);
+                }
+                
                 try
                 {
                     File.WriteAllText("path.txt", path);

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -87,7 +87,7 @@ namespace NitroxLauncher
                      {
                          LauncherLogic.Instance.NavigateTo<OptionPage>();
                      }
-
+                     
                      logic.CheckNitroxVersion();
                  }, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.FromCurrentSynchronizationContext());
         }

--- a/NitroxModel/OS/FileSystem.cs
+++ b/NitroxModel/OS/FileSystem.cs
@@ -12,7 +12,7 @@ using NitroxModel.OS.Windows;
 
 namespace NitroxModel.OS
 {
-    public class FileSystem
+    public abstract class FileSystem
     {
         private static readonly Lazy<FileSystem> instance = new(() => Environment.OSVersion.Platform switch
                                                                 {
@@ -25,10 +25,6 @@ namespace NitroxModel.OS
         public virtual IEnumerable<string> ExecutableFileExtensions => throw new NotSupportedException();
         public static FileSystem Instance => instance.Value;
         public virtual string TextEditor => throw new NotSupportedException();
-
-        protected FileSystem()
-        {
-        }
 
         public virtual IEnumerable<string> GetDefaultPrograms(string file) => throw new NotSupportedException();
 
@@ -248,5 +244,7 @@ namespace NitroxModel.OS
             }
             return true;
         }
+
+        public abstract bool SetFullAccessToCurrentUser(string directory);
     }
 }

--- a/NitroxModel/OS/MacOS/MacFileSystem.cs
+++ b/NitroxModel/OS/MacOS/MacFileSystem.cs
@@ -8,5 +8,10 @@ namespace NitroxModel.OS.MacOS
         {
             yield return "open";
         }
+
+        public override bool SetFullAccessToCurrentUser(string directory)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/NitroxModel/OS/Unix/UnixFileSystem.cs
+++ b/NitroxModel/OS/Unix/UnixFileSystem.cs
@@ -8,5 +8,10 @@ namespace NitroxModel.OS.Unix
         {
             yield return "xdg-open";
         }
+
+        public override bool SetFullAccessToCurrentUser(string directory)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
If user restarts as admin then Nitrox Launcher will add file permissions where needed.

Fixes #1559