### PR TITLE
Adding a way to specify the installation path through environment variables

### DIFF
--- a/NitroxModel/Discovery/GameInstallationFinder.cs
+++ b/NitroxModel/Discovery/GameInstallationFinder.cs
@@ -23,7 +23,8 @@ namespace NitroxModel.Discovery
             new ConfigGameFinder(),
             new SteamGameRegistryFinder(),
             new EpicGamesInstallationFinder(),
-            new DiscordGameFinder()
+            new DiscordGameFinder(),
+            new EnvironmentGameFinder()
         };
 
         public string FindGame(IList<string> errors = null)

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NitroxModel.Discovery.InstallationFinders
+{
+    /// <summary>
+    ///     Trying to find the path in environment variables by the key SubnauticaInstallationPath that contains the installation directory of Subnautica.
+    /// </summary>
+    public class EnvironmentGameFinder : IFindGameInstallation
+    {
+        public string FindGame(IList<string> errors = null)
+        {
+            string path = Environment.GetEnvironmentVariable("SubnauticaInstallationPath");
+            if (string.IsNullOrEmpty(path))
+            {
+                errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");
+                return null;
+            }
+
+            if (!Directory.Exists(Path.Combine(path, "Subnautica_Data", "Managed")))
+            {
+                errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica installation.");
+                return null;
+            }
+
+            return path;
+        }
+    }
+}

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -1,30 +1,29 @@
-﻿using System;
+﻿namespace NitroxModel.Discovery.InstallationFinders;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace NitroxModel.Discovery.InstallationFinders
+/// <summary>
+///     Trying to find the path in environment variables by the key SUBNAUTICA_INSTALLATION_PATH that contains the installation directory of Subnautica.
+/// </summary>
+public class EnvironmentGameFinder : IFindGameInstallation
 {
-    /// <summary>
-    ///     Trying to find the path in environment variables by the key SUBNAUTICA_INSTALLATION_PATH that contains the installation directory of Subnautica.
-    /// </summary>
-    public class EnvironmentGameFinder : IFindGameInstallation
+    public string FindGame(IList<string> errors = null)
     {
-        public string FindGame(IList<string> errors = null)
+        string path = Environment.GetEnvironmentVariable("SUBNAUTICA_INSTALLATION_PATH");
+        if (string.IsNullOrEmpty(path))
         {
-            string path = Environment.GetEnvironmentVariable("SUBNAUTICA_INSTALLATION_PATH");
-            if (string.IsNullOrEmpty(path))
-            {
-                errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");
-                return null;
-            }
-
-            if (!Directory.Exists(Path.Combine(path, "Subnautica_Data", "Managed")))
-            {
-                errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica installation.");
-                return null;
-            }
-
-            return path;
+            errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");
+            return null;
         }
+
+        if (!Directory.Exists(Path.Combine(path, "Subnautica_Data", "Managed")))
+        {
+            errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica installation.");
+            return null;
+        }
+
+        return path;
     }
 }

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -1,8 +1,8 @@
-﻿namespace NitroxModel.Discovery.InstallationFinders;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
+
+namespace NitroxModel.Discovery.InstallationFinders;
 
 /// <summary>
 ///     Trying to find the path in environment variables by the key SUBNAUTICA_INSTALLATION_PATH that contains the installation directory of Subnautica.

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -5,13 +5,13 @@ using System.IO;
 namespace NitroxModel.Discovery.InstallationFinders
 {
     /// <summary>
-    ///     Trying to find the path in environment variables by the key SubnauticaInstallationPath that contains the installation directory of Subnautica.
+    ///     Trying to find the path in environment variables by the key SUBNAUTICA_INSTALLATION_PATH that contains the installation directory of Subnautica.
     /// </summary>
     public class EnvironmentGameFinder : IFindGameInstallation
     {
         public string FindGame(IList<string> errors = null)
         {
-            string path = Environment.GetEnvironmentVariable("SubnauticaInstallationPath");
+            string path = Environment.GetEnvironmentVariable("SUBNAUTICA_INSTALLATION_PATH");
             if (string.IsNullOrEmpty(path))
             {
                 errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -14,7 +14,7 @@ public class EnvironmentGameFinder : IFindGameInstallation
         string path = Environment.GetEnvironmentVariable("SUBNAUTICA_INSTALLATION_PATH");
         if (string.IsNullOrEmpty(path))
         {
-            errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");
+            errors?.Add(@"Configured game path with environment variable SUBNAUTICA_INSTALLATION_PATH was found empty.");
             return null;
         }
 

--- a/NitroxServer/GameLogic/Items/InventoryManager.cs
+++ b/NitroxServer/GameLogic/Items/InventoryManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
@@ -16,11 +16,6 @@ namespace NitroxServer.GameLogic.Items
             inventoryItemsById = new ThreadSafeDictionary<NitroxId, ItemData>(inventoryItems.ToDictionary(item => item.ItemId), false);
             storageSlotItemsByContainerId = new ThreadSafeDictionary<NitroxId, ItemData>(storageSlotItems.ToDictionary(item => item.ContainerId), false);
             modulesById = new ThreadSafeDictionary<NitroxId, EquippedItemData>(modules.ToDictionary(module => module.ItemId), false);
-            Log.Debug($"Create InventoryManager with {modules.Count} modules");
-            foreach (EquippedItemData module in modules)
-            {
-                Log.Debug($"Module {module.ItemId} in container {module.ContainerId} with slot {module.Slot}");
-            }
         }
 
         public void InventoryItemAdded(ItemData itemData)
@@ -57,7 +52,6 @@ namespace NitroxServer.GameLogic.Items
         public void ModuleAdded(EquippedItemData itemData)
         {
             modulesById[itemData.ItemId] = itemData;
-            Log.Debug($"Received module {itemData.ItemId} to container {itemData.ContainerId} and slot {itemData.Slot}. Total modules: {modulesById.Count}");
         }
 
         public bool ModuleRemoved(NitroxId ownerId)

--- a/NitroxServer/GameLogic/Items/InventoryManager.cs
+++ b/NitroxServer/GameLogic/Items/InventoryManager.cs
@@ -16,6 +16,11 @@ namespace NitroxServer.GameLogic.Items
             inventoryItemsById = new ThreadSafeDictionary<NitroxId, ItemData>(inventoryItems.ToDictionary(item => item.ItemId), false);
             storageSlotItemsByContainerId = new ThreadSafeDictionary<NitroxId, ItemData>(storageSlotItems.ToDictionary(item => item.ContainerId), false);
             modulesById = new ThreadSafeDictionary<NitroxId, EquippedItemData>(modules.ToDictionary(module => module.ItemId), false);
+            Log.Debug($"Create InventoryManager with {modules.Count} modules");
+            foreach (EquippedItemData module in modules)
+            {
+                Log.Debug($"Module {module.ItemId} in container {module.ContainerId} with slot {module.Slot}");
+            }
         }
 
         public void InventoryItemAdded(ItemData itemData)
@@ -52,6 +57,7 @@ namespace NitroxServer.GameLogic.Items
         public void ModuleAdded(EquippedItemData itemData)
         {
             modulesById[itemData.ItemId] = itemData;
+            Log.Debug($"Received module {itemData.ItemId} to container {itemData.ContainerId} and slot {itemData.Slot}. Total modules: {modulesById.Count}");
         }
 
         public bool ModuleRemoved(NitroxId ownerId)

--- a/NitroxServer/GameLogic/Items/InventoryManager.cs
+++ b/NitroxServer/GameLogic/Items/InventoryManager.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;


### PR DESCRIPTION
**Background**
Right now we have no way to specify the install location explicitly. It would be useful to have a way to do this, as other ways can fail and the user can specify the path to the game himself. 

**Changes**
- Added `SUBNAUTICA_INSTALLATION_PATH`, which doesn't break the current functionality in any way.

**How to test**
- Change environment variable `SUBNAUTICA_INSTALLATION_PATH` (see how [here](https://www.architectryan.com/2018/08/31/how-to-change-environment-variables-on-windows-10/))
- Run server and check that path from environment variable catch correctly

If you have the game installed and one of the classes above has already found its way, you can test this change by moving that class up.