### PR TITLE
Fixes null ref in PlayerManager

### DIFF
--- a/NitroxServer/Communication/ConnectionState.cs
+++ b/NitroxServer/Communication/ConnectionState.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NitroxServer.Communication
+{
+    public enum NitroxConnectionState
+    {
+        Unknown,
+        Disconnected,
+        Connected,
+        Reserved,
+        InGame
+    }
+}

--- a/NitroxServer/Communication/LiteNetLib/LiteNetLibConnection.cs
+++ b/NitroxServer/Communication/LiteNetLib/LiteNetLibConnection.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using LiteNetLib;
 using LiteNetLib.Utils;
 using NitroxModel.Networking;
@@ -12,6 +12,24 @@ namespace NitroxServer.Communication.LiteNetLib
         private readonly NetPeer peer;
 
         public IPEndPoint Endpoint => peer.EndPoint;
+        public NitroxConnectionState State => MapConnectionState(peer.ConnectionState);
+
+        private NitroxConnectionState MapConnectionState(ConnectionState connectionState)
+        {
+            NitroxConnectionState state = NitroxConnectionState.Unknown;
+
+            if (connectionState.HasFlag(ConnectionState.Connected))
+            {
+                state = NitroxConnectionState.Connected;
+            }
+
+            if (connectionState.HasFlag(ConnectionState.Disconnected))
+            {
+                state = NitroxConnectionState.Disconnected;
+            }
+
+            return state;
+        }
 
         public LiteNetLibConnection(NetPeer peer)
         {

--- a/NitroxServer/Communication/NitroxConnection.cs
+++ b/NitroxServer/Communication/NitroxConnection.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using NitroxModel.Packets;
 using NitroxModel.Packets.Processors.Abstract;
 
@@ -7,6 +7,7 @@ namespace NitroxServer.Communication
     public interface NitroxConnection : IProcessorContext
     {
         IPEndPoint Endpoint { get; }
+        NitroxConnectionState State { get; }
         void SendPacket(Packet packet);
     }
 }

--- a/NitroxServer/GameLogic/InitialSyncTimerData.cs
+++ b/NitroxServer/GameLogic/InitialSyncTimerData.cs
@@ -8,12 +8,25 @@ using NitroxServer.Communication;
 
 namespace NitroxServer.GameLogic
 {
+    /// <summary>
+    /// Contains data used in InitialSyncTimer callback
+    /// 
+    /// For use with <see cref="System.Threading.Timer"/>
+    /// </summary>
     internal class InitialSyncTimerData
     {
+        public readonly NitroxConnection Connection;
+        public readonly AuthenticationContext Context;
+        public readonly int MaxCounter;
+
+        /// <summary>
+        /// Keeps track of how many times the timer has elapsed
+        /// </summary>
         public int Counter = 0;
-        public NitroxConnection Connection;
-        public AuthenticationContext Context;
-        public int MaxCounter;
+
+        /// <summary>
+        /// Set to true if disposing the timer
+        /// </summary>
         public bool Disposing = false;
 
         public InitialSyncTimerData(NitroxConnection connection, AuthenticationContext context, int initialSyncTimeout)

--- a/NitroxServer/GameLogic/InitialSyncTimerData.cs
+++ b/NitroxServer/GameLogic/InitialSyncTimerData.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NitroxModel.MultiplayerSession;
+using NitroxServer.Communication;
+
+namespace NitroxServer.GameLogic
+{
+    internal class InitialSyncTimerData
+    {
+        public int Counter = 0;
+        public NitroxConnection Connection;
+        public AuthenticationContext Context;
+        public int MaxCounter;
+        public bool Disposing = false;
+
+        public InitialSyncTimerData(NitroxConnection connection, AuthenticationContext context, int initialSyncTimeout)
+        {
+            Connection = connection;
+            Context = context;
+            MaxCounter = (int)Math.Ceiling(initialSyncTimeout / 200f);
+        }
+    }
+}

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -92,7 +92,11 @@ namespace NitroxServer.GameLogic
 
             string playerName = authenticationContext.Username;
 
-            allPlayersByName.TryGetValue(playerName, out Player player);
+            if (!allPlayersByName.TryGetValue(playerName, out Player player))
+            {
+                return new MultiplayerSessionReservation(correlationId, MultiplayerSessionReservationState.REJECTED); // There is no invalid state
+            }
+            
             if (player?.IsPermaDeath == true && serverConfig.IsHardcore)
             {
                 MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.HARDCORE_PLAYER_DEAD;

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -91,8 +91,8 @@ namespace NitroxServer.GameLogic
             }
 
             string playerName = authenticationContext.Username;
-            allPlayersByName.TryGetValue(playerName, out Player player)
-            
+
+            allPlayersByName.TryGetValue(playerName, out Player player);
             if (player?.IsPermaDeath == true && serverConfig.IsHardcore)
             {
                 MultiplayerSessionReservationState rejectedState = MultiplayerSessionReservationState.REJECTED | MultiplayerSessionReservationState.HARDCORE_PLAYER_DEAD;
@@ -127,14 +127,13 @@ namespace NitroxServer.GameLogic
 
             initialSyncTimer = new Timer(state =>
             {
-                if (player != null)
+                if (player != null) // player can cancel the joining process before this timer elapses
                 {
                     player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
                     PlayerDisconnected(player.Connection);
                     SendPacketToOtherPlayers(new Disconnect(player.Id), player);
-
-                    FinishProcessingReservation();
                 }
+                FinishProcessingReservation();
             });
 
             // Starts the timer, using the server config option as the due time and with intervals disabled

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -127,7 +127,11 @@ namespace NitroxServer.GameLogic
 
             initialSyncTimer = new Timer(state =>
             {
-                if (player != null) // player can cancel the joining process before this timer elapses
+                if (player == null) // player can cancel the joining process before this timer elapses
+                {
+                    Log.Error("Player was nulled while joining");
+                }
+                else
                 {
                     player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
                     PlayerDisconnected(player.Connection);

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -125,25 +125,47 @@ namespace NitroxServer.GameLogic
 
             PlayerCurrentlyJoining = true;
 
-            initialSyncTimer = new Timer(state =>
-            {
-                if (player == null) // player can cancel the joining process before this timer elapses
-                {
-                    Log.Error("Player was nulled while joining");
-                }
-                else
-                {
-                    player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
-                    PlayerDisconnected(player.Connection);
-                    SendPacketToOtherPlayers(new Disconnect(player.Id), player);
-                }
-                FinishProcessingReservation();
-            });
+            InitialSyncTimerData timerData = new InitialSyncTimerData(connection, authenticationContext, serverConfig.InitialSyncTimeout);
+            initialSyncTimer = new Timer(InitialSyncTimerElapsed, timerData, 0, 200);
 
-            // Starts the timer, using the server config option as the due time and with intervals disabled
-            initialSyncTimer.Change(serverConfig.InitialSyncTimeout, Timeout.Infinite);
 
             return new MultiplayerSessionReservation(correlationId, playerId, reservationKey);
+        }
+        
+        private void InitialSyncTimerElapsed(object state)
+        {
+            if (state is InitialSyncTimerData timerData && !timerData.Disposing)
+            {
+                allPlayersByName.TryGetValue(timerData.Context.Username, out Player player);
+
+                if (timerData.Connection.State < NitroxConnectionState.Connected)
+                {
+                    if (player == null) // player can cancel the joining process before this timer elapses
+                    {
+                        Log.Error("Player was nulled while joining");
+                        PlayerDisconnected(timerData.Connection);
+                    }
+                    else
+                    {
+                        player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
+                        PlayerDisconnected(player.Connection);
+                        SendPacketToOtherPlayers(new Disconnect(player.Id), player);
+                    }
+                    timerData.Disposing = true;
+                    FinishProcessingReservation();
+                }
+
+                if (timerData.Counter >= timerData.MaxCounter)
+                {
+                    Log.Error("An unexpected Error occured during InitialSync");
+                    PlayerDisconnected(timerData.Connection);
+
+                    timerData.Disposing = true;
+                    initialSyncTimer.Dispose(); // Looped long enough to require an override
+                }
+
+                timerData.Counter++;
+            }
         }
 
         public void NonPlayerDisconnected(NitroxConnection connection)
@@ -226,6 +248,8 @@ namespace NitroxServer.GameLogic
                 Server.Instance.PauseServer();
                 Server.Instance.Save();
             }
+
+
         }
 
         public void FinishProcessingReservation()

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -248,8 +248,6 @@ namespace NitroxServer.GameLogic
                 Server.Instance.PauseServer();
                 Server.Instance.Save();
             }
-
-
         }
 
         public void FinishProcessingReservation()

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -91,11 +91,7 @@ namespace NitroxServer.GameLogic
             }
 
             string playerName = authenticationContext.Username;
-
-            if (!allPlayersByName.TryGetValue(playerName, out Player player))
-            {
-                return new MultiplayerSessionReservation(correlationId, MultiplayerSessionReservationState.REJECTED); // There is no invalid state
-            }
+            allPlayersByName.TryGetValue(playerName, out Player player)
             
             if (player?.IsPermaDeath == true && serverConfig.IsHardcore)
             {
@@ -131,11 +127,14 @@ namespace NitroxServer.GameLogic
 
             initialSyncTimer = new Timer(state =>
             {
-                player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
-                PlayerDisconnected(player.Connection);
-                SendPacketToOtherPlayers(new Disconnect(player.Id), player);
+                if (player != null)
+                {
+                    player.SendPacket(new PlayerKicked("An error occured while loading, Initial sync took too long to complete"));
+                    PlayerDisconnected(player.Connection);
+                    SendPacketToOtherPlayers(new Disconnect(player.Id), player);
 
-                FinishProcessingReservation();
+                    FinishProcessingReservation();
+                }
             });
 
             // Starts the timer, using the server config option as the due time and with intervals disabled


### PR DESCRIPTION
A player could leave while in the JoinQueue and it would cause a null reference when trying to reserve that player later