### PR TITLE
MP Building Inventory 'sharing' fixup

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -25,6 +25,21 @@ namespace NitroxPatcher.Patches.Dynamic
             UnityEngine.GameObject gameObject;
             float dist;
 
+            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
+            // as it will not be available when the construction hits 100%
+            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
+
+            if (baseGhost != null && baseGhost.TargetBase)
+            {
+                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
+                lastTargetBaseOffset = baseGhost.TargetOffset;
+            }
+            else
+            {
+                lastTargetBase = null;
+                lastTargetBaseOffset = default(Int3);
+            }
+
             //   Prefix returning false skips client execution of patched routine; here
             // we're (ideally) skipping execution of Constructable class Construct
             // function any time the client running code is not the client building
@@ -67,26 +82,6 @@ namespace NitroxPatcher.Patches.Dynamic
                                 // False positive consequence; Player running code loses one inventory item of matching type, only if player building does not have required items available
                                 // False negative consequence; Player is unable to continue building until condition clears. No known -valid- conditions exist.
                                 return true;
-                            }
-                        }
-                        else
-                        {
-                            // We're only running this code if the prc is using a builder and targetting something constructable within its build range.
-                            // Feels sane -- feedback?
-
-                            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
-                            // as it will not be available when the construction hits 100%
-                            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
-
-                            if (baseGhost != null && baseGhost.TargetBase)
-                            {
-                                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
-                                lastTargetBaseOffset = baseGhost.TargetOffset;
-                            }
-                            else
-                            {
-                                lastTargetBase = null;
-                                lastTargetBaseOffset = default(Int3);
                             }
                         }
                     }

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -22,22 +22,78 @@ namespace NitroxPatcher.Patches.Dynamic
                 NitroxServiceLocator.LocateService<Building>().ChangeConstructionAmount(__instance.gameObject, __instance.constructedAmount);
             }
 
-            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
-            // as it will not be available when the construction hits 100%
-            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
+            UnityEngine.GameObject gameObject;
+            float dist;
 
-            if (baseGhost != null && baseGhost.TargetBase)
-            {
-                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
-                lastTargetBaseOffset = baseGhost.TargetOffset;
-            }
-            else
-            {
-                lastTargetBase = null;
-                lastTargetBaseOffset = default(Int3);
+            //   Prefix returning false skips client execution of patched routine; here
+            // we're (ideally) skipping execution of Constructable class Construct
+            // function any time the client running code is not the client building
+            // this thing. Rationale; Subnautica runs this to update visuals as well
+            // as resources (recipe items) added/requried, and build progress. It
+            // ALSO uses the same block of code to remove the next required item from
+            // the player's inventory, which causes the bug.
+            //   Since I cannot skip parts of the code, we skip the whole thing. The
+            // *only* side-effect I've seen from this is that non-building clients
+            // don't see the slow-fade-progression of building in progress. This is
+            // an acceptable compromise, in my opinion.
+            //   Also I'm using ugly if-else nesting to force context for variable
+            // scope to (ideally) allow the compiler to optimize destruction events
+            // instead of throwing it to GC. I know it's difficult to read, there's a
+            // decent reason for it though.
+            // -- codefaux
+
+            // We are checking for ....
+            if ((Inventory.main.quickSlots.GetSlotBinding(Inventory.main.quickSlots.activeSlot) == TechType.Builder) && (GameInput.GetButtonHeld(GameInput.Button.LeftHand)) )
+            { // Is the player running code currently weilding a builder, and holding the left hand key?
+                Targeting.GetTarget(Player.main.gameObject, 30f, out gameObject, out dist, null);
+                if (gameObject != null)
+                { // Is the prc targetting an object we can identify within a sane range?
+                    Constructable constructable = gameObject.GetComponentInParent<Constructable>();
+                    if (constructable != null)
+                    { // Is the thing prc is targetting a constructable?
+                        if (dist <= constructable.placeMaxDistance)
+                        { // Is the constructable thing prc is targetting within allowed build range?
+                            if (constructable == __instance.gameObject.GetComponentInParent<Constructable>())
+                            { // Is the constructable prc is targetting the same as the instance gameobject?
+
+                                // We have checked for:
+                                // - prc holding builder + pressing build key
+                                // -- aiming at a thing within moderate range
+                                // --- which is constructable
+                                // ---- which is within construction range
+                                // ----- which is also 'this' constructable
+
+                                // If we're here, client has extremely high odds of being positively identified as builder
+                                // False positive consequence; Player running code loses one inventory item of matching type, only if player building does not have required items available
+                                // False negative consequence; Player is unable to continue building until condition clears. No known -valid- conditions exist.
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            // We're only running this code if the prc is using a builder and targetting something constructable within its build range.
+                            // Feels sane -- feedback?
+
+                            // If we are constructing a base piece then we'll want to store all of the BaseGhost information
+                            // as it will not be available when the construction hits 100%
+                            BaseGhost baseGhost = __instance.gameObject.GetComponentInChildren<BaseGhost>();
+
+                            if (baseGhost != null && baseGhost.TargetBase)
+                            {
+                                lastTargetBase = baseGhost.TargetBase.GetComponent<Base>();
+                                lastTargetBaseOffset = baseGhost.TargetOffset;
+                            }
+                            else
+                            {
+                                lastTargetBase = null;
+                                lastTargetBaseOffset = default(Int3);
+                            }
+                        }
+                    }
+                }
             }
 
-            return true;
+            return false;
         }
 
         public static void Postfix(Constructable __instance, bool __result)


### PR DESCRIPTION
Second attempt, this time without extra accidental patches, and a proper non-hack solution (so far as I can see it)

Bug: When building, if player (Builder) attempts to construct an object but does not have all required items in inventory, other players' inventory will have said item deleted.

Cause: Constructable class, Construct function - run on all clients regardless of wether they're building or not.

Proposed fix: Proper checks throughout, to ensure player is holding the builder, using the tool, aiming at the right thing, etc etc.

FLAWS: Currently the only flaw we've noticed to this fix is buildables don't seem to update their texture mid-construction for other players but I've tested this with a few players and it seems to not introduce unexpected behaviors.

Will be testing if this cooperates with PR#1587 (#1587) after stability is verified.
(EDIT: Played all day w/ #1587 applied, no issues so far.)

This is my second pull request, be gentle lol