### PR TITLE
Fix the vehicle stuck on nothing bug

### DIFF
--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -351,6 +351,21 @@ namespace NitroxClient.GameLogic
 
             VehicleChildObjectIdentifierHelper.SetInteractiveChildrenIds(gameObject, interactiveChildIdentifiers);
 
+            // TODO: Remove this when merging
+            // Testing instructions:
+            // Spawn an exosuit or a seamoth, leave the server then rejoin
+            // If you disable the fix (comment the "Exit()" in Vehicle_OnPilotModeEnd_Patch), you will see that there's the vehicle stuck bug
+            // Enable back the fix, then when you come back, if you join for the first time you will have the stuck bug for the vehicle, but as soon as you leave it and enter it again, the bug will be gone
+            switch (techType)
+            {
+                case TechType.Seamoth:
+                    gameObject.EnsureComponent<MultiplayerSeaMoth>();
+                    break;
+                case TechType.Exosuit:
+                    gameObject.EnsureComponent<MultiplayerExosuit>();
+                    break;
+            }
+
             // Send event after everything is created            
             if (VehicleCreated != null)
             {

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -351,21 +351,6 @@ namespace NitroxClient.GameLogic
 
             VehicleChildObjectIdentifierHelper.SetInteractiveChildrenIds(gameObject, interactiveChildIdentifiers);
 
-            // TODO: Remove this when merging
-            // Testing instructions:
-            // Spawn an exosuit or a seamoth, leave the server then rejoin
-            // If you disable the fix (comment the "Exit()" in Vehicle_OnPilotModeEnd_Patch), you will see that there's the vehicle stuck bug
-            // Enable back the fix, then when you come back, if you join for the first time you will have the stuck bug for the vehicle, but as soon as you leave it and enter it again, the bug will be gone
-            switch (techType)
-            {
-                case TechType.Seamoth:
-                    gameObject.EnsureComponent<MultiplayerSeaMoth>();
-                    break;
-                case TechType.Exosuit:
-                    gameObject.EnsureComponent<MultiplayerExosuit>();
-                    break;
-            }
-
             // Send event after everything is created            
             if (VehicleCreated != null)
             {

--- a/NitroxClient/MonoBehaviours/MultiplayerExosuit.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerExosuit.cs
@@ -28,7 +28,7 @@ namespace NitroxClient.MonoBehaviours
             base.Enter();
         }
 
-        internal override void Exit()
+        public override void Exit()
         {
             GetComponent<Rigidbody>().freezeRotation = true;
             exosuit.SetIKEnabled(false);

--- a/NitroxClient/MonoBehaviours/MultiplayerSeaMoth.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerSeaMoth.cs
@@ -38,7 +38,7 @@ namespace NitroxClient.MonoBehaviours
             }
         }
 
-        internal override void Exit()
+        public override void Exit()
         {
             seamoth.bubbles.Stop();
             base.Exit();

--- a/NitroxClient/MonoBehaviours/MultiplayerVehicleControl.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerVehicleControl.cs
@@ -74,7 +74,7 @@ namespace NitroxClient.MonoBehaviours
             enabled = true;
         }
 
-        internal virtual void Exit()
+        public virtual void Exit()
         {
             enabled = false;
         }

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_OnPilotModeEnd_Patch.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
@@ -14,11 +13,15 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Prefix(Vehicle __instance)
         {
-            NitroxServiceLocator.LocateService<Vehicles>().BroadcastOnPilotModeChanged(__instance, false);
+            Resolve<Vehicles>().BroadcastOnPilotModeChanged(__instance, false);
+            // Fixes instances of vehicles stuck on nothing by forcing the workaround (let another player enter and leave the vehicle)
+            if (__instance.TryGetComponent(out MultiplayerVehicleControl mvc))
+            {
+                mvc.Exit();
+            }
 
             NitroxId id = NitroxEntity.GetId(__instance.gameObject);
-            SimulationOwnership simulationOwnership = NitroxServiceLocator.LocateService<SimulationOwnership>();
-            simulationOwnership.RequestSimulationLock(id, SimulationLockType.TRANSIENT);
+            Resolve<SimulationOwnership>().RequestSimulationLock(id, SimulationLockType.TRANSIENT);
         }
 
         public override void Patch(Harmony harmony)


### PR DESCRIPTION
Title says it all, I hope it doesn't sound too much like a workaround (#1522)

To test, you need to force the issue, you can do this:
add the following code at line 353 (end of **OnVehiclePrefabLoaded**) in **Vehicles.cs**
```
switch (techType)
{
    case TechType.Seamoth:
        gameObject.EnsureComponent<MultiplayerSeaMoth>();
        break;
    case TechType.Exosuit:
        gameObject.EnsureComponent<MultiplayerExosuit>();
        break;
}
```
Then follow these instructions:
- Spawn an exosuit or a seamoth, leave the server then rejoin
- If you disable the fix (comment the "Exit()" in Vehicle_OnPilotModeEnd_Patch), you will see that there's the vehicle stuck bug
- Enable back the fix, then when you come back, if you join for the first time you will have the stuck bug for the vehicle, but as soon as you leave it and enter it again, the bug will be gone