### PR TITLE
Base Construction Stabilization

### DIFF
--- a/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
+++ b/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
@@ -218,8 +218,7 @@ namespace NitroxClient.MonoBehaviours
                 // we look for a object that is able to be deconstructed that hasn't been tagged yet.
                 foreach (Transform child in cellTransform)
                 {
-                    bool isNewBasePiece = !child.GetComponent<NitroxEntity>() && child.GetComponent<BaseDeconstructable>();
-
+                    bool isNewBasePiece = !child.GetComponent<NitroxEntity>() && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector");
                     if (isNewBasePiece)
                     {
                         finishedPiece = child.gameObject;
@@ -227,6 +226,26 @@ namespace NitroxClient.MonoBehaviours
                     }
                 }
 
+                // This is a backup way to find the cell and final object if the TargetOffset fails.
+                if (finishedPiece == null)
+                {
+                    latestBase.GetClosestCell(constructing.gameObject.transform.position, out latestCell, out _, out _);
+                    cellTransform = latestBase.GetCellObject(latestCell);
+                    Validate.NotNull(cellTransform, $"Must have a cell transform, one not found near {constructing.gameObject.transform.position} for latestCell {latestCell}");
+                    
+                    // There can be multiple objects in a cell (such as a corridor with hatches built into it)
+                    // we look for a object that is able to be deconstructed that hasn't been tagged yet.
+                    foreach (Transform child in cellTransform)
+                    {
+                        bool isNewBasePiece = !child.GetComponent<NitroxEntity>() && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector");
+                        
+                        if (isNewBasePiece)
+                        {
+                            finishedPiece = child.gameObject;
+                            break;
+                        }
+                    }
+                }
                 Validate.NotNull(finishedPiece, $"Could not find finished piece in cell {latestCell} when constructing {constructionCompleted.PieceId}");
 
                 Log.Debug($"Construction completed on a base piece: {constructionCompleted.PieceId} {finishedPiece.name}");

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxModel.Core;
 using NitroxModel.DataStructures.Util;
+using NitroxModel.Logger;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
@@ -14,22 +15,30 @@ namespace NitroxPatcher.Patches.Dynamic
 
         private static Base lastTargetBase;
         private static Int3 lastTargetBaseOffset;
+        private static Base.Face lastFace;
 
         public static bool Prefix(Constructable __instance)
         {
-            if (!__instance._constructed && __instance.constructedAmount < 1.0f)
+            if (__instance.constructed)
             {
-                NitroxServiceLocator.LocateService<Building>().ChangeConstructionAmount(__instance.gameObject, __instance.constructedAmount);
+                return true;
             }
-
+            
             // If we are constructing a base piece then we'll want to store all of the BaseGhost information
             // as it will not be available when the construction hits 100%
-            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
-
-            if (baseGhost != null && baseGhost.TargetBase)
+            if (__instance is ConstructableBase constructableBase)
             {
-                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
-                lastTargetBaseOffset = baseGhost.TargetOffset;
+                BaseGhost baseGhost = constructableBase.gameObject.GetComponentInChildren<BaseGhost>();
+                if (baseGhost != null)
+                {
+                    lastTargetBase = baseGhost.TargetBase;
+                    lastTargetBaseOffset = baseGhost.TargetOffset;
+                }
+
+                if (constructableBase.moduleFace.HasValue)
+                {
+                    lastFace = constructableBase.moduleFace.Value;
+                }
             }
             else
             {
@@ -42,9 +51,13 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(Constructable __instance, bool __result)
         {
-            if (__result && __instance.constructedAmount >= 1.0f)
+            if (__result)
             {
-                NitroxServiceLocator.LocateService<Building>().ConstructionComplete(__instance.gameObject, Optional.OfNullable(lastTargetBase), lastTargetBaseOffset);
+                NitroxServiceLocator.LocateService<Building>().ChangeConstructionAmount(__instance.gameObject, __instance.constructedAmount);
+                if ( __instance._constructed)
+                {
+                    NitroxServiceLocator.LocateService<Building>().ConstructionComplete(__instance.gameObject, Optional.OfNullable(lastTargetBase), lastTargetBaseOffset, lastFace);
+                }
             }
         }
 


### PR DESCRIPTION
Constructable_Construct_Patch:
Ensured only run prefix if not already completed so it doesn't Null out the required data.
Ensured construction change only occured after a change actually happened.
Added Face Data for use to pinpoint Windows, Hatches, etc

Building:
Filtered false positives for connectors that are auto generated.
Added Face Pinpointing for Windows, Hatches, etc

Throttled Bulder:
Filtered false positives for connectors that are auto generated.
Added backup search incase offset fails