### PR TITLE
Correct soundsWhitelist path

### DIFF
--- a/NitroxClient/Properties/Resources.resx
+++ b/NitroxClient/Properties/Resources.resx
@@ -122,6 +122,6 @@
     <value>..\Resources\playerBackgroundImage;System.Byte[], mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="soundsWhitelist" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\soundswhitelist.csv;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\soundsWhitelist.csv;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>


### PR DESCRIPTION
Compilation will fail on a case-sensitive file system (e.g. Linux ext4).