### PR TITLE
Remove error by MonitorLauncher

### DIFF
--- a/NitroxPatcher/Patches/Persistent/MonitorLauncher_Awake_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/MonitorLauncher_Awake_Patch.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Persistent;
+
+public class MonitorLauncher_Awake_Patch : NitroxPatch, IPersistentPatch
+{
+    private static readonly MethodInfo targetMethod = Reflect.Method((MonitorLauncher t) => t.Awake());
+
+    public static void Postfix(MonitorLauncher __instance)
+    {
+        UnityEngine.Object.Destroy(__instance);
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, targetMethod);
+    }
+}


### PR DESCRIPTION
`MonitorLauncher` is a memory debug and warning utility for UWE. For some reason it fails at each game start so this pr prevents it's initialization.

![grafik](https://user-images.githubusercontent.com/23176718/151671025-3346a1b5-0778-449d-b91c-90e2f7004a74.png)
