### PR TITLE
BuilderTool_HandleInput_Patch Transpiler fix

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/BuilderTool_HandleInput_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BuilderTool_HandleInput_Patch.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
 using NitroxModel.Helper;
 using UnityEngine;
 
@@ -32,6 +33,7 @@ namespace NitroxPatcher.Patches.Dynamic
                     yield return TranspilerHelper.LocateService<Building>();
                     yield return original.Ldloc<Constructable>();
                     yield return new CodeInstruction(OpCodes.Callvirt, typeof(Component).GetMethod("get_gameObject", BindingFlags.Instance | BindingFlags.Public));
+                    yield return new CodeInstruction(OpCodes.Callvirt, typeof(NitroxEntity).GetMethod("GetId", BindingFlags.Public | BindingFlags.Static));
                     yield return new CodeInstruction(OpCodes.Callvirt, typeof(Building).GetMethod("DeconstructionBegin", BindingFlags.Public | BindingFlags.Instance));
                 }
             }


### PR DESCRIPTION
DeconstructionBegin needs a NitroxId not a gameobject. 

Every time I would try to deconstruct something it would throw an exception as this method was being provided with the wrong type.