### PR TITLE
Sign metadata processor null ref fix

### DIFF
--- a/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
@@ -1,6 +1,8 @@
 ﻿using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Logger;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases.Metadata
@@ -10,13 +12,13 @@ namespace NitroxClient.GameLogic.Bases.Metadata
         public override void UpdateMetadata(NitroxId id, SignMetadata metadata)
         {
             GameObject gameObject = NitroxEntity.RequireObjectFrom(id);
-            uGUI_SignInput sign = gameObject.GetComponentInChildren<uGUI_SignInput>();
 
             sign.text = metadata.Text;
             sign.colorIndex = metadata.ColorIndex;
             sign.elementsState = metadata.Elements;
             sign.scaleIndex = metadata.ScaleIndex;
             sign.SetBackground(metadata.Background);
+            uGUI_SignInput sign = gameObject.GetComponentInChildren<uGUI_SignInput>(true);
         }
     }
 }

--- a/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
@@ -12,13 +12,19 @@ namespace NitroxClient.GameLogic.Bases.Metadata
         public override void UpdateMetadata(NitroxId id, SignMetadata metadata)
         {
             GameObject gameObject = NitroxEntity.RequireObjectFrom(id);
-
-            sign.text = metadata.Text;
-            sign.colorIndex = metadata.ColorIndex;
-            sign.elementsState = metadata.Elements;
-            sign.scaleIndex = metadata.ScaleIndex;
-            sign.SetBackground(metadata.Background);
             uGUI_SignInput sign = gameObject.GetComponentInChildren<uGUI_SignInput>(true);
+            if (sign.AliveOrNull() != null)
+            {
+                sign.text = metadata.Text;
+                sign.colorIndex = metadata.ColorIndex;
+                sign.elementsState = metadata.Elements;
+                sign.scaleIndex = metadata.ScaleIndex;
+                sign.SetBackground(metadata.Background);
+            }
+            else
+            {
+                Log.Error($"SignMetaData Processing failed for {gameObject.name}({gameObject.transform.position}). No sign component found on object.");
+            }
         }
     }
 }


### PR DESCRIPTION
Small Lockers with a name stop the world from loading as the sign component is not active when metadata is being restored causing the getcomponentinchildren to fail to find it causing a nullref which breaks the initial loader.