### PR TITLE
Convert to HarmonyX

### DIFF
--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -23,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject/>
+    <StartupObject />
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
@@ -207,14 +207,14 @@
     <PackageReference Include="dnlib">
       <Version>3.3.2</Version>
     </PackageReference>
+    <PackageReference Include="HarmonyX">
+      <Version>2.5.4</Version>
+    </PackageReference>
     <PackageReference Include="WindowsAPICodePack-Core">
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="WindowsAPICodePack-Shell">
       <Version>1.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="Lib.Harmony">
-      <Version>2.0.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Assembly References">

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -212,8 +212,8 @@
     <PackageReference Include="Autofac">
       <Version>4.9.4</Version>
     </PackageReference>
-    <PackageReference Include="Lib.Harmony">
-      <Version>2.0.4.0</Version>
+    <PackageReference Include="HarmonyX">
+      <Version>2.5.4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/NitroxPatcher/Patches/Dynamic/BaseAddBulkheadGhost_UpdatePlacement_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseAddBulkheadGhost_UpdatePlacement_Patch.cs
@@ -20,7 +20,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static readonly OpCode INSTRUCTION_BEFORE_JUMP = OpCodes.Ldfld;
         public static readonly object INSTRUCTION_BEFORE_JUMP_OPERAND = typeof(SubRoot).GetField("isBase", BindingFlags.Public | BindingFlags.Instance);
-        public static readonly OpCode JUMP_INSTRUCTION_TO_COPY = OpCodes.Brtrue_S;
+        public static readonly OpCode JUMP_INSTRUCTION_TO_COPY = OpCodes.Brtrue;
 
         public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
         {

--- a/NitroxPatcher/Patches/Dynamic/BaseAddModuleGhost_UpdatePlacement_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseAddModuleGhost_UpdatePlacement_Patch.cs
@@ -20,7 +20,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static readonly OpCode INSTRUCTION_BEFORE_JUMP = OpCodes.Ldfld;
         public static readonly object INSTRUCTION_BEFORE_JUMP_OPERAND = typeof(SubRoot).GetField("isBase", BindingFlags.Public | BindingFlags.Instance);
-        public static readonly OpCode JUMP_INSTRUCTION_TO_COPY = OpCodes.Brtrue_S;
+        public static readonly OpCode JUMP_INSTRUCTION_TO_COPY = OpCodes.Brtrue;
 
         public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
         {

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -50,7 +50,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Creature_ChooseBestAction_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Creature_ChooseBestAction_Patch.cs
@@ -45,7 +45,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsExternalDamageManager_CreatePoint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsExternalDamageManager_CreatePoint_Patch.cs
@@ -30,7 +30,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleFloodlights_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleFloodlights_Patch.cs
@@ -30,7 +30,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleInternalLighting_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsLightingPanel_ToggleInternalLighting_Patch.cs
@@ -30,7 +30,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
@@ -45,7 +45,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnHit_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitGrapplingArm_OnHit_Patch.cs
@@ -37,7 +37,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FMODUWE_PlayOneShotImpl_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMODUWE_PlayOneShotImpl_Patch.cs
@@ -29,7 +29,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FMOD_CustomEmitter_OnPlay_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_CustomEmitter_OnPlay_Patch.cs
@@ -49,7 +49,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
 
     }

--- a/NitroxPatcher/Patches/Dynamic/FMOD_CustomLoopingEmitter_OnPlay_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_CustomLoopingEmitter_OnPlay_Patch.cs
@@ -36,7 +36,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FMOD_CustomLoopingEmitter_PlayStopSound_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_CustomLoopingEmitter_PlayStopSound_Patch.cs
@@ -36,7 +36,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FMOD_StudioEventEmitter_PlayUI_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_StudioEventEmitter_PlayUI_Patch.cs
@@ -40,7 +40,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
 
     }

--- a/NitroxPatcher/Patches/Dynamic/FMOD_StudioEventEmitter_Stop_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_StudioEventEmitter_Stop_Patch.cs
@@ -36,7 +36,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
 
     }

--- a/NitroxPatcher/Patches/Dynamic/LiveMixin_AddHealth_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LiveMixin_AddHealth_Patch.cs
@@ -49,7 +49,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/LiveMixin_TakeDamage_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LiveMixin_TakeDamage_Patch.cs
@@ -58,7 +58,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/QuickSlots_SelectInternal_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/QuickSlots_SelectInternal_Patch.cs
@@ -42,7 +42,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             player = NitroxServiceLocator.LocateService<LocalPlayer>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Rocket_CallElevator_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Rocket_CallElevator_Patch.cs
@@ -32,7 +32,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Rocket_ElevatorControlButtonActivate_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Rocket_ElevatorControlButtonActivate_Patch.cs
@@ -34,7 +34,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/SeaMoth_OnUpgradeModuleUse_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaMoth_OnUpgradeModuleUse_Patch.cs
@@ -36,7 +36,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubFire_CreateFire_Patch.cs
@@ -55,7 +55,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/ToggleLights_SetLightsActive_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ToggleLights_SetLightsActive_Patch.cs
@@ -73,7 +73,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
 
         public class LightToggleContainer

--- a/NitroxPatcher/Patches/Dynamic/Utils_PlayFMODAsset_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Utils_PlayFMODAsset_Patch.cs
@@ -28,7 +28,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public override void Patch(Harmony harmony)
         {
             fmodSystem = NitroxServiceLocator.LocateService<FMODSystem>();
-            PatchMultiple(harmony, targetMethod, true, true, false, false);
+            PatchMultiple(harmony, targetMethod, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
@@ -42,7 +42,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, true, false, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, postfix:true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Welder_Weld_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Welder_Weld_Patch.cs
@@ -54,7 +54,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchMultiple(harmony, TARGET_METHOD, true, false, true, false);
+            PatchMultiple(harmony, TARGET_METHOD, prefix:true, transpiler:true);
         }
 
         public static float AddHealthOverride(LiveMixin live, float addHealth, Welder welder)

--- a/NitroxPatcher/Patches/NitroxPatch.cs
+++ b/NitroxPatcher/Patches/NitroxPatch.cs
@@ -46,18 +46,19 @@ namespace NitroxPatcher.Patches
             PatchMultiple(harmony, targetMethod, null, postfixMethod);
         }
 
-        protected void PatchMultiple(Harmony harmony, MethodBase targetMethod, bool prefix, bool postfix, bool transpiler, bool finalizer)
+        protected void PatchMultiple(Harmony harmony, MethodBase targetMethod, bool prefix = false, bool postfix = false, bool transpiler = false, bool finalizer = false, bool iLManipulator = false)
         {
             string prefixMethod = prefix ? "Prefix" : null;
             string postfixMethod = postfix ? "Postfix" : null;
             string transpilerMethod = transpiler ? "Transpiler" : null;
             string finalizerMethod = finalizer ? "Finalizer" : null;
+            string iLManipulatorMethod = iLManipulator ? "ILManipulator" : null;
 
-            PatchMultiple(harmony, targetMethod, prefixMethod, postfixMethod, transpilerMethod, finalizerMethod);
+            PatchMultiple(harmony, targetMethod, prefixMethod, postfixMethod, transpilerMethod, finalizerMethod, iLManipulatorMethod);
         }
 
         protected void PatchMultiple(Harmony harmony, MethodBase targetMethod,
-            string prefixMethod = null, string postfixMethod = null, string transpilerMethod = null, string finalizerMethod = null)
+            string prefixMethod = null, string postfixMethod = null, string transpilerMethod = null, string finalizerMethod = null, string iLManipulatorMethod = null)
         {
             Validate.NotNull(targetMethod, "Target method cannot be null");
 
@@ -65,8 +66,9 @@ namespace NitroxPatcher.Patches
             HarmonyMethod harmonyPostfixMethod = postfixMethod != null ? GetHarmonyMethod(postfixMethod) : null;
             HarmonyMethod harmonyTranspilerMethod = transpilerMethod != null ? GetHarmonyMethod(transpilerMethod) : null;
             HarmonyMethod harmonyFinalizerMethod = finalizerMethod != null ? GetHarmonyMethod(finalizerMethod) : null;
+            HarmonyMethod harmonyILManipulatorMethod = iLManipulatorMethod != null ? GetHarmonyMethod(iLManipulatorMethod) : null;
 
-            harmony.Patch(targetMethod, harmonyPrefixMethod, harmonyPostfixMethod, harmonyTranspilerMethod, harmonyFinalizerMethod);
+            harmony.Patch(targetMethod, harmonyPrefixMethod, harmonyPostfixMethod, harmonyTranspilerMethod, harmonyFinalizerMethod, harmonyILManipulatorMethod);
             activePatches.Add(targetMethod); // Store our patched methods
         }
     }

--- a/NitroxTest/NitroxTest.csproj
+++ b/NitroxTest/NitroxTest.csproj
@@ -78,8 +78,8 @@
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>
-    <PackageReference Include="Lib.Harmony">
-      <Version>2.0.4.0</Version>
+    <PackageReference Include="HarmonyX">
+      <Version>2.5.4</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.15.2</Version>


### PR DESCRIPTION
Changes out Harmony2 for HarmonyX to be more compatible with QModManager in the future.

https://github.com/BepInEx/HarmonyX/wiki

info on the new patch type 
https://github.com/BepInEx/HarmonyX/wiki/ILManipulators

Info on some operational differences/improvements 
https://github.com/BepInEx/HarmonyX/wiki/Difference-between-Harmony-and-HarmonyX