### PR TITLE
Changed default server serializer to json from protobuf

### DIFF
--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -97,7 +97,7 @@ namespace NitroxServer.Serialization
         public ServerGameMode GameMode { get; set; } = ServerGameMode.SURVIVAL;
 
         [PropertyDescription("Possible values:", typeof(ServerSerializerMode))]
-        public ServerSerializerMode SerializerMode { get; set; } = ServerSerializerMode.PROTOBUF;
+        public ServerSerializerMode SerializerMode { get; set; } = ServerSerializerMode.JSON;
 
         [PropertyDescription("Possible values:", typeof(Perms))]
         public Perms DefaultPlayerPerm { get; set; } = Perms.PLAYER;


### PR DESCRIPTION
I think this has been tested enough now to prove its stable going forward. This will help with issues people may have through allowing inspection of save files and with upgrading saves without having to switch serializer first.

I question if we want to remove the protobuf serializer completly as we wont use it?