### PR TITLE
Cyclops sync fix and improvements

### DIFF
--- a/Nitrox.Test/Patcher/Patches/CyclopsSonarButton_Update_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/CyclopsSonarButton_Update_PatchTest.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxModel.Helper;
+using NitroxPatcher.Patches.Dynamic;
+using NitroxTest.Patcher.Test;
+
+namespace Nitrox.Test.Patcher.Patches
+{
+    [TestClass]
+    public class CyclopsSonarButton_Update_PatchTest
+    {
+        [TestMethod]
+        public void Sanity()
+        {
+            List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
+            instructions.Add(new CodeInstruction(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE, CyclopsSonarButton_Update_Patch.INJECTION_OPERAND));
+            instructions.Add(new CodeInstruction(OpCodes.Callvirt, Reflect.Method((Player player) => player.GetMode())));
+            instructions.Add(new CodeInstruction(OpCodes.Brtrue));
+
+            IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(null, instructions);
+            Assert.AreEqual(instructions.Count + 2, result.Count());
+        }
+
+        [TestMethod]
+        public void InjectionSanity()
+        {
+            ReadOnlyCollection<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
+            IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, beforeInstructions);
+
+            Assert.IsTrue(beforeInstructions.Count < result.Count());
+        }
+
+        [TestMethod]
+        public void CheckMethodValidity()
+        {
+            ReadOnlyCollection<CodeInstruction> instructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                CodeInstruction instruction = instructions[i];
+                if (instruction.opcode.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE) && instruction.operand.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPERAND))
+                {
+                    CodeInstruction nextBr = instructions[i + 2];
+                    Assert.IsTrue(nextBr.opcode.Equals(OpCodes.Brtrue), "Looks like subnautica code has changed. Update jump offset!");
+                }
+            }
+        }
+    }
+}

--- a/Nitrox.Test/Patcher/Patches/CyclopsSonarButton_Update_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/CyclopsSonarButton_Update_PatchTest.cs
@@ -5,47 +5,45 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxModel.Helper;
-using NitroxPatcher.Patches.Dynamic;
 using NitroxTest.Patcher.Test;
 
-namespace Nitrox.Test.Patcher.Patches
+namespace NitroxPatcher.Patches.Dynamic;
+
+[TestClass]
+public class CyclopsSonarButton_Update_PatchTest
 {
-    [TestClass]
-    public class CyclopsSonarButton_Update_PatchTest
+    [TestMethod]
+    public void Sanity()
     {
-        [TestMethod]
-        public void Sanity()
+        List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
+        instructions.Add(new CodeInstruction(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE, CyclopsSonarButton_Update_Patch.INJECTION_OPERAND));
+        instructions.Add(new CodeInstruction(OpCodes.Callvirt, Reflect.Method((Player player) => player.GetMode())));
+        instructions.Add(new CodeInstruction(OpCodes.Brtrue));
+
+        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(null, instructions);
+        Assert.AreEqual(instructions.Count + 2, result.Count());
+    }
+
+    [TestMethod]
+    public void InjectionSanity()
+    {
+        ReadOnlyCollection<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, beforeInstructions);
+
+        Assert.IsTrue(beforeInstructions.Count < result.Count());
+    }
+
+    [TestMethod]
+    public void CheckMethodValidity()
+    {
+        ReadOnlyCollection<CodeInstruction> instructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
+        for (int i = 0; i < instructions.Count; i++)
         {
-            List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
-            instructions.Add(new CodeInstruction(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE, CyclopsSonarButton_Update_Patch.INJECTION_OPERAND));
-            instructions.Add(new CodeInstruction(OpCodes.Callvirt, Reflect.Method((Player player) => player.GetMode())));
-            instructions.Add(new CodeInstruction(OpCodes.Brtrue));
-
-            IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(null, instructions);
-            Assert.AreEqual(instructions.Count + 2, result.Count());
-        }
-
-        [TestMethod]
-        public void InjectionSanity()
-        {
-            ReadOnlyCollection<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
-            IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, beforeInstructions);
-
-            Assert.IsTrue(beforeInstructions.Count < result.Count());
-        }
-
-        [TestMethod]
-        public void CheckMethodValidity()
-        {
-            ReadOnlyCollection<CodeInstruction> instructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
-            for (int i = 0; i < instructions.Count; i++)
+            CodeInstruction instruction = instructions[i];
+            if (instruction.opcode.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE) && instruction.operand.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPERAND))
             {
-                CodeInstruction instruction = instructions[i];
-                if (instruction.opcode.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPCODE) && instruction.operand.Equals(CyclopsSonarButton_Update_Patch.INJECTION_OPERAND))
-                {
-                    CodeInstruction nextBr = instructions[i + 2];
-                    Assert.IsTrue(nextBr.opcode.Equals(OpCodes.Brtrue), "Looks like subnautica code has changed. Update jump offset!");
-                }
+                CodeInstruction nextBr = instructions[i + 2];
+                Assert.IsTrue(nextBr.opcode.Equals(OpCodes.Brtrue), "Looks like subnautica code has changed. Update jump offset!");
             }
         }
     }

--- a/NitroxClient/Communication/Packets/Processors/CyclopsChangeEngineModeProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CyclopsChangeEngineModeProcessor.cs
@@ -1,5 +1,4 @@
-﻿using NitroxClient.Communication.Abstract;
-using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel_Subnautica.Packets;
 
@@ -7,12 +6,10 @@ namespace NitroxClient.Communication.Packets.Processors
 {
     public class CyclopsChangeEngineModeProcessor : ClientPacketProcessor<CyclopsChangeEngineMode>
     {
-        private readonly IPacketSender packetSender;
         private readonly Cyclops cyclops;
 
-        public CyclopsChangeEngineModeProcessor(IPacketSender packetSender, Cyclops cyclops)
+        public CyclopsChangeEngineModeProcessor(Cyclops cyclops)
         {
-            this.packetSender = packetSender;
             this.cyclops = cyclops;
         }
 

--- a/NitroxClient/Communication/Packets/Processors/CyclopsChangeSonarModeProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CyclopsChangeSonarModeProcessor.cs
@@ -1,5 +1,4 @@
-﻿using NitroxClient.Communication.Abstract;
-using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel_Subnautica.Packets;
 
@@ -7,12 +6,10 @@ namespace NitroxClient.Communication.Packets.Processors
 {
     public class CyclopsChangeSonarModeProcessor : ClientPacketProcessor<CyclopsChangeSonarMode>
     {
-        private readonly IPacketSender packetSender;
         private readonly Cyclops cyclops;
 
-        public CyclopsChangeSonarModeProcessor(IPacketSender packetSender, Cyclops cyclops)
+        public CyclopsChangeSonarModeProcessor(Cyclops cyclops)
         {
-            this.packetSender = packetSender;
             this.cyclops = cyclops;
         }
 

--- a/NitroxClient/Communication/Packets/Processors/CyclopsToggleEngineStateProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CyclopsToggleEngineStateProcessor.cs
@@ -1,5 +1,4 @@
-﻿using NitroxClient.Communication.Abstract;
-using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel_Subnautica.Packets;
 
@@ -7,12 +6,10 @@ namespace NitroxClient.Communication.Packets.Processors
 {
     public class CyclopsToggleEngineStateProcessor : ClientPacketProcessor<CyclopsToggleEngineState>
     {
-        private readonly IPacketSender packetSender;
         private readonly Cyclops cyclops;
 
-        public CyclopsToggleEngineStateProcessor(IPacketSender packetSender, Cyclops cyclops)
+        public CyclopsToggleEngineStateProcessor(Cyclops cyclops)
         {
-            this.packetSender = packetSender;
             this.cyclops = cyclops;
         }
 

--- a/NitroxClient/Communication/Packets/Processors/VehicleColorChangeProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleColorChangeProcessor.cs
@@ -30,7 +30,10 @@ namespace NitroxClient.Communication.Packets.Processors
             }
             else
             {
-                GameObject vehicleObject = NitroxEntity.RequireObjectFrom(colorPacket.VehicleId);
+                if (!NitroxEntity.TryGetObjectFrom(colorPacket.VehicleId, out GameObject vehicleObject))
+                {
+                    return;
+                }
 
                 subNameInput = vehicleObject.GetComponentInChildren<SubNameInput>();
             }

--- a/NitroxClient/GameLogic/Cyclops.cs
+++ b/NitroxClient/GameLogic/Cyclops.cs
@@ -157,10 +157,10 @@ namespace NitroxClient.GameLogic
         public void ChangeEngineMode(NitroxId id, CyclopsMotorMode.CyclopsMotorModes mode)
         {
             GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
-            CyclopsMotorMode motorMode = cyclops.RequireComponentInChildren<CyclopsMotorMode>();
-            if (motorMode.cyclopsMotorMode != mode)
+            CyclopsMotorModeButton motorModeButton = cyclops.RequireComponentInChildren<CyclopsMotorModeButton>();
+            if (motorModeButton.motorModeIndex != mode)
             {
-                motorMode.BroadcastMessage("SetCyclopsMotorMode", mode, SendMessageOptions.RequireReceiver);
+                motorModeButton.BroadcastMessage("SetCyclopsMotorMode", mode, SendMessageOptions.RequireReceiver);
             }
         }
 

--- a/NitroxClient/GameLogic/Cyclops.cs
+++ b/NitroxClient/GameLogic/Cyclops.cs
@@ -129,7 +129,6 @@ namespace NitroxClient.GameLogic
         {
             GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
             CyclopsEngineChangeState engineState = cyclops.RequireComponentInChildren<CyclopsEngineChangeState>();
-            CyclopsMotorMode motorMode = cyclops.RequireComponentInChildren<CyclopsMotorMode>();
 
             if (isOn == engineState.motorMode.engineOn)
             {
@@ -157,10 +156,14 @@ namespace NitroxClient.GameLogic
         public void ChangeEngineMode(NitroxId id, CyclopsMotorMode.CyclopsMotorModes mode)
         {
             GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
-            CyclopsMotorModeButton motorModeButton = cyclops.RequireComponentInChildren<CyclopsMotorModeButton>();
-            if (motorModeButton.motorModeIndex != mode)
+            foreach (CyclopsMotorModeButton button in cyclops.GetComponentsInChildren<CyclopsMotorModeButton>())
             {
-                motorModeButton.BroadcastMessage("SetCyclopsMotorMode", mode, SendMessageOptions.RequireReceiver);
+                // At initial sync, this kind of processor is executed before the Start()
+                if (button.subRoot == null)
+                {
+                    button.Start();
+                }
+                button.SetCyclopsMotorMode(mode);
             }
         }
 
@@ -217,7 +220,7 @@ namespace NitroxClient.GameLogic
         public void ChangeSonarMode(NitroxId id, bool isOn)
         {
             GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
-            CyclopsSonarButton sonar = cyclops.GetComponentInChildren<CyclopsSonarButton>();
+            CyclopsSonarButton sonar = cyclops.RequireComponentInChildren<CyclopsSonarButton>();
             if (sonar != null)
             {
                 using (packetSender.Suppress<CyclopsChangeSonarMode>())

--- a/NitroxClient/MonoBehaviours/PlayerMovement.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovement.cs
@@ -3,7 +3,7 @@ using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Helper;
+using NitroxModel_Subnautica.DataStructures;
 using NitroxModel_Subnautica.Helper;
 using UnityEngine;
 
@@ -50,6 +50,11 @@ namespace NitroxClient.MonoBehaviours
                     currentPosition = undoVehicleAngle * currentPosition;
                     bodyRotation = undoVehicleAngle * bodyRotation;
                     aimingRotation = undoVehicleAngle * aimingRotation;
+                    if (Player.main.isPiloting && subRoot.isCyclops)
+                    {
+                        // In case you're driving the cyclops, the currentPosition is the real position of the player, so we need to send it to the server
+                        vehicle.Value.DriverPosition = currentPosition.ToDto();
+                    }
                 }
 
                 localPlayer.UpdateLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation, vehicle);

--- a/NitroxModel/DataStructures/GameLogic/VehicleMovementData.cs
+++ b/NitroxModel/DataStructures/GameLogic/VehicleMovementData.cs
@@ -35,6 +35,9 @@ namespace NitroxModel.DataStructures.GameLogic
         [ProtoMember(9)]
         public bool AppliedThrottle { get; }
 
+        [ProtoMember(10)]
+        public NitroxVector3? DriverPosition { get; set; }
+
         protected VehicleMovementData()
         {
             // Constructor for serialization. Has to be "protected" for json serialization.

--- a/NitroxPatcher/Patches/Dynamic/CyclopsEngineChangeState_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsEngineChangeState_OnClick_Patch.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
@@ -15,7 +14,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static void Postfix(CyclopsEngineChangeState __instance)
         {
             NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
-            NitroxServiceLocator.LocateService<Cyclops>().BroadcastToggleEngineState(id, __instance.motorMode.engineOn, __instance.startEngine);
+            Resolve<Cyclops>().BroadcastToggleEngineState(id, __instance.motorMode.engineOn, __instance.startEngine);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
@@ -4,7 +4,6 @@ using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.Helper;
 using NitroxModel_Subnautica.DataStructures.GameLogic;
-using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
@@ -14,8 +13,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {
-            GameObject cyclopsObject = __instance.transform.parent.gameObject;
-            CyclopsModel cyclops = Resolve<Vehicles>().GetVehicles<CyclopsModel>(NitroxEntity.GetId(cyclopsObject));
+            CyclopsModel cyclops = Resolve<Vehicles>().GetVehicles<CyclopsModel>(NitroxEntity.GetId(__instance.subRoot.gameObject));
             __instance.hudActive = true;
             __instance.engineToggleAnimator.SetTrigger(cyclops.EngineState ? "EngineOn" : "EngineOff");
         }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Start_Patch.cs
@@ -1,6 +1,10 @@
 ﻿using System.Reflection;
 using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
 using NitroxModel.Helper;
+using NitroxModel_Subnautica.DataStructures.GameLogic;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
@@ -10,8 +14,10 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {
+            GameObject cyclopsObject = __instance.transform.parent.gameObject;
+            CyclopsModel cyclops = Resolve<Vehicles>().GetVehicles<CyclopsModel>(NitroxEntity.GetId(cyclopsObject));
             __instance.hudActive = true;
-            __instance.engineToggleAnimator.SetTrigger(__instance.motorMode.engineOn ? "EngineOn" : "EngineOff");
+            __instance.engineToggleAnimator.SetTrigger(cyclops.EngineState ? "EngineOn" : "EngineOff");
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_StopPiloting_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_StopPiloting_Patch.cs
@@ -1,5 +1,8 @@
 ﻿using System.Reflection;
 using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
@@ -10,7 +13,9 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Postfix(CyclopsHelmHUDManager __instance)
         {
+            NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
             __instance.hudActive = true;
+            Resolve<Cyclops>().BroadcastChangeSonarState(id, false);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorModeButton_OnClick_Patch.cs
@@ -3,7 +3,6 @@ using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
@@ -37,7 +36,7 @@ namespace NitroxPatcher.Patches.Dynamic
             {
                 SubRoot cyclops = __instance.subRoot;
                 NitroxId id = NitroxEntity.GetId(cyclops.gameObject);
-                NitroxServiceLocator.LocateService<Cyclops>().BroadcastChangeEngineMode(id, __instance.motorModeIndex);
+                Resolve<Cyclops>().BroadcastChangeEngineMode(id, __instance.motorModeIndex);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_RestoreEngineState_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_RestoreEngineState_Patch.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class CyclopsMotorMode_RestoreEngineState_Patch : NitroxPatch, IDynamicPatch
+    {
+        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsMotorMode t) => t.RestoreEngineState());
+
+        public static bool Prefix()
+        {
+            // We don't want this to happen because it will prevent players that were far of the cyclops when spawning to see its actual engine state
+            return false;
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_RestoreEngineState_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_RestoreEngineState_Patch.cs
@@ -2,21 +2,20 @@
 using HarmonyLib;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class CyclopsMotorMode_RestoreEngineState_Patch : NitroxPatch, IDynamicPatch
 {
-    public class CyclopsMotorMode_RestoreEngineState_Patch : NitroxPatch, IDynamicPatch
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsMotorMode t) => t.RestoreEngineState());
+
+    public static bool Prefix()
     {
-        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsMotorMode t) => t.RestoreEngineState());
+        // We don't want this to happen because it will prevent players that were far of the cyclops when spawning to see its actual engine state
+        return false;
+    }
 
-        public static bool Prefix()
-        {
-            // We don't want this to happen because it will prevent players that were far of the cyclops when spawning to see its actual engine state
-            return false;
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchPrefix(harmony, TARGET_METHOD);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
@@ -16,7 +15,7 @@ namespace NitroxPatcher.Patches.Dynamic
         {
             NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
             bool activeSonar = __instance.sonarActive;
-            NitroxServiceLocator.LocateService<Cyclops>().BroadcastChangeSonarState(id, activeSonar);
+            Resolve<Cyclops>().BroadcastChangeSonarState(id, activeSonar);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_OnClick_Patch.cs
@@ -14,8 +14,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static void Postfix(CyclopsSonarButton __instance)
         {
             NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
-            bool activeSonar = __instance.sonarActive;
-            Resolve<Cyclops>().BroadcastChangeSonarState(id, activeSonar);
+            Resolve<Cyclops>().BroadcastChangeSonarState(id, __instance.sonarActive);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
@@ -10,7 +10,7 @@ using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
-    class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
+    public class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.SonarPing());
         public static readonly OpCode JUMP_TARGET_CODE = OpCodes.Ldsfld;

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
@@ -5,7 +5,6 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
@@ -22,7 +21,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static void Postfix(CyclopsSonarButton __instance)
         {
             NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
-            NitroxServiceLocator.LocateService<Cyclops>().BroadcastSonarPing(id);
+            Resolve<Cyclops>().BroadcastSonarPing(id);
         }
 
 
@@ -75,7 +74,7 @@ namespace NitroxPatcher.Patches.Dynamic
                  */
                 if (instruction.opcode.Equals(OpCodes.Brtrue))
                 {
-                    if (instructionList[i - 1].opcode.Equals(OpCodes.Ldloc_1) && instructionList[i + 1].opcode.Equals(OpCodes.Ldarg_0))
+                    if (instructionList[i - 1].opcode.Equals(OpCodes.Call) && instructionList[i + 1].opcode.Equals(OpCodes.Ldarg_0))
                     {
                         instruction.operand = toInjectJump;
                     }
@@ -129,8 +128,7 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public override void Patch(Harmony harmony)
         {
-            PatchPostfix(harmony, TARGET_METHOD);
-            PatchTranspiler(harmony, TARGET_METHOD);
+            PatchMultiple(harmony, TARGET_METHOD, postfix: true, transpiler: true);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
@@ -10,6 +10,9 @@ using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
+    /// <summary>
+    /// The sonar will stay on until the player leaves the vehicle and automatically turns on when they enter again (if sonar was on at that time).
+    /// </summary>
     public class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.SonarPing());

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
@@ -7,70 +7,67 @@ using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Prevents sonar from turning off automatically for the player that isn't currently piloting the Cyclops.
+/// </summary>
+public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
 {
-    /// <summary>
-    /// Prevents sonar from turning off automatically for the player that isn't currently piloting the Cyclops.
-    /// </summary>
-    public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.Update());
+
+    internal static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
+    internal static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
+
+    private static NitroxId currentCyclopsId;
+
+    public static void Prefix(CyclopsSonarButton __instance)
     {
-        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.Update());
-
-        internal static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
-        internal static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
-
-        private static NitroxId currentCyclopsId;
-
-        public static void Prefix(CyclopsSonarButton __instance)
-        {
-            currentCyclopsId = NitroxEntity.GetId(__instance.subRoot.gameObject);
-        }
-
-        public static IEnumerable<CodeInstruction> Transpiler(MethodBase methodBase, IEnumerable<CodeInstruction> instructions)
-        {
-            Validate.NotNull(INJECTION_OPERAND);
-            
-            /* Normally in the Update()
-             * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
-		     * {
-		     *     this.TurnOffSonar();
-		     * }
-             * this part will be changed into:
-             * if (CyclopsSonarButton_Update_Patch.ShouldTurnOff() && Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
-             */
-            List<CodeInstruction> codeInstructions = new List<CodeInstruction>(instructions);
-            CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff()));
-            CodeInstruction brInstruction = new(OpCodes.Brfalse);
-            for (int i = 0; i < codeInstructions.Count; i++)
-            {
-                CodeInstruction instruction = codeInstructions[i];
-
-                if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
-                {
-                    // The second line after the current instruction should be a Brtrue, we need its operand to have the same jump label for our brfalse
-                    CodeInstruction nextBr = codeInstructions[i + 2];
-                    
-                    // The new instruction will be the first of the if statement, so it should take the jump labels that the former first part of the statement had
-                    callInstruction.labels = new List<Label>(instruction.labels);
-                    instruction.labels.Clear();
-                    brInstruction.operand = nextBr.operand;
-
-                    yield return callInstruction;
-                    yield return brInstruction;
-                }
-                yield return instruction;
-            }
-        }
-
-        public static bool ShouldTurnoff()
-        {
-            return Resolve<Cyclops>().ShouldSonarTurnoff(currentCyclopsId);
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchMultiple(harmony, TARGET_METHOD, prefix: true, transpiler: true);
-        }
-
+        currentCyclopsId = NitroxEntity.GetId(__instance.subRoot.gameObject);
     }
+
+    public static IEnumerable<CodeInstruction> Transpiler(MethodBase methodBase, IEnumerable<CodeInstruction> instructions)
+    {
+        /* Normally in the Update()
+         * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
+         * {
+         *     this.TurnOffSonar();
+         * }
+         * this part will be changed into:
+         * if (CyclopsSonarButton_Update_Patch.ShouldTurnOff() && Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
+         */
+        List<CodeInstruction> codeInstructions = new List<CodeInstruction>(instructions);
+        CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff()));
+        CodeInstruction brInstruction = new(OpCodes.Brfalse);
+        for (int i = 0; i < codeInstructions.Count; i++)
+        {
+            CodeInstruction instruction = codeInstructions[i];
+
+            if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
+            {
+                // The second line after the current instruction should be a Brtrue, we need its operand to have the same jump label for our brfalse
+                CodeInstruction nextBr = codeInstructions[i + 2];
+
+                // The new instruction will be the first of the if statement, so it should take the jump labels that the former first part of the statement had
+                callInstruction.labels = new List<Label>(instruction.labels);
+                instruction.labels.Clear();
+                brInstruction.operand = nextBr.operand;
+
+                yield return callInstruction;
+                yield return brInstruction;
+            }
+            yield return instruction;
+        }
+    }
+
+    public static bool ShouldTurnoff()
+    {
+        return Resolve<Cyclops>().ShouldSonarTurnoff(currentCyclopsId);
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchMultiple(harmony, TARGET_METHOD, prefix: true, transpiler: true);
+    }
+
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
+    {
+        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.Update());
+
+        private static readonly OpCode INJECTION_OPCODE = OpCodes.Call;
+        private static readonly object INJECTION_OPERAND = Reflect.Property((CyclopsSonarButton t) => t.sonarActive).GetGetMethod(true);
+
+        private static NitroxId currentCyclopsId;
+
+        public static void Prefix(CyclopsSonarButton __instance)
+        {
+            currentCyclopsId = NitroxEntity.GetId(__instance.subRoot.gameObject);
+        }
+
+        public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+        {
+            Validate.NotNull(INJECTION_OPERAND);
+
+            /* Normally in the Update()
+             * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
+		     * {
+		     *     this.TurnOffSonar();
+		     * }
+             * this part will be changed:
+             * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive && CyclopsSonarButton_Update_Patch.ShouldTurnOff())
+             */
+            CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff()));
+            CodeInstruction brInstruction = new(OpCodes.Brfalse);
+
+            // There are 2 occurences of INJECTION_OPCODE and INJECTION_OPERAND
+            // shouldAdd makes it so that the code is only injected the second time
+            int addIndex = -1;
+            bool shouldAdd = true;
+            foreach (CodeInstruction instruction in instructions)
+            {
+                addIndex--;
+                yield return instruction;
+                
+                if (addIndex == 0)
+                {
+                    shouldAdd = !shouldAdd;
+                    if (!shouldAdd)
+                    {
+                        continue;
+                    }
+                    brInstruction.operand = instruction.operand;
+                    foreach (CodeInstruction instructionToAdd in new List<CodeInstruction>() { callInstruction, brInstruction })
+                    {
+                        yield return instructionToAdd;
+                    }
+                }
+                // When getting to this.sonarActive, we want to inject the code after the brfalse that follows this instruction
+                if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
+                {
+                    addIndex = 1;
+                }
+            }
+        }
+
+        public static bool ShouldTurnoff()
+        {
+            return Resolve<Cyclops>().ShouldSonarTurnoff(currentCyclopsId);
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchMultiple(harmony, TARGET_METHOD, prefix: true, transpiler: true);
+        }
+
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
@@ -16,8 +16,8 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.Update());
 
-        private static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
-        private static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
+        internal static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
+        internal static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
 
         private static NitroxId currentCyclopsId;
 
@@ -26,7 +26,7 @@ namespace NitroxPatcher.Patches.Dynamic
             currentCyclopsId = NitroxEntity.GetId(__instance.subRoot.gameObject);
         }
 
-        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> Transpiler(MethodBase methodBase, IEnumerable<CodeInstruction> instructions)
         {
             Validate.NotNull(INJECTION_OPERAND);
             
@@ -49,7 +49,6 @@ namespace NitroxPatcher.Patches.Dynamic
                 {
                     // The second line after the current instruction should be a Brtrue, we need its operand to have the same jump label for our brfalse
                     CodeInstruction nextBr = codeInstructions[i + 2];
-                    Validate.IsTrue(nextBr.opcode.Equals(OpCodes.Brtrue), "Looks like subnautica code has changed. Update jump offset!");
                     
                     // The new instruction will be the first of the if statement, so it should take the jump labels that the former first part of the statement had
                     callInstruction.labels = new List<Label>(instruction.labels);

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
@@ -9,6 +9,9 @@ using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
 {
+    /// <summary>
+    /// Prevents sonar from turning off automatically for the player that isn't currently piloting the Cyclops.
+    /// </summary>
     public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
     {
         public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.Update());
@@ -32,7 +35,7 @@ namespace NitroxPatcher.Patches.Dynamic
 		     * {
 		     *     this.TurnOffSonar();
 		     * }
-             * this part will be changed:
+             * this part will be changed into:
              * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive && CyclopsSonarButton_Update_Patch.ShouldTurnOff())
              */
             CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff()));
@@ -55,10 +58,8 @@ namespace NitroxPatcher.Patches.Dynamic
                         continue;
                     }
                     brInstruction.operand = instruction.operand;
-                    foreach (CodeInstruction instructionToAdd in new List<CodeInstruction>() { callInstruction, brInstruction })
-                    {
-                        yield return instructionToAdd;
-                    }
+                    yield return callInstruction;
+                    yield return brInstruction;
                 }
                 // When getting to this.sonarActive, we want to inject the code after the brfalse that follows this instruction
                 if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -18,8 +18,10 @@ using NitroxModel.DataStructures.Util;
 using NitroxModel.Discovery;
 using NitroxModel.Helper;
 using NitroxModel.Platforms.OS.Shared;
+using NitroxModel_Subnautica.DataStructures.GameLogic;
 using NitroxServer;
 using NitroxServer.ConsoleCommands.Processor;
+using NitroxServer.GameLogic.Vehicles;
 
 namespace NitroxServer_Subnautica;
 
@@ -84,6 +86,8 @@ public class Program
             NitroxServiceLocator.BeginNewLifetimeScope();
 
             server = NitroxServiceLocator.LocateService<Server>();
+            // TODO: We do not support loading back into as vehicle driver yet so the sonar must be off
+            SetDefaultCyclopsState(server.World.VehicleManager);
             await WaitForAvailablePortAsync(server.Port);
             CatchExitEvent();
             listenForCommands = ListenForCommandsAsync(server);
@@ -300,6 +304,17 @@ public class Program
     {
         Log.Info("Exiting ...");
         Server.Instance.Stop();
+    }
+
+    private static void SetDefaultCyclopsState(VehicleManager vehicleManager)
+    {
+        foreach (VehicleModel vehicleModel in vehicleManager.GetVehicles())
+        {
+            if (vehicleModel is CyclopsModel cyclopsModel)
+            {
+                cyclopsModel.SonarOn = false;
+            }
+        }
     }
 
     // See: https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -86,7 +86,7 @@ public class Program
             NitroxServiceLocator.BeginNewLifetimeScope();
 
             server = NitroxServiceLocator.LocateService<Server>();
-            // TODO: We do not support loading back into as vehicle driver yet so the sonar must be off
+            // Sonar must be set off by default since we cannot load back as a vehicle driver (as in vanilla SN)
             SetDefaultCyclopsState(server.World.VehicleManager);
             await WaitForAvailablePortAsync(server.Port);
             CatchExitEvent();

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -87,7 +87,7 @@ public class Program
 
             server = NitroxServiceLocator.LocateService<Server>();
             // Sonar must be set off by default since we cannot load back as a vehicle driver (as in vanilla SN)
-            SetDefaultCyclopsState(server.World.VehicleManager);
+            SetDefaultCyclopsState();
             await WaitForAvailablePortAsync(server.Port);
             CatchExitEvent();
             listenForCommands = ListenForCommandsAsync(server);
@@ -306,8 +306,9 @@ public class Program
         Server.Instance.Stop();
     }
 
-    private static void SetDefaultCyclopsState(VehicleManager vehicleManager)
+    private static void SetDefaultCyclopsState()
     {
+        VehicleManager vehicleManager = NitroxServiceLocator.LocateService<VehicleManager>();
         foreach (VehicleModel vehicleModel in vehicleManager.GetVehicles())
         {
             if (vehicleModel is CyclopsModel cyclopsModel)

--- a/NitroxServer/Communication/Packets/Processors/VehicleMovementPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/VehicleMovementPacketProcessor.cs
@@ -22,7 +22,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
             if (player.Id == packet.PlayerId)
             {
-                player.Position = packet.Position;
+                player.Position = packet.VehicleMovementData.DriverPosition ?? packet.Position;
             }
 
             playerManager.SendPacketToOtherPlayers(packet, player);

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -17,7 +17,7 @@ namespace NitroxServer
         private readonly WorldPersistence worldPersistence;
         private readonly ServerConfig serverConfig;
         private readonly Timer saveTimer;
-        private readonly World world;
+        public readonly World World;
         private readonly EntityManager entityManager;
         private CancellationTokenSource serverCancelSource;
 
@@ -33,7 +33,7 @@ namespace NitroxServer
             this.worldPersistence = worldPersistence;
             this.serverConfig = serverConfig;
             this.server = server;
-            this.world = world;
+            this.World = world;
             this.entityManager = entityManager;
 
             Instance = this;
@@ -55,18 +55,18 @@ namespace NitroxServer
                 // Note for later additions: order these lines by their length
                 StringBuilder builder = new("\n");
                 builder.AppendLine($" - Save location: {Path.GetFullPath(serverConfig.SaveName)}");
-                builder.AppendLine($" - Current time: day {world.EventTriggerer.Day} ({Math.Floor(world.EventTriggerer.ElapsedSeconds)}s)");
-                builder.AppendLine($" - Scheduled goals stored: {world.GameData.StoryGoals.ScheduledGoals.Count}");
-                builder.AppendLine($" - Story goals completed: {world.GameData.StoryGoals.CompletedGoals.Count}");
-                builder.AppendLine($" - Radio messages stored: {world.GameData.StoryGoals.RadioQueue.Count}");
+                builder.AppendLine($" - Current time: day {World.EventTriggerer.Day} ({Math.Floor(World.EventTriggerer.ElapsedSeconds)}s)");
+                builder.AppendLine($" - Scheduled goals stored: {World.GameData.StoryGoals.ScheduledGoals.Count}");
+                builder.AppendLine($" - Story goals completed: {World.GameData.StoryGoals.CompletedGoals.Count}");
+                builder.AppendLine($" - Radio messages stored: {World.GameData.StoryGoals.RadioQueue.Count}");
                 builder.AppendLine($" - World gamemode: {serverConfig.GameMode}");
-                builder.AppendLine($" - Story goals unlocked: {world.GameData.StoryGoals.GoalUnlocks.Count}");
-                builder.AppendLine($" - Encyclopedia entries: {world.GameData.PDAState.EncyclopediaEntries.Count}");
-                builder.AppendLine($" - Storage slot items: {world.InventoryManager.GetAllStorageSlotItems().Count}");
-                builder.AppendLine($" - Inventory items: {world.InventoryManager.GetAllInventoryItems().Count}");
-                builder.AppendLine($" - Progress tech: {world.GameData.PDAState.CachedProgress.Count}");
-                builder.AppendLine($" - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}");
-                builder.AppendLine($" - Vehicles: {world.VehicleManager.GetVehicles().Count()}");
+                builder.AppendLine($" - Story goals unlocked: {World.GameData.StoryGoals.GoalUnlocks.Count}");
+                builder.AppendLine($" - Encyclopedia entries: {World.GameData.PDAState.EncyclopediaEntries.Count}");
+                builder.AppendLine($" - Storage slot items: {World.InventoryManager.GetAllStorageSlotItems().Count}");
+                builder.AppendLine($" - Inventory items: {World.InventoryManager.GetAllInventoryItems().Count}");
+                builder.AppendLine($" - Progress tech: {World.GameData.PDAState.CachedProgress.Count}");
+                builder.AppendLine($" - Known tech: {World.GameData.PDAState.KnownTechTypes.Count}");
+                builder.AppendLine($" - Vehicles: {World.VehicleManager.GetVehicles().Count()}");
                 
                 return builder.ToString();
             }
@@ -81,7 +81,7 @@ namespace NitroxServer
 
             IsSaving = true;
 
-            bool savedSuccessfully = worldPersistence.Save(world, serverConfig.SaveName);
+            bool savedSuccessfully = worldPersistence.Save(World, serverConfig.SaveName);
             if (savedSuccessfully && !string.IsNullOrWhiteSpace(serverConfig.PostSaveCommandPath))
             {
                 try
@@ -191,8 +191,8 @@ namespace NitroxServer
         public void PauseServer()
         {
             DisablePeriodicSaving();
-            world.EventTriggerer.PauseWorldTime();
-            world.EventTriggerer.PauseEventTimers();
+            World.EventTriggerer.PauseWorldTime();
+            World.EventTriggerer.PauseEventTimers();
             Log.Info("Server has paused, waiting for players to connect");
         }
 
@@ -202,8 +202,8 @@ namespace NitroxServer
             {
                 EnablePeriodicSaving();
             }
-            world.EventTriggerer.StartWorldTime();
-            world.EventTriggerer.StartEventTimers();
+            World.EventTriggerer.StartWorldTime();
+            World.EventTriggerer.StartEventTimers();
             Log.Info("Server has resumed");
         }
     }

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -33,7 +33,7 @@ namespace NitroxServer
             this.worldPersistence = worldPersistence;
             this.serverConfig = serverConfig;
             this.server = server;
-            this.World = world;
+            World = world;
             this.entityManager = entityManager;
 
             Instance = this;

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -17,7 +17,7 @@ namespace NitroxServer
         private readonly WorldPersistence worldPersistence;
         private readonly ServerConfig serverConfig;
         private readonly Timer saveTimer;
-        public readonly World World;
+        private readonly World world;
         private readonly EntityManager entityManager;
         private CancellationTokenSource serverCancelSource;
 
@@ -33,7 +33,7 @@ namespace NitroxServer
             this.worldPersistence = worldPersistence;
             this.serverConfig = serverConfig;
             this.server = server;
-            World = world;
+            this.world = world;
             this.entityManager = entityManager;
 
             Instance = this;
@@ -55,18 +55,18 @@ namespace NitroxServer
                 // Note for later additions: order these lines by their length
                 StringBuilder builder = new("\n");
                 builder.AppendLine($" - Save location: {Path.GetFullPath(serverConfig.SaveName)}");
-                builder.AppendLine($" - Current time: day {World.EventTriggerer.Day} ({Math.Floor(World.EventTriggerer.ElapsedSeconds)}s)");
-                builder.AppendLine($" - Scheduled goals stored: {World.GameData.StoryGoals.ScheduledGoals.Count}");
-                builder.AppendLine($" - Story goals completed: {World.GameData.StoryGoals.CompletedGoals.Count}");
-                builder.AppendLine($" - Radio messages stored: {World.GameData.StoryGoals.RadioQueue.Count}");
+                builder.AppendLine($" - Current time: day {world.EventTriggerer.Day} ({Math.Floor(world.EventTriggerer.ElapsedSeconds)}s)");
+                builder.AppendLine($" - Scheduled goals stored: {world.GameData.StoryGoals.ScheduledGoals.Count}");
+                builder.AppendLine($" - Story goals completed: {world.GameData.StoryGoals.CompletedGoals.Count}");
+                builder.AppendLine($" - Radio messages stored: {world.GameData.StoryGoals.RadioQueue.Count}");
                 builder.AppendLine($" - World gamemode: {serverConfig.GameMode}");
-                builder.AppendLine($" - Story goals unlocked: {World.GameData.StoryGoals.GoalUnlocks.Count}");
-                builder.AppendLine($" - Encyclopedia entries: {World.GameData.PDAState.EncyclopediaEntries.Count}");
-                builder.AppendLine($" - Storage slot items: {World.InventoryManager.GetAllStorageSlotItems().Count}");
-                builder.AppendLine($" - Inventory items: {World.InventoryManager.GetAllInventoryItems().Count}");
-                builder.AppendLine($" - Progress tech: {World.GameData.PDAState.CachedProgress.Count}");
-                builder.AppendLine($" - Known tech: {World.GameData.PDAState.KnownTechTypes.Count}");
-                builder.AppendLine($" - Vehicles: {World.VehicleManager.GetVehicles().Count()}");
+                builder.AppendLine($" - Story goals unlocked: {world.GameData.StoryGoals.GoalUnlocks.Count}");
+                builder.AppendLine($" - Encyclopedia entries: {world.GameData.PDAState.EncyclopediaEntries.Count}");
+                builder.AppendLine($" - Storage slot items: {world.InventoryManager.GetAllStorageSlotItems().Count}");
+                builder.AppendLine($" - Inventory items: {world.InventoryManager.GetAllInventoryItems().Count}");
+                builder.AppendLine($" - Progress tech: {world.GameData.PDAState.CachedProgress.Count}");
+                builder.AppendLine($" - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}");
+                builder.AppendLine($" - Vehicles: {world.VehicleManager.GetVehicles().Count()}");
                 
                 return builder.ToString();
             }
@@ -81,7 +81,7 @@ namespace NitroxServer
 
             IsSaving = true;
 
-            bool savedSuccessfully = worldPersistence.Save(World, serverConfig.SaveName);
+            bool savedSuccessfully = worldPersistence.Save(world, serverConfig.SaveName);
             if (savedSuccessfully && !string.IsNullOrWhiteSpace(serverConfig.PostSaveCommandPath))
             {
                 try
@@ -191,8 +191,8 @@ namespace NitroxServer
         public void PauseServer()
         {
             DisablePeriodicSaving();
-            World.EventTriggerer.PauseWorldTime();
-            World.EventTriggerer.PauseEventTimers();
+            world.EventTriggerer.PauseWorldTime();
+            world.EventTriggerer.PauseEventTimers();
             Log.Info("Server has paused, waiting for players to connect");
         }
 
@@ -202,8 +202,8 @@ namespace NitroxServer
             {
                 EnablePeriodicSaving();
             }
-            World.EventTriggerer.StartWorldTime();
-            World.EventTriggerer.StartEventTimers();
+            world.EventTriggerer.StartWorldTime();
+            world.EventTriggerer.StartEventTimers();
             Log.Info("Server has resumed");
         }
     }


### PR DESCRIPTION
This PR will try to fix the existing bugs and maybe add some things that weren't synced yet

- [x] Fix cyclops sonar executing from everywhere [Issue#1493](https://github.com/SubnauticaNitrox/Nitrox/issues/1493)
- [x] Fix motor state not syncing
- [x] Fix vehicle loading errors about colors packets (silent errors in the logs but don't do anything wrong)
- [x] Fix motor state not restoring when spawning far away from the cyclops
- [x] Fix sonar button state not being synced
- [x] Fix spawning far away of the Cyclops when relogging (has to do with wrong calculations of the client position sent to the server)
