### PR TITLE
Added reference to System.Net.Http

### DIFF
--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -29,6 +29,7 @@
       <Reference Include="Serilog.Sinks.Map">
         <HintPath>..\Nitrox.Assets.Subnautica\Serilog.Sinks.Map.dll</HintPath>
       </Reference>
+      <Reference Include="System.Net.Http" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixed the bug where we couldn't build in release mode due to this missing reference 


```cs
#if RELEASE
            if (ip == null)
            {
                Regex regex = new(@"(?:[0-2]??[0-9]{1,2}\.){3}[0-2]??[0-9]+", RegexOptions.Compiled);
                string[] sites =
                {
                    "https://ipv4.icanhazip.com/",
                    "https://checkip.amazonaws.com/",
                    "https://api.ipify.org/",
                    "https://api4.my-ip.io/ip",
                    "https://ifconfig.me/",
                    "https://showmyip.com/",
                };
               // Missing type HERE
                using HttpClient client = new();
```