### PR TITLE
Fix the radio changes to make it actually work

### DIFF
--- a/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
+++ b/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
@@ -24,8 +24,20 @@ namespace NitroxServer.GameLogic
         [TestMethod]
         public void AuroraExplosionAndWarningTime()
         {
-            EventTriggerer eventTriggerer = new(null, 0.0, TimeSpan.FromDays(3).TotalMilliseconds);
+            EventTriggerer eventTriggerer = new(null, 0.0, TimeSpan.FromMinutes(40).TotalMilliseconds);
             Assert.AreEqual(eventTriggerer.eventTimers["Story_AuroraWarning4"].Interval, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
+        }
+
+        [TestMethod]
+        public void TestTimeSkip()
+        {
+            EventTriggerer eventTriggerer = new(null, 480.0, null);
+            double interval = eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval;
+            eventTriggerer.ElapsedTimeMs += TimeSpan.FromMinutes(40).TotalMilliseconds;
+            Assert.AreEqual(interval - TimeSpan.FromMinutes(40).TotalMilliseconds, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
+            interval = eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval;
+            eventTriggerer.ElapsedTimeMs += TimeSpan.FromMinutes(2).TotalMilliseconds;
+            Assert.AreEqual(interval - TimeSpan.FromMinutes(2).TotalMilliseconds, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
         }
     }
 }

--- a/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
+++ b/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NitroxServer.GameLogic
@@ -23,7 +24,7 @@ namespace NitroxServer.GameLogic
         [TestMethod]
         public void AuroraExplosionAndWarningTime()
         {
-            EventTriggerer eventTriggerer = new(null, 0.0, 30d);
+            EventTriggerer eventTriggerer = new(null, 0.0, TimeSpan.FromDays(3).TotalMilliseconds);
             Assert.AreEqual(eventTriggerer.eventTimers["Story_AuroraWarning4"].Interval, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
         }
     }

--- a/NitroxClient/Communication/Packets/Processors/ScheduleProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/ScheduleProcessor.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using NitroxClient.Communication.Packets.Processors.Abstract;
-using NitroxModel.Logger;
 using NitroxModel.Packets;
 using Story;
 
@@ -20,7 +19,7 @@ namespace NitroxClient.Communication.Packets.Processors
             {
                 StoryGoalScheduler.main.schedule.Add(goal);
             }
-            Log.Debug($"Processed a Schedule packet [{goal}]");
+            Log.Debug($"Processed a Schedule packet [Key: {goal.goalKey}, Type: {goal.goalType}, TimeExecute: {goal.timeExecute}]");
         }
 
         private bool ShouldSchedule(float timeToExecute)

--- a/NitroxClient/Communication/Packets/Processors/StoryEventHandler.cs
+++ b/NitroxClient/Communication/Packets/Processors/StoryEventHandler.cs
@@ -2,6 +2,7 @@
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
 using Story;
 
 namespace NitroxClient.Communication.Packets.Processors
@@ -28,7 +29,7 @@ namespace NitroxClient.Communication.Packets.Processors
                     using (packetSender.Suppress<StoryEventSend>())
                     using (packetSender.Suppress<PDALogEntryAdd>())
                     {
-                        StoryGoal.Execute(packet.Key, (Story.GoalType)packet.Type);
+                        StoryGoal.Execute(packet.Key, packet.Type.ToUnity());
                     }
                     break;
                 case StoryEventSend.EventType.EXTRA:

--- a/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
@@ -44,11 +44,7 @@ namespace NitroxClient.GameLogic.InitialSync
         private void SetCompletedStoryGoals(List<string> storyGoalData)
         {
             StoryGoalManager.main.completedGoals.Clear();
-
-            foreach (string completedGoal in storyGoalData)
-            {
-                StoryGoalManager.main.completedGoals.Add(completedGoal);
-            }
+            StoryGoalManager.main.completedGoals.AddRange(storyGoalData);
 
             Log.Info("Received initial sync packet with " + storyGoalData.Count + " completed story goals");
         }

--- a/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NitroxClient.GameLogic.InitialSync.Base;
-using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using Story;
 
@@ -46,7 +46,7 @@ namespace NitroxClient.GameLogic.InitialSync
             StoryGoalManager.main.completedGoals.Clear();
             StoryGoalManager.main.completedGoals.AddRange(storyGoalData);
 
-            Log.Info("Received initial sync packet with " + storyGoalData.Count + " completed story goals");
+            Log.Info($"Received initial sync packet with {storyGoalData.Count} completed story goals");
         }
 
         private void SetGoalUnlocks(List<string> goalUnlocks)

--- a/NitroxModel-Subnautica/DataStructures/DataExtensions.cs
+++ b/NitroxModel-Subnautica/DataStructures/DataExtensions.cs
@@ -2,6 +2,7 @@
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Unity;
+using NitroxModel.Packets;
 using UnityEngine;
 
 namespace NitroxModel_Subnautica.DataStructures
@@ -96,6 +97,30 @@ namespace NitroxModel_Subnautica.DataStructures
                 result[i] = v[i].ToUnity();
             }
             return result;
+        }
+
+        public static StoryEventSend.EventType ToDto(this Story.GoalType goalType)
+        {
+            return goalType switch
+            {
+                Story.GoalType.PDA => StoryEventSend.EventType.PDA,
+                Story.GoalType.Radio => StoryEventSend.EventType.RADIO,
+                Story.GoalType.Encyclopedia => StoryEventSend.EventType.ENCYCLOPEDIA,
+                Story.GoalType.Story => StoryEventSend.EventType.STORY,
+                _ => throw new ArgumentException("The provided Story.GoalType doesn't correspond to a StoryEventSend.EventType"),
+            };
+        }
+
+        public static Story.GoalType ToUnity(this StoryEventSend.EventType eventType)
+        {
+            return eventType switch
+            {
+                StoryEventSend.EventType.PDA => Story.GoalType.PDA,
+                StoryEventSend.EventType.RADIO => Story.GoalType.Radio,
+                StoryEventSend.EventType.ENCYCLOPEDIA => Story.GoalType.Encyclopedia,
+                StoryEventSend.EventType.STORY => Story.GoalType.Story,
+                _ => throw new ArgumentException("The provided StoryEventSend.EventType doesn't correspond to a Story.GoalType")
+            };
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/NitroxScheduledGoal.cs
+++ b/NitroxModel/DataStructures/GameLogic/NitroxScheduledGoal.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using ProtoBufNet;
 
-namespace NitroxModel.DataStructures
+namespace NitroxModel.DataStructures.GameLogic
 {
     [Serializable]
     [ProtoContract]

--- a/NitroxModel/Packets/StoryEventSend.cs
+++ b/NitroxModel/Packets/StoryEventSend.cs
@@ -14,7 +14,6 @@ namespace NitroxModel.Packets
             Key = key;
         }
 
-        // The 4 first items of this enum should always be in the same order as the GoalType enum
         public enum EventType
         {
             PDA,

--- a/NitroxModel/Packets/StoryEventSend.cs
+++ b/NitroxModel/Packets/StoryEventSend.cs
@@ -14,15 +14,16 @@ namespace NitroxModel.Packets
             Key = key;
         }
 
+        // The 4 first items of this enum should always be in the same order as the GoalType enum
         public enum EventType
         {
             PDA,
-            PDA_EXTRA,
             RADIO,
             ENCYCLOPEDIA,
             STORY,
+            GOAL_UNLOCK,
             EXTRA,
-            GOAL_UNLOCK
+            PDA_EXTRA,
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/StoryGoalScheduler_Schedule_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/StoryGoalScheduler_Schedule_Patch.cs
@@ -26,7 +26,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(StoryGoal goal, bool __state)
         {
-            if (__state || goal.key == "PlayerDiving")
+            if (__state || goal.key == "PlayerDiving" || goal.delay == 0f)
             {
                 return;
             }

--- a/NitroxPatcher/Patches/Dynamic/StoryGoalScheduler_Schedule_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/StoryGoalScheduler_Schedule_Patch.cs
@@ -31,8 +31,8 @@ namespace NitroxPatcher.Patches.Dynamic
                 return;
             }
 
-            float timePassed = DayNightCycle.main ? DayNightCycle.main.timePassedAsFloat : 0f;
-            packetSender.Send(new Schedule(timePassed + goal.delay, goal.key, goal.goalType.ToString()));
+            float timeExecute = StoryGoalScheduler.main.schedule.GetLast().timeExecute;
+            packetSender.Send(new Schedule(timeExecute, goal.key, goal.goalType.ToString()));
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using NitroxClient.Communication.Abstract;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
 using Story;
 
 namespace NitroxPatcher.Patches.Dynamic
@@ -15,7 +16,7 @@ namespace NitroxPatcher.Patches.Dynamic
         {
             if (!StoryGoalManager.main.completedGoals.Contains(key))
             {
-                StoryEventSend packet = new((StoryEventSend.EventType)goalType, key);
+                StoryEventSend packet = new(goalType.ToDto(), key);
                 Resolve<IPacketSender>().Send(packet);
             }
         }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -84,7 +84,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 player.Permissions
             );
 
-            eventTriggerer.SendCurrentTimePacket(true);
+            eventTriggerer.SendCurrentTimePacket(true, player);
             player.SendPacket(initialPlayerSync);
         }
 

--- a/NitroxServer/Communication/Packets/Processors/ScheduleProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/ScheduleProcessor.cs
@@ -1,4 +1,4 @@
-﻿using NitroxModel.DataStructures;
+﻿using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -29,6 +29,12 @@ namespace NitroxServer.GameLogic
             private set => ElapsedTime = value * 1000;
         }
 
+        // Using ceiling because days count start at 1 and not 0
+        public int Day
+        {
+            get => (int) Math.Ceiling(ElapsedTime / TimeSpan.FromMinutes(20).TotalMilliseconds);
+        }
+
         public EventTriggerer(PlayerManager playerManager, double elapsedTime, double? auroraExplosionTime)
         {
             this.playerManager = playerManager;

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Timers;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
 
 namespace NitroxServer.GameLogic
@@ -31,7 +32,8 @@ namespace NitroxServer.GameLogic
         public EventTriggerer(PlayerManager playerManager, double elapsedTime, double? auroraExplosionTime)
         {
             this.playerManager = playerManager;
-            elapsedTimeOutsideStopWatch = elapsedTime;
+            // Default time in Base SN is 480s
+            elapsedTimeOutsideStopWatch = elapsedTime == 0 ? 480000d : elapsedTime;
 
             Log.Debug($"Event Triggerer started! ElapsedTime={Math.Floor(ElapsedSeconds)}s");
 
@@ -115,9 +117,16 @@ namespace NitroxServer.GameLogic
             }
         }
 
-        public void SendCurrentTimePacket(bool initialSync)
+        public void SendCurrentTimePacket(bool initialSync, Optional<Player> player)
         {
-            playerManager.SendPacketToAllPlayers(new TimeChange(ElapsedSeconds, initialSync));
+            if (player.HasValue)
+            {
+                player.Value.SendPacket(new TimeChange(ElapsedSeconds, initialSync));
+            }
+            else
+            {
+                playerManager.SendPacketToAllPlayers(new TimeChange(ElapsedSeconds, initialSync));
+            }
         }
 
         public void ChangeTime(TimeModification type)
@@ -135,7 +144,7 @@ namespace NitroxServer.GameLogic
                     break;
             }
 
-            SendCurrentTimePacket(false);
+            SendCurrentTimePacket(false, null);
         }
 
         public enum TimeModification

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -33,7 +33,7 @@ namespace NitroxServer.GameLogic
         {
             this.playerManager = playerManager;
             // Default time in Base SN is 480s
-            elapsedTimeOutsideStopWatch = elapsedTime == 0 ? 480000d : elapsedTime;
+            elapsedTimeOutsideStopWatch = elapsedTime == 0 ? TimeSpan.FromMinutes(8).TotalMilliseconds : elapsedTime;
 
             Log.Debug($"Event Triggerer started! ElapsedTime={Math.Floor(ElapsedSeconds)}s");
 
@@ -44,7 +44,7 @@ namespace NitroxServer.GameLogic
             }
             else
             {
-                AuroraExplosionTime = RandomNumber(2.3d, 4d) * 1200d * 1000d; //Time.deltaTime returns seconds so we need to multiply 1000
+                AuroraExplosionTime = elapsedTimeOutsideStopWatch + RandomNumber(2.3d, 4d) * 1200d * 1000d; //Time.deltaTime returns seconds so we need to multiply 1000
             }
 
             CreateTimer(AuroraExplosionTime * 0.2d - ElapsedTime, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
@@ -144,7 +144,7 @@ namespace NitroxServer.GameLogic
                     break;
             }
 
-            SendCurrentTimePacket(false, null);
+            SendCurrentTimePacket(false, Optional.Empty);
         }
 
         public enum TimeModification

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -13,59 +13,64 @@ namespace NitroxServer.GameLogic
         private readonly Stopwatch stopWatch = new();
         private readonly PlayerManager playerManager;
 
-        public readonly double AuroraExplosionTime;
+        public readonly double AuroraExplosionTimeMs;
 
-        private double elapsedTimeOutsideStopWatch;
+        private double elapsedTimeOutsideStopWatchMs;
 
-        public double ElapsedTime
+        public double ElapsedTimeMs
         {
-            get => stopWatch.ElapsedMilliseconds + elapsedTimeOutsideStopWatch;
-            private set => elapsedTimeOutsideStopWatch = value - stopWatch.ElapsedMilliseconds;
+            get => stopWatch.ElapsedMilliseconds + elapsedTimeOutsideStopWatchMs;
+            internal set
+            {
+                foreach (Timer timer in eventTimers.Values)
+                {
+                    timer.Interval = Math.Max(1, timer.Interval - (value - ElapsedTimeMs));
+                }
+                elapsedTimeOutsideStopWatchMs = value - stopWatch.ElapsedMilliseconds;
+            }
         }
 
         public double ElapsedSeconds
         {
-            get => ElapsedTime * 0.001;
-            private set => ElapsedTime = value * 1000;
+            get => ElapsedTimeMs * 0.001;
+            private set => ElapsedTimeMs = value * 1000;
         }
 
         // Using ceiling because days count start at 1 and not 0
         public int Day
         {
-            get => (int) Math.Ceiling(ElapsedTime / TimeSpan.FromMinutes(20).TotalMilliseconds);
+            get => (int) Math.Ceiling(ElapsedTimeMs / TimeSpan.FromMinutes(20).TotalMilliseconds);
         }
 
         public EventTriggerer(PlayerManager playerManager, double elapsedTime, double? auroraExplosionTime)
         {
             this.playerManager = playerManager;
             // Default time in Base SN is 480s
-            elapsedTimeOutsideStopWatch = elapsedTime == 0 ? TimeSpan.FromMinutes(8).TotalMilliseconds : elapsedTime;
+            elapsedTimeOutsideStopWatchMs = elapsedTime == 0 ? TimeSpan.FromMinutes(8).TotalMilliseconds : elapsedTime;
 
             Log.Debug($"Event Triggerer started! ElapsedTime={Math.Floor(ElapsedSeconds)}s");
 
+            // The timer interval is in milliseconds, and so the AuroraExplosionTime should be
+            AuroraExplosionTimeMs = auroraExplosionTime ?? elapsedTimeOutsideStopWatchMs + RandomNumber(2.3d, 4d) * 1200d * 1000d;
 
-            if (auroraExplosionTime.HasValue)
-            {
-                AuroraExplosionTime = auroraExplosionTime.Value;
-            }
-            else
-            {
-                AuroraExplosionTime = elapsedTimeOutsideStopWatch + RandomNumber(2.3d, 4d) * 1200d * 1000d; //Time.deltaTime returns seconds so we need to multiply 1000
-            }
-
-            CreateTimer(AuroraExplosionTime * 0.2d - ElapsedTime, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
-            CreateTimer(AuroraExplosionTime * 0.5d - ElapsedTime, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning2");
-            CreateTimer(AuroraExplosionTime * 0.8d - ElapsedTime, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning3");
+            CreateTimer(AuroraExplosionTimeMs * 0.2d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
+            CreateTimer(AuroraExplosionTimeMs * 0.5d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning2");
+            CreateTimer(AuroraExplosionTimeMs * 0.8d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning3");
             // Story_AuroraWarning4 and Story_AuroraExplosion must occur at the same time
-            CreateTimer(AuroraExplosionTime - ElapsedTime, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning4");
-            CreateTimer(AuroraExplosionTime - ElapsedTime, StoryEventSend.EventType.EXTRA, "Story_AuroraExplosion");
+            CreateTimer(AuroraExplosionTimeMs - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning4");
+            CreateTimer(AuroraExplosionTimeMs - ElapsedTimeMs, StoryEventSend.EventType.EXTRA, "Story_AuroraExplosion");
 
             stopWatch.Start();
         }
 
+        /// <summary>
+        /// When starting the server, if some events already happened, the time parameter will be &lt; 0
+        /// in which case we don't want to create the timer
+        /// </summary>
+        /// <param name="time">In milliseconds</param>
         private void CreateTimer(double time, StoryEventSend.EventType eventType, string key)
         {
-            if (time <= 0) // Ignoring if time is in the past
+            if (time <= 0)
             {
                 return;
             }
@@ -123,6 +128,9 @@ namespace NitroxServer.GameLogic
             }
         }
 
+        /// <summary>
+        /// Send the current time (in seconds) to all players or only one player
+        /// </summary>
         public void SendCurrentTimePacket(bool initialSync, Optional<Player> player)
         {
             if (player.HasValue)
@@ -140,13 +148,13 @@ namespace NitroxServer.GameLogic
             switch (type)
             {
                 case TimeModification.DAY:
-                    ElapsedTime += 1200000.0 - ElapsedTime % 1200000.0 + 600000.0;
+                    ElapsedTimeMs += 1200000.0 - ElapsedTimeMs % 1200000.0 + 600000.0;
                     break;
                 case TimeModification.NIGHT:
-                    ElapsedTime += 1200000.0 - ElapsedTime % 1200000.0;
+                    ElapsedTimeMs += 1200000.0 - ElapsedTimeMs % 1200000.0;
                     break;
                 case TimeModification.SKIP:
-                    ElapsedTime += 600000.0 - ElapsedTime % 600000.0;
+                    ElapsedTimeMs += 600000.0 - ElapsedTimeMs % 600000.0;
                     break;
             }
 

--- a/NitroxServer/GameLogic/ScheduleKeeper.cs
+++ b/NitroxServer/GameLogic/ScheduleKeeper.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using NitroxServer.GameLogic.Unlockables;
 

--- a/NitroxServer/GameLogic/StoryTimingData.cs
+++ b/NitroxServer/GameLogic/StoryTimingData.cs
@@ -18,8 +18,8 @@ namespace NitroxServer.GameLogic
         {
             return new StoryTimingData
             {
-                ElapsedTime = eventTriggerer.ElapsedTime,
-                AuroraExplosionTime = eventTriggerer.AuroraExplosionTime
+                ElapsedTime = eventTriggerer.ElapsedTimeMs,
+                AuroraExplosionTime = eventTriggerer.AuroraExplosionTimeMs
             };
         }
     }

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -65,7 +65,7 @@ namespace NitroxServer
                 builder.AppendLine($" - Progress tech: {world.GameData.PDAState.CachedProgress.Count}");
                 builder.AppendLine($" - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}");
                 builder.AppendLine($" - Vehicles: {world.VehicleManager.GetVehicles().Count()}");
-                builder.AppendLine($" - Current Time: {Math.Floor(world.EventTriggerer.ElapsedSeconds)}s");
+                builder.AppendLine($" - Current Time: day {world.EventTriggerer.Day} ({Math.Floor(world.EventTriggerer.ElapsedSeconds)}s)");
                 
                 return builder.ToString();
             }


### PR DESCRIPTION
This will fix a bug that makes the radio play automatically and some changes

- [x] Set default time to 480s
- [x] Fix bug about initial time packets sent to everyone at each join
- [x] Fix the bug itself
- [x] Add a display for the days in the server summary
- [x] Make the StoryEventSend.EventType enum (Nitrox) an extension of the Story.GoalType enum (SN)
- [x] Make the event timers' intervals update when skipping time