### PR TITLE
Fix moonpools undocking not working

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
@@ -31,7 +31,7 @@ namespace NitroxClient.Communication.Packets.Processors
             GameObject vehicleDockingBayGo = NitroxEntity.RequireObjectFrom(packet.DockId);
 
             Vehicle vehicle = vehicleGo.RequireComponent<Vehicle>();
-            VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponentInChildren<VehicleDockingBay>();
+            VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponent<VehicleDockingBay>();
 
             using (packetSender.Suppress<VehicleDocking>())
             {

--- a/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
@@ -29,7 +29,7 @@ namespace NitroxClient.Communication.Packets.Processors
             GameObject vehicleDockingBayGo = NitroxEntity.RequireObjectFrom(packet.DockId);
 
             Vehicle vehicle = vehicleGo.RequireComponent<Vehicle>();
-            VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponentInChildren<VehicleDockingBay>();
+            VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponent<VehicleDockingBay>();
 
             using (packetSender.Suppress<VehicleUndocking>())
             {

--- a/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
@@ -33,7 +33,6 @@ namespace NitroxClient.Communication.Packets.Processors
 
             using (packetSender.Suppress<VehicleUndocking>())
             {
-
                 if (packet.UndockingStart)
                 {
                     StartVehicleUndocking(packet, vehicleGo, vehicle, vehicleDockingBay);

--- a/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
+++ b/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using NitroxClient.GameLogic.Bases.Spawning.BasePiece;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using UnityEngine;
@@ -75,6 +76,8 @@ public class GeometryRespawnManager
                 return;
             }
             NitroxEntity.SetNewId(gameObject, id);
+            // If this piece has a NitroxId, it probably had a spawn processor run for it
+            BasePieceSpawnProcessor.ReRunSpawnProcessor(gameObject, id);
         }
     }
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseMoonpoolSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseMoonpoolSpawnProcessor.cs
@@ -1,0 +1,23 @@
+﻿using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece;
+
+public class BaseMoonpoolSpawnProcessor : BasePieceSpawnProcessor
+{
+    protected override TechType[] ApplicableTechTypes { get; } =
+    {
+        TechType.BaseMoonpool
+    };
+
+    protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+    {
+        NitroxId moonpoolId = NitroxEntity.GetId(finishedPiece);
+        VehicleDockingBay dockingBay = finishedPiece.RequireComponentInChildren<VehicleDockingBay>();
+
+        NitroxId dockingBayId = moonpoolId.Increment();
+        NitroxEntity.SetNewId(dockingBay.gameObject, dockingBayId);
+    }
+}

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
@@ -9,6 +11,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
     public abstract class BasePieceSpawnProcessor
     {
         private static readonly Dictionary<TechType, BasePieceSpawnProcessor> processorsByType = new Dictionary<TechType, BasePieceSpawnProcessor>();
+        private static readonly Dictionary<NitroxId, BasePieceSpawnInfos> spawnProcessorsApplied = new();
 
         protected abstract TechType[] ApplicableTechTypes { get; }
 
@@ -34,10 +37,41 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         public static void RunSpawnProcessor(BaseDeconstructable baseDeconstructable, Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             TechType techType = baseDeconstructable.recipe;
+            if (finishedPiece.TryGetComponent(out NitroxEntity nitroxEntity))
+            {
+                spawnProcessorsApplied[nitroxEntity.Id] = new BasePieceSpawnInfos(techType, latestBase, latestCell);
+            }
+            RunSpawnProcessor(techType, latestBase, latestCell, finishedPiece);
+        }
+
+        private static void RunSpawnProcessor(TechType techType, Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        {
             if (processorsByType.TryGetValue(techType, out BasePieceSpawnProcessor processor))
             {
                 Log.Info($"Found custom BasePieceSpawnProcessor for {techType}");
                 processor.SpawnPostProcess(latestBase, latestCell, finishedPiece);
+            }
+        }
+
+        public static void ReRunSpawnProcessor(GameObject finishedPiece, NitroxId nitroxId)
+        {
+            if (spawnProcessorsApplied.TryGetValue(nitroxId, out BasePieceSpawnInfos basePieceSpawnInfos))
+            {
+                RunSpawnProcessor(basePieceSpawnInfos.TechType, basePieceSpawnInfos.LatestBase, basePieceSpawnInfos.LatestCell, finishedPiece);
+            }
+        }
+
+        class BasePieceSpawnInfos
+        {
+            public TechType TechType;
+            public Base LatestBase;
+            public Int3 LatestCell;
+
+            public BasePieceSpawnInfos(TechType techType, Base latestBase, Int3 latestCell)
+            {
+                TechType = techType;
+                LatestBase = latestBase;
+                LatestCell = latestCell;
             }
         }
     }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -53,6 +53,8 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             }
         }
 
+        // Each time an element is built in a base, all the geometries are rebuilt and therefore the modifications done in the SpawnProcessors are erased
+        // Thus, we need to reapply them each time we rebuild the geometry
         public static void ReRunSpawnProcessor(GameObject finishedPiece, NitroxId nitroxId)
         {
             if (spawnProcessorsApplied.TryGetValue(nitroxId, out BasePieceSpawnInfos basePieceSpawnInfos))
@@ -61,7 +63,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             }
         }
 
-        class BasePieceSpawnInfos
+        internal struct BasePieceSpawnInfos
         {
             public TechType TechType;
             public Base LatestBase;

--- a/NitroxClient/GameLogic/Cyclops.cs
+++ b/NitroxClient/GameLogic/Cyclops.cs
@@ -168,6 +168,20 @@ namespace NitroxClient.GameLogic
             }
         }
 
+        public void SetupChildrenIds(NitroxId id)
+        {
+            GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
+            NitroxId vehicleDockingBayId = id.Increment();
+            if (cyclops.TryGetComponentInChildren(out VehicleDockingBay dockingBay))
+            {
+                NitroxEntity.SetNewId(dockingBay.gameObject, vehicleDockingBayId);
+            }
+            else
+            {
+                Log.Warn($"Didn't find a VehicleDockingBay in Cyclops {id}");
+            }
+        }
+
         public void ChangeSilentRunning(NitroxId id, bool isOn)
         {
             GameObject cyclops = NitroxEntity.RequireObjectFrom(id);
@@ -302,6 +316,7 @@ namespace NitroxClient.GameLogic
             SetFloodLighting(cyclopsModel.Id, cyclopsModel.FloodLightsOn);
             ToggleEngineState(cyclopsModel.Id, cyclopsModel.EngineState, false, true);
             ChangeEngineMode(cyclopsModel.Id, cyclopsModel.EngineMode);
+            SetupChildrenIds(cyclopsModel.Id);
         }
 
         // Will be called at a later, because it is needed that the modules are installed and may need power to not immediatly be shut off

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -203,7 +203,7 @@ namespace NitroxClient.GameLogic
 
                     Detach();
                     ArmsController.SetWorldIKTarget(null, null);
-
+                    
                     Vehicle.GetComponent<MultiplayerVehicleControl>().Exit();
                 }
 
@@ -214,7 +214,18 @@ namespace NitroxClient.GameLogic
                     Attach(newVehicle.playerPosition.transform);
                     ArmsController.SetWorldIKTarget(newVehicle.leftHandPlug, newVehicle.rightHandPlug);
 
-                    newVehicle.GetComponent<MultiplayerVehicleControl>().Enter();
+                    // From here, a basic issue can happen.
+                    // When a vehicle is docked since we joined a game and another player undocks him before the local player does, no MultiplayerVehicleControl can be found on the vehicle because they are only created when receiving VehicleMovement packets
+                    // Therefore we need to make sure that the MultiplayerVehicleControl component exists before using it
+                    switch (newVehicle)
+                    {
+                        case SeaMoth:
+                            newVehicle.gameObject.EnsureComponent<MultiplayerSeaMoth>().Enter();
+                            break;
+                        case Exosuit:
+                            newVehicle.gameObject.EnsureComponent<MultiplayerExosuit>().Enter();
+                            break;
+                    }
                 }
 
                 RigidBody.isKinematic = newVehicle;

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -460,7 +460,10 @@ namespace NitroxClient.GameLogic
 
             if (subRoot is BaseRoot)
             {
-                dockId = NitroxEntity.GetId(dockingBay.GetComponentInParent<BaseDeconstructable>().gameObject);
+                // Means we're looking for a moonpool that's inside a base, tho we can't use this subroot as we want to look for the moonpool and not the base
+                // BaseMoonpool(Clone)/Launchbay_cinematic/DockBottom
+                Transform moonpoolParent = dockingBay.transform.parent.parent;
+                dockId = NitroxEntity.GetId(moonpoolParent.gameObject);
             }
             else // cyclops
             {
@@ -482,9 +485,11 @@ namespace NitroxClient.GameLogic
         {
             NitroxId dockId;
 
+            // Same things as for BroadcastVehicleDocking
             if (dockingBay.GetSubRoot() is BaseRoot)
             {
-                dockId = NitroxEntity.GetId(dockingBay.GetComponentInParent<BaseRoot>().gameObject);
+                Transform moonpoolParent = dockingBay.transform.parent.parent;
+                dockId = NitroxEntity.GetId(moonpoolParent.gameObject);
             }
             else if (dockingBay.GetSubRoot() is SubRoot)
             {

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -455,20 +455,8 @@ namespace NitroxClient.GameLogic
 
         public void BroadcastVehicleDocking(VehicleDockingBay dockingBay, Vehicle vehicle)
         {
-            SubRoot subRoot = dockingBay.GetSubRoot();
-            NitroxId dockId;
+            NitroxId dockId = NitroxEntity.GetId(dockingBay.gameObject);
 
-            if (subRoot is BaseRoot)
-            {
-                // Means we're looking for a moonpool that's inside a base, tho we can't use this subroot as we want to look for the moonpool and not the base
-                // BaseMoonpool(Clone)/Launchbay_cinematic/DockBottom
-                Transform moonpoolParent = dockingBay.transform.parent.parent;
-                dockId = NitroxEntity.GetId(moonpoolParent.gameObject);
-            }
-            else // cyclops
-            {
-                dockId = NitroxEntity.GetId(subRoot.gameObject);
-            }
 
             NitroxId vehicleId = NitroxEntity.GetId(vehicle.gameObject);
             ushort playerId = multiplayerSession.Reservation.PlayerId;
@@ -483,22 +471,7 @@ namespace NitroxClient.GameLogic
 
         public void BroadcastVehicleUndocking(VehicleDockingBay dockingBay, Vehicle vehicle, bool undockingStart)
         {
-            NitroxId dockId;
-
-            // Same things as for BroadcastVehicleDocking
-            if (dockingBay.GetSubRoot() is BaseRoot)
-            {
-                Transform moonpoolParent = dockingBay.transform.parent.parent;
-                dockId = NitroxEntity.GetId(moonpoolParent.gameObject);
-            }
-            else if (dockingBay.GetSubRoot() is SubRoot)
-            {
-                dockId = NitroxEntity.GetId(dockingBay.GetSubRoot().gameObject);
-            }
-            else
-            {
-                dockId = NitroxEntity.GetId(dockingBay.GetComponentInParent<ConstructableBase>().gameObject);
-            }
+            NitroxId dockId = NitroxEntity.GetId(dockingBay.gameObject);
 
             NitroxId vehicleId = NitroxEntity.GetId(vehicle.gameObject);
             ushort playerId = multiplayerSession.Reservation.PlayerId;

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 using UnityEngine;
@@ -18,7 +17,7 @@ namespace NitroxPatcher.Patches.Dynamic
         {
             Vehicle vehicle = other.GetComponentInParent<Vehicle>();
             prevInterpolatingVehicle = __instance.interpolatingVehicle;
-            return vehicle == null || NitroxServiceLocator.LocateService<SimulationOwnership>().HasAnyLockType(NitroxEntity.GetId(vehicle.gameObject));
+            return vehicle == null || Resolve<SimulationOwnership>().HasAnyLockType(NitroxEntity.GetId(vehicle.gameObject));
         }
 
         public static void Postfix(VehicleDockingBay __instance)
@@ -30,10 +29,10 @@ namespace NitroxPatcher.Patches.Dynamic
                 return;
             }
             NitroxId id = NitroxEntity.GetId(interpolatingVehicle.gameObject);
-            if (NitroxServiceLocator.LocateService<SimulationOwnership>().HasAnyLockType(id))
+            if (Resolve<SimulationOwnership>().HasAnyLockType(id))
             {
                 Log.Debug($"Will send vehicle docking for {id}");
-                NitroxServiceLocator.LocateService<Vehicles>().BroadcastVehicleDocking(__instance, interpolatingVehicle);
+                Resolve<Vehicles>().BroadcastVehicleDocking(__instance, interpolatingVehicle);
             }
         }
 

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnUndockingComplete_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnUndockingComplete_Patch.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
-using NitroxModel.Core;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic
@@ -13,7 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
         public static void Prefix(VehicleDockingBay __instance, Player player)
         {
             Vehicle vehicle = __instance.GetDockedVehicle();
-            NitroxServiceLocator.LocateService<Vehicles>().BroadcastVehicleUndocking(__instance, vehicle, false);
+            Resolve<Vehicles>().BroadcastVehicleUndocking(__instance, vehicle, false);
         }
 
         public override void Patch(Harmony harmony)


### PR DESCRIPTION
There was an error about detecting properly which was the moonpool parent of the VehicleDockingBay
Would fix #1745, #1398 

EDIT: now, each time we rebuild geometry, we also reapply the spawn processor because the gameobjects children were kind of "resetted"