### PR TITLE
Added more logging to better determine "same key" world loading error…

### DIFF
--- a/NitroxModel/DataStructures/GameLogic/EquippedItemData.cs
+++ b/NitroxModel/DataStructures/GameLogic/EquippedItemData.cs
@@ -26,7 +26,7 @@ namespace NitroxModel.DataStructures.GameLogic
 
         public override string ToString()
         {
-            return "[EquippedItemData ContainerGuid: " + ContainerId + "Id: " + ItemId + " Slot: " + Slot + " TechType: " + TechType + "]";
+            return "[EquippedItemData ContainerGuid: " + ContainerId + " Id: " + ItemId + " Slot: " + Slot + " TechType: " + TechType + "]";
         }
     }
 }


### PR DESCRIPTION
…s for potential later repair.

Without opening an issue, thought this code would be useful, and did not see existing functionality that would help with diagnosing the exact problem in the case I was investigating.

I saw a few other cases reported, but this one was produced specifically with the server upgrade from 1.5.0.1 to 1.6.0.0 using the JSON data file format.

The issue was contained in the WorldData file, concerning the "PowerCell(Charger2)" item under the below path that had duplicate sibling entries specifying different containerIds, the problem being their ItemId was identical when creating the modules of the 3 main world dictionaries.  Unsure how it arrived in this state, but the 1.5.0.1 server still seemed to at least load correctly.
Fixed using this targeted command: `jq -c --arg ItemId "$ItemId" '.InventoryData.Modules |= unique_by(.ItemId)' "$jsonFile"`