### PR TITLE
Scanner room sync

### DIFF
--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -127,6 +127,7 @@ namespace NitroxClient
             containerBuilder.RegisterType<Fires>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<FMODSystem>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<LiveMixinManager>().InstancePerLifetimeScope();
+            containerBuilder.RegisterType<CameraControlManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<NitroxSettingsManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<ThrottledPacketSender>().InstancePerLifetimeScope();
         }

--- a/NitroxClient/Communication/Packets/Processors/CameraMovementProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CameraMovementProcessor.cs
@@ -1,0 +1,25 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors
+{
+    public class CameraMovementProcessor : ClientPacketProcessor<CameraMovement>
+    {
+        public CameraMovementProcessor()
+        {
+            // TornacTODO: Include a "movement smoother"
+        }
+
+        public override void Process(CameraMovement cameraMovement)
+        {
+            if (NitroxEntity.TryGetObjectFrom(cameraMovement.CameraMovementData.Id, out GameObject cameraObject))
+            {
+                cameraObject.transform.position = cameraMovement.Position.ToUnity();
+                cameraObject.transform.rotation = cameraMovement.BodyRotation.ToUnity();
+            }
+        }
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/DockingStateChangeProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DockingStateChangeProcessor.cs
@@ -1,0 +1,32 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Logger;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors
+{
+    public class DockingStateChangeProcessor : ClientPacketProcessor<DockingStateChange>
+    {
+        public override void Process(DockingStateChange dockingStateChange)
+        {
+            if (NitroxEntity.TryGetObjectFrom(dockingStateChange.NitroxId, out GameObject gameObject))
+            {
+                if (gameObject.TryGetComponent(out MapRoomCameraDocking mapRoomCameraDocking))
+                {
+                    if (!dockingStateChange.Docked)
+                    {
+                        // Need to manually apply modifications that doesn't happen automatically
+                        mapRoomCameraDocking.camera.SetDocked(null);
+                        mapRoomCameraDocking.camera = null;
+                        mapRoomCameraDocking.cameraDocked = false;
+                    }
+                }
+            }
+            else
+            {
+                Log.Warn($"Couldn't find MapRoomCameraDocking [NitroxId:{dockingStateChange.NitroxId}], a NitroxId desync may have occurred");
+            }
+        }
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/MapRoomScanProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/MapRoomScanProcessor.cs
@@ -1,0 +1,37 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Logger;
+using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors
+{
+    public class MapRoomScanProcessor : ClientPacketProcessor<MapRoomScan>
+    {
+        public override void Process(MapRoomScan mapRoomScan)
+        {
+            if (NitroxEntity.TryGetObjectFrom(mapRoomScan.NitroxId, out GameObject gameObject))
+            {
+                if (gameObject.TryGetComponent(out uGUI_MapRoomScanner uGUI_MapRoomScanner))
+                {
+                    // ScanAction is either to scan or to cancel
+                    if (mapRoomScan.ScanAction)
+                    {
+                        uGUI_MapRoomScanner.mapRoom.StartScanning(mapRoomScan.NitroxTechType.ToUnity());
+                        uGUI_MapRoomScanner.UpdateGUIState();
+                    }
+                    else
+                    {
+                        uGUI_MapRoomScanner.mapRoom.StartScanning(TechType.None);
+                        uGUI_MapRoomScanner.UpdateGUIState();
+                    }
+                }
+            }
+            else
+            {
+                Log.Warn($"Couldn't find MapRoomFunctionality [NitroxId:{mapRoomScan.NitroxId}], a NitroxId desync may have occurred");
+            }
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Bases/Metadata/BasePieceMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/BasePieceMetadataProcessor.cs
@@ -9,7 +9,7 @@ namespace NitroxClient.GameLogic.Bases.Metadata
 {
     public abstract class BasePieceMetadataProcessor
     {
-        public abstract void UpdateMetadata(NitroxId id, BasePieceMetadata metadata);
+        public abstract void UpdateMetadata(NitroxId id, BasePieceMetadata metadata, bool initialSync = false);
 
         private static NoOpBasePieceMetadataProcessor noOpProcessor = new NoOpBasePieceMetadataProcessor();
         private static Dictionary<Type, BasePieceMetadataProcessor> processorsByType = new Dictionary<Type, BasePieceMetadataProcessor>();

--- a/NitroxClient/GameLogic/Bases/Metadata/GenericBasePieceMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/GenericBasePieceMetadataProcessor.cs
@@ -5,11 +5,11 @@ namespace NitroxClient.GameLogic.Bases.Metadata
 {
     public abstract class GenericBasePieceMetadataProcessor<T> : BasePieceMetadataProcessor where T : BasePieceMetadata
     {
-        public abstract void UpdateMetadata(NitroxId id, T metadata);
+        public abstract void UpdateMetadata(NitroxId id, T metadata, bool initialSync = false);
 
-        public override void UpdateMetadata(NitroxId id, BasePieceMetadata metadata)
+        public override void UpdateMetadata(NitroxId id, BasePieceMetadata metadata, bool initialSync = false)
         {
-            UpdateMetadata(id, (T)metadata);
+            UpdateMetadata(id, (T)metadata, initialSync);
         }
     }
 }

--- a/NitroxClient/GameLogic/Bases/Metadata/MapRoomMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/MapRoomMetadataProcessor.cs
@@ -1,0 +1,80 @@
+﻿using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Logger;
+using NitroxModel_Subnautica.DataStructures;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Bases.Metadata
+{
+    public class MapRoomMetadataProcessor : GenericBasePieceMetadataProcessor<MapRoomMetadata>
+    {
+        public override void UpdateMetadata(NitroxId id, MapRoomMetadata metadata, bool initialSync)
+        {
+            if (!initialSync)
+            {
+                // Log.Debug("UpdateMetadata() but not initial sync");
+                return;
+            }
+            // Log.Debug($"UpdateMetada({id}, {metadata})");
+
+            // MRF_GO is the MapRoomFunctionality's GameObject which has the NitroxId provided in the metadata
+            GameObject MRF_GO;
+            if (!NitroxEntity.TryGetObjectFrom(metadata.MapRoomFunctionalityId, out MRF_GO))
+            {
+                Log.Error($"There was an error while processing MapRoomMetadata for [NitroxId: {metadata.MapRoomFunctionalityId}], the corresponding game object couldn't be found");
+                return;
+            }
+            
+            MapRoomCameraDocking cameraDocking1 = MRF_GO.FindChild("dockingPoint1").GetComponent<MapRoomCameraDocking>();
+            MapRoomCameraDocking cameraDocking2 = MRF_GO.FindChild("dockingPoint2").GetComponent<MapRoomCameraDocking>();
+            if (cameraDocking1.AliveOrNull() != null && cameraDocking2.AliveOrNull() != null)
+            {
+                Log.Debug($"Processing CameraDockingMetadata [{metadata}]");
+                // Simulate Undock but don't do it else Postfix will happen
+                if (!metadata.CameraDocked1)
+                {
+                    if (cameraDocking1.camera != null)
+                    {
+                        NitroxEntity.RemoveFrom(cameraDocking1.camera.gameObject);
+                        UnityEngine.Object.Destroy(cameraDocking1.camera.gameObject);
+                        cameraDocking1.camera = null;
+                        cameraDocking1.cameraDocked = false;
+                    }
+                }
+                else if (metadata.Camera1NitroxId != null)
+                {
+                    NitroxEntity.SetNewId(cameraDocking1.camera.gameObject, metadata.Camera1NitroxId);
+                }
+                if (!metadata.CameraDocked2)
+                {
+                    NitroxEntity.RemoveFrom(cameraDocking2.camera.gameObject);
+                    UnityEngine.Object.Destroy(cameraDocking2.camera.gameObject);
+                    cameraDocking2.camera = null;
+                    cameraDocking2.cameraDocked = false;
+                }
+                else if (metadata.Camera2NitroxId != null)
+                {
+                    NitroxEntity.SetNewId(cameraDocking2.camera.gameObject, metadata.Camera2NitroxId);
+                }
+            }
+            else
+            {
+                Log.Error($"MapRoomMetadata Processing failed for {MRF_GO.name}({MRF_GO.transform.position}). No MapRoomCameraDocking component was found on object's children.");
+                return;
+            }
+            // Recover the state of the scanner
+            uGUI_MapRoomScanner uGUI_MapRoomScanner = MRF_GO.transform.Find("screen/scannerUI").GetComponent<uGUI_MapRoomScanner>();
+            if (uGUI_MapRoomScanner.AliveOrNull() != null && metadata.TypeToScan != null)
+            {
+                uGUI_MapRoomScanner.mapRoom.StartScanning(metadata.TypeToScan.ToUnity());
+                uGUI_MapRoomScanner.UpdateGUIState();
+            }
+            else
+            {
+                Log.Error($"MapRoomMetadata Processing failed for {MRF_GO.name}({MRF_GO.transform.position}). No uGUI_MapRoomScanner component was found on object's children.");
+            }
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Bases/Metadata/NoOpBasePieceMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/NoOpBasePieceMetadataProcessor.cs
@@ -5,7 +5,7 @@ namespace NitroxClient.GameLogic.Bases.Metadata
 {
     public class NoOpBasePieceMetadataProcessor : BasePieceMetadataProcessor
     {
-        public override void UpdateMetadata(NitroxId id, BasePieceMetadata metadata)
+        public override void UpdateMetadata(NitroxId id, BasePieceMetadata metadata, bool initialSync)
         {
             // No-op
         }

--- a/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Metadata/SignMetadataProcessor.cs
@@ -8,7 +8,7 @@ namespace NitroxClient.GameLogic.Bases.Metadata
 {
     public class SignMetadataProcessor : GenericBasePieceMetadataProcessor<SignMetadata>
     {
-        public override void UpdateMetadata(NitroxId id, SignMetadata metadata)
+        public override void UpdateMetadata(NitroxId id, SignMetadata metadata, bool initialSync)
         {
             GameObject gameObject = NitroxEntity.RequireObjectFrom(id);
             uGUI_SignInput sign = gameObject.GetComponentInChildren<uGUI_SignInput>(true);

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
@@ -19,7 +19,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             TechType.BaseBioReactor
         };
 
-        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstructed)
         {
             NitroxId reactorId = NitroxEntity.GetId(finishedPiece);
             BaseBioReactorGeometry bioReactor = finishedPiece.RequireComponent<BaseBioReactorGeometry>();

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
@@ -12,7 +12,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             TechType.BaseLadder
         };
 
-        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstructed)
         {
             bool builtLadderOnFloor = finishedPiece.name.Contains("Bottom");
             Int3 cellToSearch = builtLadderOnFloor ? new Int3(latestCell.x, latestCell.y - 1, latestCell.z) : new Int3(latestCell.x, latestCell.y + 1, latestCell.z);

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
@@ -29,15 +31,15 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             }
         }
 
-        protected abstract void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece);
+        protected abstract void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstructed);
 
-        public static void RunSpawnProcessor(BaseDeconstructable baseDeconstructable, Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        public static void RunSpawnProcessor(BaseDeconstructable baseDeconstructable, Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstructed)
         {
             TechType techType = baseDeconstructable.recipe;
             if (processorsByType.TryGetValue(techType, out BasePieceSpawnProcessor processor))
             {
                 Log.Info($"Found custom BasePieceSpawnProcessor for {techType}");
-                processor.SpawnPostProcess(latestBase, latestCell, finishedPiece);
+                processor.SpawnPostProcess(latestBase, latestCell, finishedPiece, justConstructed);
             }
         }
     }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
@@ -18,7 +18,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             TechType.BaseWaterPark
         };
 
-        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstruced)
         {
             NitroxId pieceId = NitroxEntity.GetId(finishedPiece);
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NitroxClient.MonoBehaviours;
+using NitroxModel.Core;
 using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Logger;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
@@ -17,9 +20,12 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         {
             TechType.BaseMapRoom
         };
+        private static Building building;
 
-        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece, bool justConstructed)
         {
+            building ??= NitroxServiceLocator.LocateService<Building>();
+
             NitroxId mapRoomGeometryPieceId = NitroxEntity.GetId(finishedPiece);
             GameObject mapRoomFunctionality = FindUntaggedMapRoomFunctionality(latestBase);
 
@@ -29,6 +35,54 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             GameObject mapRoomModules = mapRoomFunctionality.FindChild("MapRoomUpgrades");
             NitroxId mapRoomModulesId = mapRoomFunctionalityId.Increment();
             NitroxEntity.SetNewId(mapRoomModules, mapRoomModulesId);
+
+            // Need to make sure that it already spawned
+            PrefabSpawn fabricatorSpawn = mapRoomFunctionality.FindChild("MapRoomFabricatorSpawn").GetComponent<PrefabSpawn>();
+            fabricatorSpawn.spawnType = SpawnType.Manual;
+            GameObject mapRoomFabricator = fabricatorSpawn.SpawnManual();
+            NitroxId mapRoomFabricatorId = mapRoomModulesId.Increment();
+            NitroxEntity.SetNewId(mapRoomFabricator, mapRoomFabricatorId);
+
+            GameObject mapRoomScreen = mapRoomFunctionality.transform.Find("screen/cameraScreen/input").gameObject;
+            NitroxId mapRoomScreenId = mapRoomFabricatorId.Increment();
+            NitroxEntity.SetNewId(mapRoomScreen, mapRoomScreenId);
+
+            GameObject scannerUI = mapRoomFunctionality.transform.Find("screen/scannerUI").gameObject;
+            NitroxId scannerUIId = mapRoomScreenId.Increment();
+            NitroxEntity.SetNewId(scannerUI, scannerUIId);
+
+            NitroxId dockingPoint1Id = scannerUIId.Increment();
+            NitroxId dockingPoint2Id = dockingPoint1Id.Increment().Increment();
+
+            Log.Debug($"Spawned MapRoomFunctionality: {mapRoomFunctionality.name}, justConstructed: {justConstructed}");
+            foreach (MapRoomCameraDocking docking in mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>())
+            {
+                // Simulate Start but don't call DockCamera to not start a Postfix
+                // Log.Debug($"Docking found: [name: {docking.name}, camera: {docking.camera}, cameraDocked: {docking.cameraDocked}]");
+                docking.cameraDocked = true;
+                docking.deserialized = true;
+                GameObject cameraGameObject = UnityEngine.Object.Instantiate(docking.cameraPrefab);
+                CrafterLogic.NotifyCraftEnd(cameraGameObject, TechType.MapRoomCamera);
+                docking.camera = cameraGameObject.GetComponent<MapRoomCamera>();
+                docking.camera.transform.position = docking.dockingTransform.position;
+                docking.camera.transform.rotation = docking.dockingTransform.rotation;
+                docking.camera.SetDocked(docking);
+                switch (docking.gameObject.name)
+                {
+                    case "dockingPoint1":
+                        NitroxEntity.SetNewId(docking.gameObject, dockingPoint1Id);
+                        NitroxEntity.SetNewId(cameraGameObject, dockingPoint1Id.Increment());
+                        break;
+                    case "dockingPoint2":
+                        NitroxEntity.SetNewId(docking.gameObject, dockingPoint2Id);
+                        NitroxEntity.SetNewId(cameraGameObject, dockingPoint2Id.Increment());
+                        break;
+                }
+            }
+            if (justConstructed)
+            {
+                building.MetadataChanged(mapRoomGeometryPieceId, mapRoomFunctionalityId, new MapRoomMetadata(mapRoomFunctionalityId, true, true, dockingPoint1Id.Increment(), dockingPoint2Id.Increment(), null));
+            }
         }
 
         private static GameObject FindUntaggedMapRoomFunctionality(Base latestBase)

--- a/NitroxClient/GameLogic/Building.cs
+++ b/NitroxClient/GameLogic/Building.cs
@@ -186,7 +186,7 @@ namespace NitroxClient.GameLogic
                 Object.Destroy(ghost);
                 NitroxEntity.SetNewId(finishedPiece, id);
 
-                BasePieceSpawnProcessor.RunSpawnProcessor(finishedPiece.GetComponent<BaseDeconstructable>(), latestBase, latestCell, finishedPiece);
+                BasePieceSpawnProcessor.RunSpawnProcessor(finishedPiece.GetComponent<BaseDeconstructable>(), latestBase, latestCell, finishedPiece, true);
             }
             else if (ghost.TryGetComponent(out Constructable constructable))
             {
@@ -221,9 +221,16 @@ namespace NitroxClient.GameLogic
             NitroxEntity.RemoveFrom(gameObject);
         }
 
+        // Deprecated, this should no longer be used
         public void MetadataChanged(NitroxId pieceId, BasePieceMetadata metadata)
         {
-            BasePieceMetadataChanged changePacket = new BasePieceMetadataChanged(pieceId, metadata);
+            BasePieceMetadataChanged changePacket = new BasePieceMetadataChanged(null, pieceId, metadata);
+            packetSender.Send(changePacket);
+        }
+
+        public void MetadataChanged(NitroxId baseParentId, NitroxId pieceId, BasePieceMetadata metadata)
+        {
+            BasePieceMetadataChanged changePacket = new BasePieceMetadataChanged(baseParentId, pieceId, metadata);
             packetSender.Send(changePacket);
         }
     }

--- a/NitroxClient/GameLogic/CameraControlManager.cs
+++ b/NitroxClient/GameLogic/CameraControlManager.cs
@@ -1,0 +1,95 @@
+﻿using NitroxClient.GameLogic.Simulation;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Core;
+using NitroxModel.DataStructures;
+using NitroxModel.Logger;
+
+namespace NitroxClient.GameLogic
+{
+    public class CameraControlManager
+    {
+        public static CameraControlManager Instance;
+        private SimulationOwnership simulationOwnership;
+
+        public NitroxId CurrentCameraId;
+        public bool WaitingForLock;
+        private bool hasControlOverCurrentCameraCache;
+        
+        public CameraControlManager()
+        {
+            // TornacTODO: Verify why player's location is not locked when controlling a camera
+            Instance = this;
+            simulationOwnership = NitroxServiceLocator.LocateService<SimulationOwnership>();
+        }
+
+        public void ControlCamera(MapRoomCamera mapRoomCamera)
+        {
+            CurrentCameraId = NitroxEntity.GetId(mapRoomCamera.gameObject);
+            PlayerMovement.ControlledCamera = mapRoomCamera;
+            PlayerMovement.ControllingCamera = false;
+            hasControlOverCurrentCameraCache = false;
+            WaitingForLock = true;
+            ChangeCameraTitle("Trying to get control over this camera", "fff700");
+            LockRequest<CameraControl> lockRequest = new(CurrentCameraId, SimulationLockType.EXCLUSIVE, ReceivedSimulationLockResponse, new CameraControl(CurrentCameraId));
+            simulationOwnership.RequestSimulationLock(lockRequest);
+        }
+
+        public void FreeCamera()
+        {
+            PlayerMovement.ControllingCamera = false;
+            PlayerMovement.ControlledCamera = null;
+            hasControlOverCurrentCameraCache = false;
+            WaitingForLock = false;
+            simulationOwnership.RequestSimulationLock(CurrentCameraId, SimulationLockType.TRANSIENT);
+            CurrentCameraId = null;
+            ChangeCameraTitle(null);
+        }
+
+        public void ReceivedSimulationLockResponse(NitroxId id, bool lockAquired, CameraControl context)
+        {
+            WaitingForLock = false;
+
+            // Maybe the client cycled to another camera before he received the lock
+            if (id.Equals(CurrentCameraId))
+            {
+                if (lockAquired)
+                {
+                    // Now controlling camera
+                    Log.Debug($"Now controlling camera [{id}]");
+                    PlayerMovement.ControllingCamera = true;
+                    hasControlOverCurrentCameraCache = true;
+                    ChangeCameraTitle(null, "00ff00");
+                }
+                else
+                {
+                    // Camera is already controlled
+                    Log.Debug($"Now spectating camera [{id}]");
+                    ChangeCameraTitle("This camera is already being controlled by another player", "FFB200");
+                    hasControlOverCurrentCameraCache = false;
+                }
+            }
+            else
+            {
+                hasControlOverCurrentCameraCache = false;
+            }
+        }
+
+        public bool HasControlOverCurrentCamera()
+        {
+            return hasControlOverCurrentCameraCache;
+        }
+
+        public void ChangeCameraTitle(string titleAddition, string colorCode = "ffffff")
+        {
+            uGUI_CameraDrone.main.UpdateCameraTitle();
+            if (titleAddition != null)
+            {
+                uGUI_CameraDrone.main.textTitle.text += $" <color=#{colorCode}>{titleAddition}</color>";
+            }
+            else if(colorCode != "ffffff")
+            {
+                uGUI_CameraDrone.main.textTitle.text = $"<color=#{colorCode}>{uGUI_CameraDrone.main.textTitle.text}</color>";
+            }
+        }
+    }
+}

--- a/NitroxClient/GameLogic/InitialSync/BasePieceMetadataInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/BasePieceMetadataInitialSyncProcessor.cs
@@ -27,7 +27,7 @@ namespace NitroxClient.GameLogic.InitialSync
                 {
                     BasePieceMetadata metadata = basePiece.Metadata.Value;
                     BasePieceMetadataProcessor metadataProcessor = BasePieceMetadataProcessor.FromMetaData(metadata);
-                    metadataProcessor.UpdateMetadata(basePiece.Id, metadata);
+                    metadataProcessor.UpdateMetadata(basePiece.ParentId.Value, metadata, true);
                     basePiecesWithMetadata++;
                 }
 

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -49,6 +49,12 @@ namespace NitroxClient.GameLogic
             packetSender.Send(playerStats);
         }
 
+        public void UpdateCameraLocation(CameraMovementData cameraMovementData)
+        {
+            CameraMovement cameraMovement = new CameraMovement(multiplayerSession.Reservation.PlayerId, cameraMovementData);
+            packetSender.Send(cameraMovement);
+        }
+
         public void UpdateLocation(Vector3 location, Vector3 velocity, Quaternion bodyRotation, Quaternion aimingRotation, Optional<VehicleMovementData> vehicle)
         {
             Movement movement;

--- a/NitroxClient/GameLogic/Simulation/CameraControl.cs
+++ b/NitroxClient/GameLogic/Simulation/CameraControl.cs
@@ -1,0 +1,14 @@
+﻿using NitroxModel.DataStructures;
+
+namespace NitroxClient.GameLogic.Simulation
+{
+    public class CameraControl : LockRequestContext
+    {
+        public NitroxId CameraNitroxId { get; }
+
+        public CameraControl(NitroxId cameraNitroxId)
+        {
+            CameraNitroxId = cameraNitroxId;
+        }
+    }
+}

--- a/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
+++ b/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
@@ -228,7 +228,7 @@ namespace NitroxClient.MonoBehaviours
                 Destroy(constructableBase.gameObject);
                 NitroxEntity.SetNewId(finishedPiece, constructionCompleted.PieceId);
 
-                BasePieceSpawnProcessor.RunSpawnProcessor(finishedPiece.GetComponent<BaseDeconstructable>(), latestBase, latestCell, finishedPiece);
+                BasePieceSpawnProcessor.RunSpawnProcessor(finishedPiece.GetComponent<BaseDeconstructable>(), latestBase, latestCell, finishedPiece, false);
             }
             else if (constructing.TryGetComponent(out Constructable constructable))
             {

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Communication\Packets\Processors\AnimationProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\BasePieceMetadataChangedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\BedEnterProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\CameraMovementProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\CellEntitiesProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ChatMessageProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ConstructionAmountChangedProcessor.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="Communication\Packets\Processors\DeconstructionBeginProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\DeconstructionCompletedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\DisconnectProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\DockingStateChangeProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EnergyMixinValueChangedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EntityMetadataUpdateProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EntityTransformUpdatesProcessor.cs" />
@@ -88,6 +90,7 @@
     <Compile Include="Communication\Packets\Processors\ItemPositionProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\KnownTechEntryAddProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\LifeMixinChangedProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\MapRoomScanProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\MedicalCabinetClickedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ModuleAddedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ModuleRemovedProcessor.cs" />
@@ -152,6 +155,7 @@
     <Compile Include="GameLogic\Bases\GeometryRespawnManager.cs" />
     <Compile Include="GameLogic\Bases\Metadata\BasePieceMetadataProcessor.cs" />
     <Compile Include="GameLogic\Bases\Metadata\GenericBasePieceMetadataProcessor.cs" />
+    <Compile Include="GameLogic\Bases\Metadata\MapRoomMetadataProcessor.cs" />
     <Compile Include="GameLogic\Bases\Metadata\NoOpBasePieceMetadataProcessor.cs" />
     <Compile Include="GameLogic\Bases\Metadata\SignMetadataProcessor.cs" />
     <Compile Include="GameLogic\Bases\Spawning\BasePiece\BaseBioReactorSpawnProcessor.cs" />
@@ -168,6 +172,7 @@
     <Compile Include="GameLogic\Containers\ContainerAddItemPostProcessor.cs" />
     <Compile Include="GameLogic\Containers\NoOpContainerAddItemPostProcessor.cs" />
     <Compile Include="GameLogic\Containers\PlantableContainerAddItemPostProcessor.cs" />
+    <Compile Include="GameLogic\CameraControlManager.cs" />
     <Compile Include="GameLogic\Crafting.cs" />
     <Compile Include="GameLogic\Cyclops.cs" />
     <Compile Include="GameLogic\Debugger.cs" />
@@ -261,6 +266,7 @@
     <Compile Include="GameLogic\Rockets.cs" />
     <Compile Include="GameLogic\SeamothModulesEvent.cs" />
     <Compile Include="GameLogic\Settings\NitroxSettingsManager.cs" />
+    <Compile Include="GameLogic\Simulation\CameraControl.cs" />
     <Compile Include="GameLogic\Simulation\HandInteraction.cs" />
     <Compile Include="GameLogic\Simulation\LockRequest.cs" />
     <Compile Include="GameLogic\Simulation\LockRequestBase.cs" />

--- a/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/BasePieceMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/BasePieceMetadata.cs
@@ -5,7 +5,13 @@ namespace NitroxModel.DataStructures.GameLogic.Buildings.Metadata
 {
     [Serializable]
     [ProtoContract, ProtoInclude(50, typeof(SignMetadata))]
+    [ProtoInclude(100, typeof(MapRoomMetadata))]
     public abstract class BasePieceMetadata
     {
+        public bool OnlyUpdate;
+        public object[] UpdatePayload;
+        public int PayloadType;
+        public abstract void RefreshUpdatePayload();
+        public abstract BasePieceMetadata LoadUpdatePayload(object[] updatePayload, int payloadType);
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/MapRoomMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/MapRoomMetadata.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using ProtoBufNet;
+
+namespace NitroxModel.DataStructures.GameLogic.Buildings.Metadata
+{
+    [Serializable]
+    [ProtoContract]
+    public class MapRoomMetadata : BasePieceMetadata
+    {
+        [ProtoMember(1)]
+        public NitroxId MapRoomFunctionalityId { get; set; }
+        [ProtoMember(2)]
+        public bool CameraDocked1 { get; set; }
+        [ProtoMember(3)]
+        public bool CameraDocked2 { get; set; }
+        [ProtoMember(4)]
+        public NitroxId Camera1NitroxId { get; set; }
+        [ProtoMember(5)]
+        public NitroxId Camera2NitroxId { get; set; }
+        [ProtoMember(6)]
+        public NitroxTechType TypeToScan { get; set; }
+
+        protected MapRoomMetadata()
+        {
+            //Constructor for serialization. Has to be "protected" for json serialization.
+        }
+
+        public MapRoomMetadata(NitroxId mapRoomFunctionalityId, bool cameraDocked1, bool cameraDocked2, NitroxId camera1NitroxId, NitroxId camera2NitroxId, NitroxTechType typeToScan, bool onlyUpdate = false, int payloadType = 0) : base()
+        {
+            MapRoomFunctionalityId = mapRoomFunctionalityId;
+            CameraDocked1 = cameraDocked1;
+            CameraDocked2 = cameraDocked2;
+            Camera1NitroxId = camera1NitroxId;
+            Camera2NitroxId = camera2NitroxId;
+            TypeToScan = typeToScan;
+            OnlyUpdate = onlyUpdate;
+            PayloadType = payloadType;
+            RefreshUpdatePayload();
+        }
+        public MapRoomMetadata(NitroxId mapRoomFunctionalityId, bool cameraDocked1, bool cameraDocked2, NitroxId camera1NitroxId, NitroxId camera2NitroxId) : this(mapRoomFunctionalityId, cameraDocked1, cameraDocked2, camera1NitroxId, camera2NitroxId, null, true, 1)
+        { }
+
+        public MapRoomMetadata(NitroxId mapRoomFunctionalityId, NitroxTechType typeToScan) : this(mapRoomFunctionalityId, false, false, null, null, typeToScan, true, 2)
+        { }
+
+        public override void RefreshUpdatePayload()
+        {
+            switch (PayloadType)
+            {
+                case 1:
+                    UpdatePayload = new object[] { CameraDocked1, CameraDocked2, Camera1NitroxId, Camera2NitroxId };
+                    break;
+                case 2:
+                    UpdatePayload = new object[] { TypeToScan };
+                    break;
+            }
+            
+        }
+
+        public override BasePieceMetadata LoadUpdatePayload(object[] updatePayload, int payloadType)
+        {
+            switch (payloadType)
+            {
+                case 1:
+                    CameraDocked1 = (bool)updatePayload[0];
+                    CameraDocked2 = (bool)updatePayload[1];
+                    Camera1NitroxId = (NitroxId)updatePayload[2];
+                    Camera2NitroxId = (NitroxId)updatePayload[3];
+                    break;
+                case 2:
+                    TypeToScan = (NitroxTechType)updatePayload[0];
+                    break;
+            }
+            return this;
+        }
+
+        public override string ToString()
+        {
+            return $"[CameraDockingMetadata - MapRoomFunctionalityId: {MapRoomFunctionalityId}, CameraDocked1: {CameraDocked1}, CameraDocked2: {CameraDocked2}, Camera1NitroxId: {Camera1NitroxId}, Camera2NitroxId: {Camera2NitroxId}, TypeToScan: {TypeToScan}]";
+        }
+    }
+}

--- a/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/SignMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Buildings/Metadata/SignMetadata.cs
@@ -38,7 +38,17 @@ namespace NitroxModel.DataStructures.GameLogic.Buildings.Metadata
 
         public override string ToString()
         {
-            return "[SignMetadata - Text: " + Text + " ColorIndex: " + ColorIndex + "ScaleIndex: " + ScaleIndex + " Elements: " + Elements + " Background: " + Background + "]";
+            return "[SignMetadata - Text: " + Text + ", ColorIndex: " + ColorIndex + ", ScaleIndex: " + ScaleIndex + ", Elements: " + Elements + ", Background: " + Background + "]";
+        }
+
+        public override BasePieceMetadata LoadUpdatePayload(object[] updatePayload, int payloadType)
+        {
+            return this;
+        }
+
+        public override void RefreshUpdatePayload()
+        {
+            
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/CameraMovementData.cs
+++ b/NitroxModel/DataStructures/GameLogic/CameraMovementData.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NitroxModel.DataStructures.Unity;
+using ProtoBufNet;
+
+namespace NitroxModel.DataStructures.GameLogic
+{
+    [Serializable]
+    [ProtoContract]
+    public class CameraMovementData
+    {
+        [ProtoMember(1)]
+        public NitroxTechType TechType { get; }
+
+        [ProtoMember(2)]
+        public NitroxId Id { get; set; }
+
+        [ProtoMember(3)]
+        public NitroxVector3 Position { get; }
+
+        [ProtoMember(4)]
+        public NitroxQuaternion Rotation { get; }
+
+        protected CameraMovementData()
+        {
+            // Constructor for serialization. Has to be "protected" for json serialization.
+        }
+
+        public CameraMovementData(NitroxTechType techType, NitroxId id, NitroxVector3 position, NitroxQuaternion rotation)
+        {
+            TechType = techType;
+            Id = id;
+            Position = position;
+            Rotation = rotation;
+        }
+
+        public override string ToString()
+        {
+            return $"[CameraMovementData - TechType: {TechType}, Id: {Id}, Position: {Position}, Rotation: {Rotation}]";
+        }
+    }
+}

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -28,6 +28,7 @@
     <Compile Include="DataStructures\GameLogic\AbsoluteEntityCell.cs" />
     <Compile Include="DataStructures\GameLogic\BasePiece.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Metadata\BasePieceMetadata.cs" />
+    <Compile Include="DataStructures\GameLogic\Buildings\Metadata\MapRoomMetadata.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Metadata\SignMetadata.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Rotation\RotationMetadata.cs" />
     <Compile Include="DataStructures\GameLogic\Buildings\Rotation\RotationMetadataFactory.cs" />
@@ -46,6 +47,7 @@
     <Compile Include="DataStructures\GameLogic\Entities\UwePrefabFactory.cs" />
     <Compile Include="DataStructures\GameLogic\Entities\UweWorldEntity.cs" />
     <Compile Include="DataStructures\GameLogic\Entities\UweWorldEntityFactory.cs" />
+    <Compile Include="DataStructures\GameLogic\CameraMovementData.cs" />
     <Compile Include="DataStructures\GameLogic\Entity.cs" />
     <Compile Include="DataStructures\GameLogic\EquippedItemData.cs" />
     <Compile Include="DataStructures\GameLogic\EscapePodModel.cs" />
@@ -117,6 +119,7 @@
     <Compile Include="Packets\AnimationChangeEvent.cs" />
     <Compile Include="Packets\BasePieceMetadataChanged.cs" />
     <Compile Include="Packets\BedEnter.cs" />
+    <Compile Include="Packets\CameraMovement.cs" />
     <Compile Include="Packets\CellEntities.cs" />
     <Compile Include="Packets\CellVisibilityChanged.cs" />
     <Compile Include="Packets\ChatMessage.cs" />
@@ -128,6 +131,7 @@
     <Compile Include="Packets\DeconstructionBegin.cs" />
     <Compile Include="Packets\DeconstructionCompleted.cs" />
     <Compile Include="Packets\Disconnect.cs" />
+    <Compile Include="Packets\DockingStateChange.cs" />
     <Compile Include="Packets\DroppedItem.cs" />
     <Compile Include="Packets\EnergyMixinValueChanged.cs" />
     <Compile Include="Packets\EntityMetadataUpdate.cs" />
@@ -147,6 +151,7 @@
     <Compile Include="Packets\ItemPosition.cs" />
     <Compile Include="Packets\KnownTechEntry.cs" />
     <Compile Include="Packets\LiveMixinHealthChanged.cs" />
+    <Compile Include="Packets\MapRoomScan.cs" />
     <Compile Include="Packets\MedicalCabinetClicked.cs" />
     <Compile Include="Packets\ModuleAdded.cs" />
     <Compile Include="Packets\ModuleRemoved.cs" />

--- a/NitroxModel/Packets/BasePieceMetadataChanged.cs
+++ b/NitroxModel/Packets/BasePieceMetadataChanged.cs
@@ -7,11 +7,13 @@ namespace NitroxModel.Packets
     [Serializable]
     public class BasePieceMetadataChanged : Packet
     {
+        public NitroxId BaseParentId { get; }
         public NitroxId PieceId { get; }
         public BasePieceMetadata Metadata { get; }
 
-        public BasePieceMetadataChanged(NitroxId pieceId, BasePieceMetadata metadata)
+        public BasePieceMetadataChanged(NitroxId baseParentId, NitroxId pieceId, BasePieceMetadata metadata)
         {
+            BaseParentId = baseParentId;
             PieceId = pieceId;
             Metadata = metadata;
         }

--- a/NitroxModel/Packets/CameraMovement.cs
+++ b/NitroxModel/Packets/CameraMovement.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Unity;
+using NitroxModel.Networking;
+
+namespace NitroxModel.Packets
+{
+    [Serializable]
+    public class CameraMovement : Movement
+    {
+        public CameraMovementData CameraMovementData { get; }
+
+        public CameraMovement(ushort playerId, CameraMovementData cameraMovementData) : base(playerId, cameraMovementData.Position, NitroxVector3.Zero, cameraMovementData.Rotation, NitroxQuaternion.Identity)
+        {
+            CameraMovementData = cameraMovementData;
+            DeliveryMethod = NitroxDeliveryMethod.DeliveryMethod.UNRELIABLE_SEQUENCED;
+            UdpChannel = UdpChannelId.CAMERA_MOVEMENT;
+        }
+    }
+}

--- a/NitroxModel/Packets/DockingStateChange.cs
+++ b/NitroxModel/Packets/DockingStateChange.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using NitroxModel.DataStructures;
+
+namespace NitroxModel.Packets
+{
+    [Serializable]
+    public class DockingStateChange : Packet
+    {
+        public NitroxId NitroxId;
+        public bool Docked;
+
+        public DockingStateChange(NitroxId nitroxId, bool docked)
+        {
+            NitroxId = nitroxId;
+            Docked = docked;
+        }
+    }
+}

--- a/NitroxModel/Packets/MapRoomScan.cs
+++ b/NitroxModel/Packets/MapRoomScan.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+
+namespace NitroxModel.Packets
+{
+    [Serializable]
+    public class MapRoomScan : Packet
+    {
+        public NitroxId NitroxId;
+        public NitroxTechType NitroxTechType;
+        public bool ScanAction;
+
+        public MapRoomScan(NitroxId nitroxId, NitroxTechType nitroxTechType, bool scanAction) : base ()
+        {
+            NitroxId = nitroxId;
+            NitroxTechType = nitroxTechType;
+            ScanAction = scanAction;
+        }
+
+        public MapRoomScan(NitroxId nitroxId, bool scanAction) : this(nitroxId, null, scanAction)
+        { }
+    }
+}

--- a/NitroxModel/Packets/Packet.cs
+++ b/NitroxModel/Packets/Packet.cs
@@ -60,7 +60,8 @@ namespace NitroxModel.Packets
             DEFAULT = 0,
             PLAYER_MOVEMENT = 1,
             VEHICLE_MOVEMENT = 2,
-            PLAYER_STATS = 3
+            PLAYER_STATS = 3,
+            CAMERA_MOVEMENT = 4
         }
 
         public byte[] Serialize()

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -121,6 +121,11 @@
     <Compile Include="Patches\Dynamic\KnownTech_NotifyAdd_Patch.cs" />
     <Compile Include="Patches\Dynamic\LiveMixin_AddHealth_Patch.cs" />
     <Compile Include="Patches\Dynamic\LiveMixin_TakeDamage_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MapRoomCamera_Control_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MapRoomCamera_FreeCamera_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MapRoomCamera_Update_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MapRoomCameraDocking_DockCamera_Patch.cs" />
+    <Compile Include="Patches\Dynamic\MapRoomScreen_OnHandClick_Patch.cs" />
     <Compile Include="Patches\Dynamic\MedicalCabinet_OnHandClick_Patch.cs" />
     <Compile Include="Patches\Dynamic\OnGoalUnlockTracker_NotifyGoalComplete_Patch.cs" />
     <Compile Include="Patches\Dynamic\Openable_PlayOpenAnimation_Patch.cs" />
@@ -136,6 +141,7 @@
     <Compile Include="Patches\Dynamic\PilotingChair_OnPlayerDeath_Patch.cs" />
     <Compile Include="Patches\Dynamic\PilotingChair_ReleaseBy_Patch.cs" />
     <Compile Include="Patches\Dynamic\PingManager_NotifyRename_Patch.cs" />
+    <Compile Include="Patches\Dynamic\Player_EnterLockedMode_Patch.cs" />
     <Compile Include="Patches\Dynamic\Player_OnKill_Patch.cs" />
     <Compile Include="Patches\Dynamic\Player_SetCurrentEscapePod_Patch.cs" />
     <Compile Include="Patches\Dynamic\Player_SetCurrentSub_Patch.cs" />
@@ -176,6 +182,8 @@
     <Compile Include="Patches\Dynamic\SubRoot_OnTakeDamage_Patch.cs" />
     <Compile Include="Patches\Dynamic\ToggleLights_OnPoweredChanged_Patch.cs" />
     <Compile Include="Patches\Dynamic\ToggleLights_SetLightsActive_Patch.cs" />
+    <Compile Include="Patches\Dynamic\uGUI_MapRoomScanner_OnCancelScan_Patch.cs" />
+    <Compile Include="Patches\Dynamic\uGUI_MapRoomScanner_OnStartScan_Patch.cs" />
     <Compile Include="Patches\Dynamic\uGUI_OnApplicationQuit_Patch.cs" />
     <Compile Include="Patches\Dynamic\uGUI_SignInput_OnDeselect_Patch.cs" />
     <Compile Include="Patches\Dynamic\UniqueIdentifier_Id_Getter_Patch.cs" />

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_DockCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_DockCamera_Patch.cs
@@ -1,0 +1,81 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class MapRoomCameraDocking_DockCamera_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD_DOCK = Reflect.Method((MapRoomCameraDocking t) => t.DockCamera(default(MapRoomCamera)));
+        private static readonly MethodInfo TARGET_METHOD_UNDOCK = Reflect.Method((MapRoomCameraDocking t) => t.UndockCamera());
+        private static IPacketSender packetSender;
+        private static Building building;
+
+        public static void PostfixDock(MapRoomCameraDocking __instance, MapRoomCamera camera)
+        {
+            UpdateMetadata(__instance, true, camera.GetComponent<NitroxEntity>().Id);
+        }
+
+        public static void PostfixUndock(MapRoomCameraDocking __instance)
+        {
+            packetSender ??= Resolve<IPacketSender>();
+            packetSender.Send(new DockingStateChange(NitroxEntity.GetId(__instance.gameObject), false));
+            UpdateMetadata(__instance, false);
+        }
+
+        private static void UpdateMetadata(MapRoomCameraDocking __instance, bool cameraDocked, NitroxId nitroxId = null)
+        {
+            building ??= Resolve<Building>();
+            // Log.Debug($"Updating metadata for [{__instance.gameObject.name}, cameraDocked: {cameraDocked}]");
+            // MRF_GO is the MapRoomFunctionality's GameObject containing dockPoint1 and dockPoint2
+            GameObject MRF_GO = __instance.transform.parent.gameObject;
+            GameObject baseParent = MRF_GO.transform.parent.gameObject;
+            // NitroxEntity of the MapRoomFunctionality which is the direct parent of the docking
+            NitroxId mapRoomFunctionalityId = NitroxEntity.GetId(MRF_GO);
+            MapRoomMetadata cameraDockingMetadata = new(mapRoomFunctionalityId, false, false, null, null);
+            // Verify which docking point is __instance then set CameraDocked to true if a camera is docked to it
+            if (__instance.gameObject.name.Equals("dockingPoint1"))
+            {
+                MapRoomCameraDocking otherDocking = MRF_GO.FindChild("dockingPoint2").GetComponent<MapRoomCameraDocking>();
+                cameraDockingMetadata.CameraDocked1 = cameraDocked;
+                cameraDockingMetadata.CameraDocked2 = otherDocking.cameraDocked;
+                cameraDockingMetadata.Camera1NitroxId = (cameraDocked ? nitroxId : null);
+                if (otherDocking.cameraDocked && otherDocking.camera.TryGetComponent(out NitroxEntity otherNitroxEntity))
+                {
+                    cameraDockingMetadata.Camera2NitroxId = otherNitroxEntity.Id;
+                }
+            }
+            else if (__instance.gameObject.name.Equals("dockingPoint2"))
+            {
+                MapRoomCameraDocking otherDocking = MRF_GO.FindChild("dockingPoint1").GetComponent<MapRoomCameraDocking>();
+                cameraDockingMetadata.CameraDocked2 = cameraDocked;
+                cameraDockingMetadata.CameraDocked1 = otherDocking.cameraDocked;
+                cameraDockingMetadata.Camera2NitroxId = (cameraDocked ? nitroxId : null);
+                if (otherDocking.cameraDocked && otherDocking.camera.TryGetComponent(out NitroxEntity otherNitroxEntity))
+                {
+                    cameraDockingMetadata.Camera1NitroxId = otherNitroxEntity.Id;
+                }
+            }
+
+            // If we don't refresh the payload, an empty one will be sent
+            cameraDockingMetadata.RefreshUpdatePayload();
+            // Log.Debug($"Sending MetadataChanged packet [{cameraDockingMetadata}]");
+            building.MetadataChanged(NitroxEntity.GetId(baseParent), NitroxEntity.GetId(MRF_GO), cameraDockingMetadata);
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD_DOCK, nameof(PostfixDock));
+            PatchPostfix(harmony, TARGET_METHOD_UNDOCK, nameof(PostfixUndock));
+        }
+    }
+}
+

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Control_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Control_Patch.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class MapRoomCamera_ControlCamera_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.ControlCamera(default(Player), default(MapRoomScreen)));
+        private static CameraControlManager cameraControlManager;
+
+        public static void Postfix(MapRoomCamera __instance)
+        {
+            cameraControlManager ??= Resolve<CameraControlManager>();
+            cameraControlManager.ControlCamera(__instance);
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}
+

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_FreeCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_FreeCamera_Patch.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    class MapRoomCamera_FreeCamera_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.FreeCamera(default(bool)));
+        private static CameraControlManager cameraControlManager;
+
+        public static void Postfix()
+        {
+            cameraControlManager ??= Resolve<CameraControlManager>();
+            cameraControlManager.FreeCamera();
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Update_Patch.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    class MapRoomCamera_Update_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.Update());
+
+        private static readonly OpCode INJECTION_OPCODE = OpCodes.Call;
+        private static readonly object INJECTION_OPERAND = Reflect.Method((MapRoomCamera t) => t.CanBeControlled(default(MapRoomScreen)));
+
+        private static readonly OpCode INJECTION_OPCODE_2 = OpCodes.Call;
+        private static readonly object INJECTION_OPERAND_2 = Reflect.Method((MapRoomCamera t) => t.FreeCamera(default(bool)));
+
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            Validate.NotNull(INJECTION_OPERAND);
+            Validate.NotNull(INJECTION_OPERAND_2);
+
+            int addIndex = -1;
+
+            CodeInstruction loadInstruction = new CodeInstruction(OpCodes.Ldsfld, Reflect.Field(() => CameraControlManager.Instance));
+            CodeInstruction callInstruction = new CodeInstruction(OpCodes.Call, Reflect.Method((CameraControlManager t) => t.HasControlOverCurrentCamera()));
+            CodeInstruction brFalseInstruction = new CodeInstruction(OpCodes.Brfalse);
+            foreach (CodeInstruction instruction in instructions)
+            {
+                addIndex--;
+                yield return instruction;
+
+                if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
+                {
+                    // We need to add it 1 line under (after the brfalse line)
+                    addIndex = 1;
+                }
+                if (addIndex == 0)
+                {
+                    // This is the good place to add the code
+                    brFalseInstruction.operand = instruction.operand;
+                    foreach (CodeInstruction instructionToAdd in new List<CodeInstruction>(){ loadInstruction, callInstruction, brFalseInstruction })
+                    {
+                        yield return instructionToAdd;
+                    }
+                }
+
+                if (instruction.opcode.Equals(INJECTION_OPCODE_2) && instruction.operand.Equals(INJECTION_OPERAND_2))
+                {
+                    yield return new CodeInstruction(OpCodes.Call, Reflect.Method(() => MapRoomScreen_OnHandClick_Patch.ReleaseScreen()));
+                }
+            }
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchTranspiler(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomScreen_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomScreen_OnHandClick_Patch.cs
@@ -1,0 +1,80 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.HUD;
+using NitroxClient.GameLogic.Simulation;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class MapRoomScreen_OnHandClick_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomScreen t) => t.OnHandClick(default(GUIHand)));
+        
+        private static bool skipPrefix;
+        private static NitroxId currentScreenId;
+        private static SimulationOwnership simulationOwnership;
+
+        public static bool Prefix(MapRoomScreen __instance, GUIHand guiHand)
+        {
+            simulationOwnership ??= Resolve<SimulationOwnership>();
+            if (skipPrefix)
+            {
+                return true;
+            }
+
+            NitroxId id = NitroxEntity.GetId(__instance.gameObject);
+
+            if (simulationOwnership.HasExclusiveLock(id))
+            {
+                Log.Debug($"Already have an exclusive lock on the room screen: {id}");
+                return true;
+            }
+
+            // Simulate the camera search and don't try to lock if there are no cameras available
+            __instance.currentIndex = __instance.NormalizeIndex(__instance.currentIndex);
+            MapRoomCamera mapRoomCamera = __instance.FindCamera(1);
+            if (mapRoomCamera)
+            {
+                HandInteraction<MapRoomScreen> context = new(__instance, guiHand);
+                LockRequest<HandInteraction<MapRoomScreen>> lockRequest = new(id, SimulationLockType.EXCLUSIVE, ReceivedSimulationLockResponse, context);
+
+                simulationOwnership.RequestSimulationLock(lockRequest);
+            }
+
+            return false;
+        }
+
+        public static void ReleaseScreen()
+        {
+            simulationOwnership.RequestSimulationLock(currentScreenId, SimulationLockType.TRANSIENT);
+            currentScreenId = null;
+        }
+
+        private static void ReceivedSimulationLockResponse(NitroxId id, bool lockAquired, HandInteraction<MapRoomScreen> context)
+        {
+            MapRoomScreen mapRoomScreen = context.Target;
+
+            if (lockAquired)
+            {
+                currentScreenId = id;
+                skipPrefix = true;
+                mapRoomScreen.OnHandClick(context.GuiHand);
+                skipPrefix = false;
+            }
+            else
+            {
+                mapRoomScreen.gameObject.AddComponent<DenyOwnershipHand>();
+                mapRoomScreen.isValidHandTarget = false;
+            }
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Player_EnterLockedMode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_EnterLockedMode_Patch.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class Player_EnterLockedMode_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Player t) => t.EnterLockedMode(default(Transform), default(bool)));
+        private static LocalPlayer localPlayer;
+
+        public static void Postfix(Transform parent, bool teleport)
+        {
+            localPlayer ??= Resolve<LocalPlayer>();
+            if (parent == null && teleport == false)
+            {
+                // When a player enters a locked state, we should stop all placeholder movement automatically created by the other clients
+                // e.g. you clicked on the MapRoomScreen and entered the camera controlling but you were moving so other clients consider that you're still running in that direction (you go through the world in their perspective)
+                // Doesn't seem to work as it should
+                Vector3 currentPosition = Player.main.transform.position;
+                Quaternion bodyRotation = MainCameraControl.main.viewModel.transform.rotation;
+                localPlayer.UpdateLocation(currentPosition, Vector3.zero, bodyRotation, Quaternion.identity, Optional.Empty);
+            }
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/uGUI_MapRoomScanner_OnCancelScan_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_MapRoomScanner_OnCancelScan_Patch.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class uGUI_MapRoomScanner_OnCancelScan_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_MapRoomScanner t) => t.OnCancelScan());
+        private static IPacketSender packetSender;
+        private static Building building;
+
+        public static void Postfix(uGUI_MapRoomScanner __instance)
+        {
+            packetSender ??= Resolve<IPacketSender>();
+            building ??= Resolve<Building>();
+            GameObject MRF_GO = __instance.transform.parent.parent.gameObject;
+            NitroxId mapRoomFunctionalityId = NitroxEntity.GetId(MRF_GO);
+
+            building.MetadataChanged(NitroxEntity.GetId(MRF_GO.transform.parent.gameObject), mapRoomFunctionalityId, new MapRoomMetadata(mapRoomFunctionalityId, null));
+            packetSender.Send(new MapRoomScan(NitroxEntity.GetId(__instance.gameObject), false));
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/uGUI_MapRoomScanner_OnStartScan_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_MapRoomScanner_OnStartScan_Patch.cs
@@ -1,0 +1,40 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic.Buildings.Metadata;
+using NitroxModel.Helper;
+using NitroxModel.Logger;
+using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class uGUI_MapRoomScanner_OnStartScan_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_MapRoomScanner t) => t.OnStartScan(default(int)));
+        private static IPacketSender packetSender;
+        private static Building building;
+
+        public static void Postfix(uGUI_MapRoomScanner __instance)
+        {
+            packetSender ??= Resolve<IPacketSender>();
+            building ??= Resolve<Building>();
+            NitroxTechType newTypeToScan = __instance.mapRoom.typeToScan.ToDto();
+            GameObject MRF_GO = __instance.transform.parent.parent.gameObject;
+            NitroxId mapRoomFunctionalityId = NitroxEntity.GetId(MRF_GO);
+
+            building.MetadataChanged(NitroxEntity.GetId(MRF_GO.transform.parent.gameObject), mapRoomFunctionalityId, new MapRoomMetadata(mapRoomFunctionalityId, newTypeToScan));
+            packetSender.Send(new MapRoomScan(NitroxEntity.GetId(__instance.gameObject), newTypeToScan, true));
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPostfix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
@@ -18,9 +18,10 @@ namespace NitroxPatcher.Patches.Dynamic
         {
             GameObject gameObject = __instance.gameObject.FindAncestor<PrefabIdentifier>().gameObject;
             NitroxId id = NitroxEntity.GetId(gameObject);
+            NitroxId baseParentId = NitroxEntity.GetId(gameObject.transform.parent.gameObject);
 
             SignMetadata signMetadata = new(__instance.text, __instance.colorIndex, __instance.scaleIndex, __instance.elementsState, __instance.IsBackground());
-            NitroxServiceLocator.LocateService<Building>().MetadataChanged(id, signMetadata);
+            NitroxServiceLocator.LocateService<Building>().MetadataChanged(baseParentId, id, signMetadata);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxServer/Communication/Packets/Processors/BasePieceMetadataChangedPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/BasePieceMetadataChangedPacketProcessor.cs
@@ -18,7 +18,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(BasePieceMetadataChanged packet, Player player)
         {
-            baseManager.UpdateBasePieceMetadata(packet.PieceId, packet.Metadata);
+            baseManager.UpdateBasePieceMetadata(packet.BaseParentId, packet.PieceId, packet.Metadata);
 
             playerManager.SendPacketToOtherPlayers(packet, player);
         }

--- a/NitroxServer/Communication/Packets/Processors/CameraMovementPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/CameraMovementPacketProcessor.cs
@@ -1,0 +1,38 @@
+﻿using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Entities;
+
+namespace NitroxServer.Communication.Packets.Processors
+{
+    class CameraMovementPacketProcessor : AuthenticatedPacketProcessor<CameraMovement>
+    {
+        private readonly PlayerManager playerManager;
+        private readonly EntityManager entityManager;
+
+        public CameraMovementPacketProcessor(PlayerManager playerManager, EntityManager entityManager)
+        {
+            this.playerManager = playerManager;
+            this.entityManager = entityManager;
+        }
+
+        public override void Process(CameraMovement packet, Player player)
+        {
+            Optional<Entity> entity = entityManager.GetEntityById(packet.CameraMovementData.Id);
+            if (entity.HasValue)
+            {
+                entity.Value.Transform.Position = packet.Position;
+                entity.Value.Transform.Rotation = packet.BodyRotation;
+            }
+
+            if (player.Id == packet.PlayerId)
+            {
+                player.Position = packet.Position;
+            }
+
+            playerManager.SendPacketToOtherPlayers(packet, player);
+        }
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/DockingStateChangeProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DockingStateChangeProcessor.cs
@@ -1,0 +1,21 @@
+﻿using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using NitroxServer.GameLogic;
+
+namespace NitroxServer.Communication.Packets.Processors
+{
+    class DockingStateChangeProcessor : AuthenticatedPacketProcessor<DockingStateChange>
+    {
+        private readonly PlayerManager playerManager;
+
+        public DockingStateChangeProcessor(PlayerManager playerManager)
+        {
+            this.playerManager = playerManager;
+        }
+
+        public override void Process(DockingStateChange packet, Player player)
+        {
+            playerManager.SendPacketToOtherPlayers(packet, player);
+        }
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/MapRoomScanProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/MapRoomScanProcessor.cs
@@ -1,0 +1,21 @@
+﻿using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using NitroxServer.GameLogic;
+
+namespace NitroxServer.Communication.Packets.Processors
+{
+    class MapRoomScanProcessor : AuthenticatedPacketProcessor<MapRoomScan>
+    {
+        private readonly PlayerManager playerManager;
+
+        public MapRoomScanProcessor(PlayerManager playerManager)
+        {
+            this.playerManager = playerManager;
+        }
+
+        public override void Process(MapRoomScan packet, Player player)
+        {
+            playerManager.SendPacketToOtherPlayers(packet, player);
+        }
+    }
+}

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Communication\Packets\Processors\Abstract\UnauthenticatedPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\BasePieceMetadataChangedPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\BedEnterProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\CameraMovementPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\CellVisibilityChangedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ChatMessageProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ConstructionAmountChangedPacketProcessor.cs" />
@@ -55,6 +56,7 @@
     <Compile Include="Communication\Packets\Processors\DeconstructionBeginPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\DeconstructionCompletedPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\DefaultServerPacketProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\DockingStateChangeProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\DroppedItemPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EnergyMixinValueChangedPacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\EntityMetadataUpdateProcessor.cs" />
@@ -69,6 +71,7 @@
     <Compile Include="Communication\Packets\Processors\ItemContainerRemovePacketProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\KnownTechEntryAddProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\LiveMixinChangedProcessor.cs" />
+    <Compile Include="Communication\Packets\Processors\MapRoomScanProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ModuleAddedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\ModuleRemovedProcessor.cs" />
     <Compile Include="Communication\Packets\Processors\MovementPacketProcessor.cs" />


### PR DESCRIPTION
Fixes [Issue#1602](https://github.com/SubnauticaNitrox/Nitrox/issues/1602)

The goal is to sync every action of the scanner room (also called Map Room)
The first commit includes these changes:
- Camera's movement sync (with a lock system on every MapRoomScreen: the screens to take control over a camera and over each camera)
- Scanner room's states are now synced and saved (the docking points states are synced and also the object being scanned with the map scanner)
- Some stuff around Metadata saving/updating/processing has been modified/fixed
- There's a try of making a "Packet Saver" in the PlayerMovement, the objective is to not send movement packets when the player is not moving anymore but it lacks some tests and tweaks to work