### PR TITLE
Added glow effect on options informations hover

### DIFF
--- a/NitroxLauncher/Pages/OptionPage.xaml
+++ b/NitroxLauncher/Pages/OptionPage.xaml
@@ -105,8 +105,27 @@
 
                         <Rectangle Grid.Column="1" Width="24" Height="24" Margin="10,0,0,0">
                             <Rectangle.Fill>
-                                <VisualBrush Visual="{StaticResource InformationIcon}" />
+                                <VisualBrush Visual="{StaticResource InformationIcon}" AutoLayoutContent="True" />
                             </Rectangle.Fill>
+
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle">
+                                    <Style.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Trigger.Setters>
+
+                                                <Setter Property="Effect">
+                                                    <Setter.Value>
+                                                        <DropShadowEffect ShadowDepth="0" Color="White" Opacity="1" BlurRadius="20" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                                
+                                                <Setter Property="Cursor" Value="Hand" />
+                                            </Trigger.Setters>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Rectangle.Style>
 
                             <Rectangle.ToolTip>
                                 <StackPanel>
@@ -122,7 +141,7 @@
 
                                     <Border BorderBrush="Silver" BorderThickness="0,1,0,0" Margin="0,8" />
 
-                                    <TextBlock FontStyle="Italic">Contact our support for more informations</TextBlock>
+                                    <TextBlock FontStyle="Italic">Contact our support for more information</TextBlock>
                                 </StackPanel>
                             </Rectangle.ToolTip>
                         </Rectangle>


### PR DESCRIPTION
Reported by Ninja that this button doesn't give enough visual feedback to be clear to a user that it will show something, so :
* Added glow effect on hover
* Added hand pointer on hover
* 
![image](https://user-images.githubusercontent.com/10561268/154770299-ca419058-37d9-4398-afa9-3e266f66406b.png)
