### PR TITLE
Fixed RegistryEx.cs key compare

### DIFF
--- a/NitroxModel/Platforms/OS/Windows/Internal/RegistryEx.cs
+++ b/NitroxModel/Platforms/OS/Windows/Internal/RegistryEx.cs
@@ -158,6 +158,12 @@ namespace NitroxModel.Platforms.OS.Windows.Internal
                                 {
                                     while (!token.IsCancellationRequested)
                                     {
+                                        // If regkey didn't exist yet it might later.
+                                        if (baseKey == null)
+                                        {
+                                            (baseKey, valueKey) = GetKey(pathWithKey, false);
+                                        }
+                                        
                                         if (!Test(baseKey, valueKey, predicate))
                                         {
                                             await Task.Delay(100, token);
@@ -169,7 +175,7 @@ namespace NitroxModel.Platforms.OS.Windows.Internal
                                 }
                                 finally
                                 {
-                                    baseKey.Dispose();
+                                    baseKey?.Dispose();
                                 }
                             },
                             token);


### PR DESCRIPTION
If the registry key does not exist then it will be null and the compare will always fail to compare the key's value.