### PR TITLE
PDA Initial Sync NullRef Checks.

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using NitroxClient.Communication.Abstract;
@@ -105,17 +106,19 @@ namespace NitroxClient.GameLogic.InitialSync
 
                 foreach (PDALogEntry logEntry in logEntries)
                 {
-                    if (!entries.ContainsKey(logEntry.Key))
+                    if (logEntry.Key != null && !entries.ContainsKey(logEntry.Key))
                     {
-                        PDALog.GetEntryData(logEntry.Key, out PDALog.EntryData entryData);
-                        PDALog.Entry entry = new PDALog.Entry();
-                        entry.data = entryData;
-                        entry.timestamp = logEntry.Timestamp;
-                        entries.Add(entryData.key, entry);
-
-                        if (entryData.key == "Story_AuroraWarning4")
+                        if (PDALog.GetEntryData(logEntry.Key, out PDALog.EntryData entryData))
                         {
-                            CrashedShipExploder.main.ReflectionCall("SwapModels", false, false, new object[] { true });
+                            PDALog.Entry entry = new PDALog.Entry();
+                            entry.data = entryData;
+                            entry.timestamp = logEntry.Timestamp;
+                            entries.Add(entryData.key, entry);
+
+                            if (entryData.key == "Story_AuroraWarning4")
+                            {
+                                CrashedShipExploder.main.ReflectionCall("SwapModels", false, false, new object[] { true });
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I sometimes was getting Null ref exceptions during load when reaching this point which would cause the whole loading to stop forever.  This fixes them and allowed me to load into the server.

implement null checks in PDA Initial Sync