### PR TITLE
Load Entity Batches Up-Front and Cache

### DIFF
--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -41,8 +41,8 @@ namespace NitroxServer_Subnautica
 
             AppMutex.Hold(() =>
             {
-                Log.Info("Waiting for 30 seconds on other Nitrox servers to initialize before starting..");
-            }, 30000);
+                Log.Info("Waiting on other Nitrox servers to initialize before starting..");
+            }, 120000);
             Server server;
             Task listenForCommands;
             try

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -73,6 +73,7 @@ namespace NitroxServer_Subnautica
 
                 server = NitroxServiceLocator.LocateService<Server>();
                 await WaitForAvailablePortAsync(server.Port);
+                CatchExitEvent();
                 if (!server.Start())
                 {
                     throw new Exception("Unable to start server.");
@@ -83,7 +84,6 @@ namespace NitroxServer_Subnautica
                 Log.Info($"Server started ({Math.Round(watch.Elapsed.TotalSeconds, 1)}s)");
                 Log.Info("To get help for commands, run help in console or /help in chatbox");
 
-                CatchExitEvent();
             }
             finally
             {

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -44,6 +44,7 @@ namespace NitroxServer_Subnautica
                 Log.Info("Waiting for 30 seconds on other Nitrox servers to initialize before starting..");
             }, 30000);
             Server server;
+            Task listenForCommands;
             try
             {
                 Stopwatch watch = Stopwatch.StartNew();
@@ -74,9 +75,9 @@ namespace NitroxServer_Subnautica
                 server = NitroxServiceLocator.LocateService<Server>();
                 await WaitForAvailablePortAsync(server.Port);
                 CatchExitEvent();
-                ListenForCommandsAsync(server);
+                listenForCommands = ListenForCommandsAsync(server);
 
-                CancellationTokenSource cancellationToken = new CancellationTokenSource();
+                CancellationTokenSource cancellationToken = new();
                 if (!server.Start(cancellationToken) && !cancellationToken.IsCancellationRequested)
                 {
                     throw new Exception("Unable to start server.");
@@ -93,6 +94,7 @@ namespace NitroxServer_Subnautica
                     Log.Info("To get help for commands, run help in console or /help in chatbox");
                 }
 
+                await listenForCommands;
             }
             finally
             {

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -85,7 +85,6 @@ namespace NitroxServer_Subnautica
                 else if (cancellationToken.IsCancellationRequested)
                 {
                     watch.Stop();
-                    Log.Info("Server Loading canceled by user");
                 }
                 else
                 {
@@ -93,15 +92,14 @@ namespace NitroxServer_Subnautica
                     Log.Info($"Server started ({Math.Round(watch.Elapsed.TotalSeconds, 1)}s)");
                     Log.Info("To get help for commands, run help in console or /help in chatbox");
                 }
-
-                await listenForCommands;
             }
             finally
             {
                 // Allow other servers to start initializing.
                 AppMutex.Release();
             }
-
+            
+            await listenForCommands;
         }
 
         private static async Task ListenForCommandsAsync(Server server)

--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -208,7 +208,7 @@ namespace NitroxServer.GameLogic.Entities
             }
         }
 
-        public void LoadAllUnspawnedEntities()
+        public void LoadAllUnspawnedEntities(System.Threading.CancellationToken token)
         {
             
             IMap map = NitroxServiceLocator.LocateService<IMap>();
@@ -216,6 +216,7 @@ namespace NitroxServer.GameLogic.Entities
             int totalEntites = 0;
             for (int x = 0; x < map.DimensionsInBatches.X; x++)
             {
+                token.ThrowIfCancellationRequested();
                 for (int y = 0; y < map.DimensionsInBatches.Y; y++)
                 {
                     for (int z = 0; z < map.DimensionsInBatches.Z; z++)

--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -252,6 +252,8 @@ namespace NitroxServer.GameLogic.Entities
                                 }
                             }
                         }
+
+                        Log.Debug($"Loaded {spawnedEntities.Count} entities from batch ({x}, {y}, {z})");
                     }
                 }
 

--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -213,6 +213,7 @@ namespace NitroxServer.GameLogic.Entities
             
             IMap map = NitroxServiceLocator.LocateService<IMap>();
 
+            int totalEntites = 0;
             for (int x = 0; x < map.DimensionsInBatches.X; x++)
             {
                 for (int y = 0; y < map.DimensionsInBatches.Y; y++)
@@ -220,7 +221,7 @@ namespace NitroxServer.GameLogic.Entities
                     for (int z = 0; z < map.DimensionsInBatches.Z; z++)
                     {
                         NitroxInt3 batchId = new NitroxInt3(x, y, z);
-                        List<Entity> spawnedEntities = batchEntitySpawner.LoadUnspawnedEntities(batchId);
+                        List<Entity> spawnedEntities = batchEntitySpawner.LoadUnspawnedEntities(batchId, true);
 
                         lock (entitiesById)
                         {
@@ -246,10 +247,16 @@ namespace NitroxServer.GameLogic.Entities
                                     entitiesInCell.Add(entity);
 
                                     entitiesById.Add(entity.Id, entity);
+                                    totalEntites++;
                                 }
                             }
                         }
                     }
+                }
+
+                if (totalEntites > 0)
+                {
+                    Log.Info($"Loading: {(int)((totalEntites/ 504732.0) * 100)}%");
                 }
             }
         }

--- a/NitroxServer/GameLogic/Entities/Spawning/BatchEntitySpawner.cs
+++ b/NitroxServer/GameLogic/Entities/Spawning/BatchEntitySpawner.cs
@@ -68,7 +68,7 @@ namespace NitroxServer.GameLogic.Entities.Spawning
             batchCellsParser = new BatchCellsParser(entitySpawnPointFactory, serializer);
         }
 
-        public List<Entity> LoadUnspawnedEntities(NitroxInt3 batchId)
+        public List<Entity> LoadUnspawnedEntities(NitroxInt3 batchId, bool fullCacheCreation = false)
         {
             lock (parsedBatches)
             {
@@ -91,7 +91,7 @@ namespace NitroxServer.GameLogic.Entities.Spawning
                     emptyBatches.Add(batchId);
                 }
             }
-            else
+            else if(!fullCacheCreation)
             {
                 Log.Info("Spawning " + entities.Count + " entities from " + spawnPoints.Count + " spawn points in batch " + batchId);
             }

--- a/NitroxServer/GameLogic/Entities/Spawning/IEntitySpawner.cs
+++ b/NitroxServer/GameLogic/Entities/Spawning/IEntitySpawner.cs
@@ -6,6 +6,6 @@ namespace NitroxServer.GameLogic.Entities.Spawning
 {
     public interface IEntitySpawner
     {
-        List<Entity> LoadUnspawnedEntities(NitroxInt3 batchId);
+        List<Entity> LoadUnspawnedEntities(NitroxInt3 batchId, bool fullCacheCreation = false);
     }
 }

--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -9,6 +9,9 @@ namespace NitroxServer.Serialization
     public class ServerConfig : NitroxConfig<ServerConfig>
     {
         private int maxConnectionsSetting = 100;
+        
+        [PropertyDescription("Set to true to Cache entities for the whole map on next run. \nWARNING! Will make server load take longer on the cache run but players will gain a performance boost when entering new areas.")]
+        public bool CreateFullEntityCache = false;
 
         private int portSetting = ServerList.DEFAULT_PORT;
 

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -106,6 +106,22 @@ namespace NitroxServer
                 return false;
             }
 
+            if (serverConfig.CreateFullEntityCache)
+            {
+                Log.Info("Starting to load all batches up front.");
+                Log.Info("This can take up to several minutes and you can't join until it's completed.");
+                EntityManager entityManager = NitroxServiceLocator.LocateService<EntityManager>();
+                Log.Info($"{entityManager.GetAllEntities().Count} entities already cached");
+                if (entityManager.GetAllEntities().Count < 504732)
+                {
+                    entityManager.LoadAllUnspawnedEntities();
+
+                    Log.Info($"Saving newly cached entities.");
+                    Save();
+                }
+                Log.Info("All batches have now been loaded.");
+            }
+
             Log.Info($"Server is listening on port {Port} UDP");
             Log.Info($"Using {serverConfig.SerializerMode} as save file serializer");
             Log.InfoSensitive("Server Password: {password}", string.IsNullOrEmpty(serverConfig.ServerPassword) ? "None. Public Server." : serverConfig.ServerPassword);
@@ -119,12 +135,6 @@ namespace NitroxServer
 #if RELEASE
             IpLogger.PrintServerIps();
 #endif
-
-            if (serverConfig.CreateFullEntityCache)
-            {
-                NitroxServiceLocator.LocateService<EntityManager>().LoadAllUnspawnedEntities();
-                Save();
-            }
             return true;
         }
 

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Timers;
+using NitroxModel.Core;
 using NitroxModel.Logger;
+using NitroxServer.GameLogic.Entities;
 using NitroxServer.Serialization;
 using NitroxServer.Serialization.World;
 
@@ -117,6 +119,12 @@ namespace NitroxServer
 #if RELEASE
             IpLogger.PrintServerIps();
 #endif
+
+            if (serverConfig.CreateFullEntityCache)
+            {
+                NitroxServiceLocator.LocateService<EntityManager>().LoadAllUnspawnedEntities();
+                Save();
+            }
             return true;
         }
 

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -20,6 +20,7 @@ namespace NitroxServer
         private readonly ServerConfig serverConfig;
         private readonly Timer saveTimer;
         private readonly World world;
+        private readonly EntityManager entityManager;
         private CancellationTokenSource serverCancelSource;
 
         public static Server Instance { get; private set; }
@@ -29,12 +30,13 @@ namespace NitroxServer
 
         public int Port => serverConfig?.ServerPort ?? -1;
 
-        public Server(WorldPersistence worldPersistence, World world, ServerConfig serverConfig, Communication.NitroxServer server)
+        public Server(WorldPersistence worldPersistence, World world, ServerConfig serverConfig, Communication.NitroxServer server, EntityManager entityManager)
         {
             this.worldPersistence = worldPersistence;
             this.serverConfig = serverConfig;
             this.server = server;
             this.world = world;
+            this.entityManager = entityManager;
 
             Instance = this;
 
@@ -115,7 +117,6 @@ namespace NitroxServer
                 {
                     Log.Info("Starting to load all batches up front.");
                     Log.Info("This can take up to several minutes and you can't join until it's completed.");
-                    EntityManager entityManager = NitroxServiceLocator.LocateService<EntityManager>();
                     Log.Info($"{entityManager.GetAllEntities().Count} entities already cached");
                     if (entityManager.GetAllEntities().Count < 504732)
                     {

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -152,7 +152,7 @@ namespace NitroxServer
         public void Stop(bool shouldSave = true)
         {
             if (!IsRunning)
-            { 
+            {
                 return;
             }
 


### PR DESCRIPTION

https://github.com/SubnauticaNitrox/Nitrox/issues/1109

Add functionality for the server to Cache all entity batches on the NEXT server start. This will loop through all possible batches and try to load them into the entity cache. 

Gated behind a new configuration option:
`# Set to true to Cache entities for the whole map on next run. `
`# WARNING! Will make server load take longer on the cache run but players will gain a performance boost when entering new areas.`
`CreateFullEntityCache=True`
