### PR TITLE
Fades out disorienting Nitrox Alpha Version text when in VR

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using UnityEngine;
+using UnityEngine.XR;
 
 namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 {
@@ -9,10 +10,11 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         private static GameObject loadingTextGameObject => uGUI.main.loading.loadingText.gameObject;
 
         private static uGUI_TextFade loadingScreenWarning;
+        private static uGUI_TextFade versionText;
 
         public static void Initialize()
         {
-            AddTextToLoadingScreen($"\nNitrox Alpha V{assemblyVersion}");
+            versionText = AddTextToLoadingScreen($"\nNitrox Alpha V{assemblyVersion}");
             loadingScreenWarning = AddTextToLoadingScreen($"\n\n{Language.main.Get("Nitrox_LoadingScreenWarn")}");
         }
 
@@ -32,6 +34,10 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         public static void DisableWarningText()
         {
             loadingScreenWarning.FadeOut(1f, null);
+            if(XRSettings.enabled)
+            {
+                versionText.FadeOut(1f, null);
+            }
         }
     }
 }

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/LoadingScreenVersionText.cs
@@ -34,7 +34,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         public static void DisableWarningText()
         {
             loadingScreenWarning.FadeOut(1f, null);
-            if(XRSettings.enabled)
+            if (XRSettings.enabled)
             {
                 versionText.FadeOut(1f, null);
             }


### PR DESCRIPTION
Simple change that only fades out the Nitrox version on screen text but only when in VR as it is very disorienting in VR.
![Subnautica_zkZIV7QRuT](https://user-images.githubusercontent.com/7858500/131237944-a378ce96-6010-4058-bf4b-6cfad66fae9c.jpg)
