### PR TITLE
Cleans publicised assemblies on clean of project

### DIFF
--- a/Nitrox.BuildTool/Nitrox.BuildTool.csproj
+++ b/Nitrox.BuildTool/Nitrox.BuildTool.csproj
@@ -35,7 +35,7 @@
       <ProjectReference Include="..\NitroxModel\NitroxModel.csproj" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Target Name="Clean"  AfterTargets="Clean">
+    <Target Name="Clean" AfterTargets="Clean">
         <!-- Clean bin folder -->
         <RemoveDir Directories="$(OutputPath)" />
     </Target>


### PR DESCRIPTION
Cleans the bin folder and removes the publicised assemblies meaning manual removal is not needed. Especially when switching between games