### PR TITLE
Constructable mp inventory 'sharing' fix

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -22,10 +22,6 @@ namespace NitroxPatcher.Patches.Dynamic
                 NitroxServiceLocator.LocateService<Building>().ChangeConstructionAmount(__instance.gameObject, __instance.constructedAmount);
             }
 
-            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
-            // as it will not be available when the construction hits 100%
-            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
-
             UnityEngine.GameObject gameObject;
             float dist;
 
@@ -78,6 +74,11 @@ namespace NitroxPatcher.Patches.Dynamic
                         {
                             // We're only running this code if the prc is using a builder and targetting something constructable within its build range.
                             // Feels sane -- feedback?
+
+                            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
+                            // as it will not be available when the construction hits 100%
+                            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
+
                             if (baseGhost != null && baseGhost.TargetBase)
                             {
                                 lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -26,6 +26,35 @@ namespace NitroxPatcher.Patches.Dynamic
             // as it will not be available when the construction hits 100%
             BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
 
+            UnityEngine.GameObject gameObject;
+            float dist;
+
+            Targeting.GetTarget(Player.main.gameObject, 30f, out gameObject, out dist, null);
+            if (gameObject != null)
+            {
+                Constructable constructable = gameObject.GetComponentInParent<Constructable>();
+                if (constructable != null)
+                {
+                    if (dist > constructable.placeMaxDistance)
+                    {
+                        return false;
+                    }
+
+                    if (!(GameInput.GetButtonHeld(GameInput.Button.LeftHand) | GameInput.GetButtonDown(GameInput.Button.Deconstruct) | GameInput.GetButtonHeld(GameInput.Button.Deconstruct)))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+
             if (baseGhost != null && baseGhost.TargetBase)
             {
                 lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -29,44 +29,81 @@ namespace NitroxPatcher.Patches.Dynamic
             UnityEngine.GameObject gameObject;
             float dist;
 
-            Targeting.GetTarget(Player.main.gameObject, 30f, out gameObject, out dist, null);
-            if (gameObject != null)
-            {
-                Constructable constructable = gameObject.GetComponentInParent<Constructable>();
-                if (constructable != null)
-                {
-                    if (dist > constructable.placeMaxDistance)
-                    {
-                        return false;
-                    }
 
-                    if (!(GameInput.GetButtonHeld(GameInput.Button.LeftHand) | GameInput.GetButtonDown(GameInput.Button.Deconstruct) | GameInput.GetButtonHeld(GameInput.Button.Deconstruct)))
-                    {
+            //   Prefix returning false skips client execution of patched routine; here
+            // we're (ideally) skipping execution of Constructable class Construct
+            // function any time the client running code is not the client building
+            // this thing. Rationale; Subnautica runs this to update visuals as well
+            // as resources (recipe items) added/requried, and build progress. It
+            // ALSO uses the same block of code to remove the next required item from
+            // the player's inventory, which causes the bug.
+            //   Since I cannot skip parts of the code, we skip the whole thing. The
+            // *only* side-effect I've seen from this is that non-building clients
+            // don't see the slow-fade-progression of building in progress. This is
+            // an acceptable compromise, in my opinion.
+            //   Also I'm using ugly if-else nesting to force context for variable
+            // scope to (ideally) allow the compiler to optimize destruction events
+            // instead of throwing it to GC. I know it's difficult to read, there's a
+            // decent reason for it though.
+            // -- codefaux
+
+            // We are checking for ....
+            if ((Inventory.main.quickSlots.GetSlotBinding(Inventory.main.quickSlots.activeSlot) == TechType.Builder) && (GameInput.GetButtonHeld(GameInput.Button.LeftHand)) )
+            { // Is the player running code currently weilding a builder, and holding the left hand key?
+                Targeting.GetTarget(Player.main.gameObject, 30f, out gameObject, out dist, null);
+                if (gameObject != null)
+                { // Is the prc targetting an object we can identify within a sane range?
+                    Constructable constructable = gameObject.GetComponentInParent<Constructable>();
+                    if (constructable != null)
+                    { // Is the thing prc is targetting a constructable?
+                        if (dist <= constructable.placeMaxDistance)
+                        { // Is the constructable thing prc is targetting within allowed build range?
+                            if (constructable == __instance.gameObject.GetComponentInParent<Constructable>())
+                            { // Is the constructable prc is targetting the same as the instance gameobject?
+
+                                // We have checked for:
+                                // - prc holding builder + pressing build key
+                                // -- aiming at a thing within moderate range
+                                // --- which is constructable
+                                // ---- which is within construction range
+                                // ----- which is also 'this' constructable
+
+                                // If we're here, client has extremely high odds of being positively identified as builder
+                                // False positive consequence; Player running code loses one inventory item of matching type, only if player building does not have required items available
+                                // False negative consequence; Player is unable to continue building until condition clears. No known -valid- conditions exist.
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            // We're only running this code if the prc is using a builder and targetting something constructable within its build range.
+                            // Feels sane -- feedback?
+                            if (baseGhost != null && baseGhost.TargetBase)
+                            {
+                                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
+                                lastTargetBaseOffset = baseGhost.TargetOffset;
+                            }
+                            else
+                            {
+                                lastTargetBase = null;
+                                lastTargetBaseOffset = default(Int3);
+                            }
+                        }
+                    }
+                    else
+                    { // The prc is not targetting a constructable
                         return false;
                     }
                 }
                 else
-                {
+                { // The prc is not targetting an object within scan range
                     return false;
                 }
             }
             else
-            {
+            { // The player running this code is not using a builder.
                 return false;
             }
-
-            if (baseGhost != null && baseGhost.TargetBase)
-            {
-                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
-                lastTargetBaseOffset = baseGhost.TargetOffset;
-            }
-            else
-            {
-                lastTargetBase = null;
-                lastTargetBaseOffset = default(Int3);
-            }
-
-            return true;
         }
 
         public static void Postfix(Constructable __instance, bool __result)

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -115,10 +115,11 @@ namespace NitroxServer.Serialization.World
             catch (Exception ex)
             {
                 Log.Error($"Could not load world, creating a new one : {ex.GetType()} {ex.Message}");
+                Log.Error($" {ex.StackTrace}");
 
                 //Backup world if loading fails
-                string outZip = Path.Combine(saveDir, "worldBackup.zip");
-                Log.WarnSensitive("Creating a backup at {path}", Path.GetFullPath(outZip));
+                string outZip = Path.Combine(saveDir, "worldBackup-" + DateTime.Now.ToString("ddMMMyy_HHmm") + ".zip");
+                Log.WarnSensitive("Creating a backup at {path}", Path.GetFullPath(outZip)); 
                 FileSystem.Instance.ZipFilesInDirectory(saveDir, outZip, $"*{FileEnding}", true);
             }
 


### PR DESCRIPTION
Bug: When building, if player (Builder) attempts to construct an object but does not have all required items in inventory, other players' inventory will have said item deleted.

Cause: Constructable class, Construct function - run on all clients regardless of wether they're building or not.

Proposed fix: It's a hack, but it works - simply check if the client is targetting an object, if that object is constructable, and if they're holding the construct buttons. Better fix would be to verify player is weilding BuilderTool, is targetting same constructable, is holding construct buttons -- but this is my first attempt at using Harmony, Visual Studio 2019, interfacing with the Unity engine, etc etc etc etc, so it's a hack....but to my surprise it works.

FLAWS: Currently the only flaw we've noticed to this fix is buildables don't seem to update their texture mid-construction for other players but I've tested this for a few hours with a few players and it seems to not introduce unexpected behaviors.

Will be testing if this cooperates with PR#1587 (https://github.com/SubnauticaNitrox/Nitrox/pull/1587) after stability is verified.

- This is my first pull request, be gentle lol