### PR TITLE
Synced commands concerning aurora

### DIFF
--- a/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
+++ b/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
@@ -13,7 +13,7 @@ namespace NitroxServer.GameLogic
         [TestMethod]
         public void VerifyEventsOrder()
         {
-            EventTriggerer eventTriggerer = new(null, seed, 0.0, null);
+            EventTriggerer eventTriggerer = new(null, null, null, seed, 0.0, null, null);
             List<string> eventsOrder = new() { "Story_AuroraWarning1", "Story_AuroraWarning2", "Story_AuroraWarning3", "Story_AuroraWarning4", "Story_AuroraExplosion" };
             List<string> eventTriggererEvents = new(eventTriggerer.eventTimers.Keys);
 
@@ -27,14 +27,14 @@ namespace NitroxServer.GameLogic
         [TestMethod]
         public void AuroraExplosionAndWarningTime()
         {
-            EventTriggerer eventTriggerer = new(null, seed, 0.0, TimeSpan.FromMinutes(40).TotalMilliseconds);
+            EventTriggerer eventTriggerer = new(null, null, null, seed, 0.0, TimeSpan.FromMinutes(40).TotalMilliseconds, null);
             Assert.AreEqual(eventTriggerer.eventTimers["Story_AuroraWarning4"].Interval, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
         }
 
         [TestMethod]
         public void TestTimeSkip()
         {
-            EventTriggerer eventTriggerer = new(null, seed, 480.0, null);
+            EventTriggerer eventTriggerer = new(null, null, null, seed, 480.0, null, null);
             eventTriggerer.PauseWorld();
 
             double interval = eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval;

--- a/NitroxClient/Communication/Packets/Processors/AuroraExplodeNowProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraExplodeNowProcessor.cs
@@ -1,0 +1,25 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using NitroxModel.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class AuroraExplodeNowProcessor : ClientPacketProcessor<AuroraExplodeNow>
+{
+    private readonly PDAManagerEntry pdaManagerEntry;
+
+    public AuroraExplodeNowProcessor(PDAManagerEntry pdaManagerEntry)
+    {
+        this.pdaManagerEntry = pdaManagerEntry;
+    }
+    public override void Process(AuroraExplodeNow packet)
+    {
+        pdaManagerEntry.AuroraExplosionTriggered = true;
+        CrashedShipExploder main = CrashedShipExploder.main;
+        main.timeMonitor.Update(DayNightCycle.main.timePassedAsFloat);
+        // Same code as in OnConsoleCommand_explodeship, but we prefixed it so we can't call it like this
+        main.timeToStartCountdown = main.timeMonitor.Get() - 25f + 1f;
+        main.timeToStartWarning = main.timeToStartCountdown - 1f;
+        Log.Debug("Exploding aurora now");
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/AuroraExplodeNowProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraExplodeNowProcessor.cs
@@ -12,6 +12,7 @@ public class AuroraExplodeNowProcessor : ClientPacketProcessor<AuroraExplodeNow>
     {
         this.pdaManagerEntry = pdaManagerEntry;
     }
+
     public override void Process(AuroraExplodeNow packet)
     {
         pdaManagerEntry.AuroraExplosionTriggered = true;

--- a/NitroxClient/Communication/Packets/Processors/AuroraRestoreProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraRestoreProcessor.cs
@@ -1,0 +1,25 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using NitroxModel.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class AuroraRestoreProcessor : ClientPacketProcessor<AuroraRestore>
+{
+    private readonly PDAManagerEntry pdaManagerEntry;
+
+    public AuroraRestoreProcessor(PDAManagerEntry pdaManagerEntry)
+    {
+        this.pdaManagerEntry = pdaManagerEntry;
+    }
+    public override void Process(AuroraRestore packet)
+    {
+        pdaManagerEntry.AuroraExplosionTriggered = false;
+        // Same code as in OnConsoleCommand_restoreship, but we prefixed it so we can't call it like this, also we don't need to SetExplodeTime as it's server stuff
+        CrashedShipExploder main = CrashedShipExploder.main;
+        main.SwapModels(false);
+        main.fxControl.StopAndDestroy(0, 0f);
+        main.fxControl.StopAndDestroy(1, 0f);
+        Log.Debug("Restored aurora");
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/AuroraRestoreProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraRestoreProcessor.cs
@@ -12,6 +12,7 @@ public class AuroraRestoreProcessor : ClientPacketProcessor<AuroraRestore>
     {
         this.pdaManagerEntry = pdaManagerEntry;
     }
+
     public override void Process(AuroraRestore packet)
     {
         pdaManagerEntry.AuroraExplosionTriggered = false;

--- a/NitroxModel/Packets/AuroraExplodeNow.cs
+++ b/NitroxModel/Packets/AuroraExplodeNow.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class AuroraExplodeNow : Packet
+{
+    public AuroraExplodeNow()
+    {
+
+    }
+}

--- a/NitroxModel/Packets/AuroraRestore.cs
+++ b/NitroxModel/Packets/AuroraRestore.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class AuroraRestore : Packet
+{
+    public AuroraRestore()
+    {
+
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/CrashedShipExploder_OnConsoleCommand_explodeship_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CrashedShipExploder_OnConsoleCommand_explodeship_Patch.cs
@@ -1,0 +1,47 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// We just want to disable all these commands on client-side and redirect them as ConsoleCommand
+/// TODO: Remove this file when we'll have the command system
+public class CrashedShipExploder_OnConsoleCommand_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD_COUNTDOWNSHIP = Reflect.Method((CrashedShipExploder t) => t.OnConsoleCommand_countdownship());
+    private static readonly MethodInfo TARGET_METHOD_EXPLODEFORCE = Reflect.Method((CrashedShipExploder t) => t.OnConsoleCommand_explodeforce());
+    private static readonly MethodInfo TARGET_METHOD_EXPLODESHIP = Reflect.Method((CrashedShipExploder t) => t.OnConsoleCommand_explodeship());
+    private static readonly MethodInfo TARGET_METHOD_RESTORESHIP = Reflect.Method((CrashedShipExploder t) => t.OnConsoleCommand_restoreship());
+
+    public static bool PrefixCountdownShip()
+    {
+        Resolve<IPacketSender>().Send(new ServerCommand("aurora countdown"));
+        return false;
+    }
+
+    // This command's purpose is just to show FX, we don't need to sync it
+    public static bool PrefixExplodeForce()
+    {
+        return false;
+    }
+    public static bool PrefixExplodeShip()
+    {
+        Resolve<IPacketSender>().Send(new ServerCommand("aurora explode"));
+        return false;
+    }
+    public static bool PrefixRestoreShip()
+    {
+        Resolve<IPacketSender>().Send(new ServerCommand("aurora restore"));
+        return false;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD_COUNTDOWNSHIP, nameof(PrefixCountdownShip));
+        PatchPrefix(harmony, TARGET_METHOD_EXPLODEFORCE, nameof(PrefixExplodeForce));
+        PatchPrefix(harmony, TARGET_METHOD_EXPLODESHIP, nameof(PrefixExplodeShip));
+        PatchPrefix(harmony, TARGET_METHOD_RESTORESHIP, nameof(PrefixRestoreShip));
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/CrashedShipExploder_OnConsoleCommand_explodeship_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CrashedShipExploder_OnConsoleCommand_explodeship_Patch.cs
@@ -26,11 +26,13 @@ public class CrashedShipExploder_OnConsoleCommand_Patch : NitroxPatch, IDynamicP
     {
         return false;
     }
+
     public static bool PrefixExplodeShip()
     {
         Resolve<IPacketSender>().Send(new ServerCommand("aurora explode"));
         return false;
     }
+
     public static bool PrefixRestoreShip()
     {
         Resolve<IPacketSender>().Send(new ServerCommand("aurora restore"));

--- a/NitroxServer/ConsoleCommands/AuroraCommand.cs
+++ b/NitroxServer/ConsoleCommands/AuroraCommand.cs
@@ -1,0 +1,42 @@
+﻿using NitroxModel.DataStructures.GameLogic;
+using NitroxServer.ConsoleCommands.Abstract;
+using NitroxServer.ConsoleCommands.Abstract.Type;
+using NitroxServer.GameLogic;
+
+namespace NitroxServer.ConsoleCommands;
+
+// TODO: When we have the command system, we'll need to move this stuff to the new system
+public class AuroraCommand : Command
+{
+    private readonly EventTriggerer eventTriggerer;
+
+    // We shouldn't let the server use this command because it needs some stuff to happen client-side like goals
+    public AuroraCommand(EventTriggerer eventTriggerer) : base("aurora", Perms.ADMIN, PermsFlag.NO_CONSOLE, "Manage Aurora's state")
+    {
+        AddParameter(new TypeString("countdown/restore/explode", true, "Which action to apply to Aurora"));
+
+        this.eventTriggerer = eventTriggerer;
+    }
+
+    protected override void Execute(CallArgs args)
+    {
+        string action = args.Get<string>(0);
+
+        switch (action.ToLower())
+        {
+            case "countdown":
+                eventTriggerer.ExplodeAurora(true);
+                break;
+            case "restore":
+                eventTriggerer.RestoreAurora();
+                break;
+            case "explode":
+                eventTriggerer.ExplodeAurora(false);
+                break;
+            default:
+                // Same message as in the abstract class, in method TryExecute
+                SendMessage(args.Sender, $"Error: Invalid Parameters\nUsage: {ToHelpText(false, true)}");
+                break;
+        }
+    }
+}

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -83,6 +83,11 @@ namespace NitroxServer.GameLogic
         private void CreateEventTimers()
         {
             double ExplosionCycleDuration = AuroraExplosionTimeMs - AuroraWarningTimeMs;
+            // If aurora's warning is set to later than explosion's time, we don't want to create any timer
+            if (ExplosionCycleDuration > 0)
+            {
+                return;
+            }
             double TimePassedSinceWarning = ElapsedTimeMs - AuroraWarningTimeMs;
             CreateTimer(ExplosionCycleDuration * 0.2d - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
             CreateTimer(ExplosionCycleDuration * 0.5d - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning2");

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -1,22 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Timers;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
 using NitroxServer.Helper;
+using NitroxServer.GameLogic.Unlockables;
 
 namespace NitroxServer.GameLogic
 {
+    /// <summary>
+    /// Keeps track of Aurora-related events
+    /// </summary>
     public class EventTriggerer
     {
         internal readonly Dictionary<string, Timer> eventTimers = new();
         private readonly Stopwatch stopWatch = new();
         private readonly PlayerManager playerManager;
+        private readonly PDAStateData pdaStateData;
+        private readonly StoryGoalData storyGoalData;
+        private string seed;
 
-        public readonly double AuroraExplosionTimeMs;
+        public double AuroraExplosionTimeMs;
+        // Necessary to calculate correctly the timers' duration
+        public double AuroraWarningTimeMs;
 
         private double elapsedTimeOutsideStopWatchMs;
 
+        /// <summary>
+        /// Total Elapsed Time in milliseconds
+        /// </summary>
         public double ElapsedTimeMs
         {
             get => stopWatch.ElapsedMilliseconds + elapsedTimeOutsideStopWatchMs;
@@ -30,31 +45,51 @@ namespace NitroxServer.GameLogic
             }
         }
 
+        /// <summary>
+        /// Total Elapsed Time in seconds
+        /// </summary>
         public double ElapsedSeconds
         {
             get => ElapsedTimeMs * 0.001;
             private set => ElapsedTimeMs = value * 1000;
         }
 
+        /// <summary>
+        /// Subnautica's equivalent of days
+        /// </summary>
         // Using ceiling because days count start at 1 and not 0
         public int Day => (int)Math.Ceiling(ElapsedTimeMs / TimeSpan.FromMinutes(20).TotalMilliseconds);
 
-        public EventTriggerer(PlayerManager playerManager, string seed, double elapsedTime, double? auroraExplosionTime)
+        public EventTriggerer(PlayerManager playerManager, PDAStateData pdaStateData, StoryGoalData storyGoalData, string seed, double elapsedTime, double? auroraExplosionTime, double? auroraWarningTime)
         {
             this.playerManager = playerManager;
+            this.pdaStateData = pdaStateData;
+            this.storyGoalData = storyGoalData;
+            this.seed = seed;
             // Default time in Base SN is 480s
             elapsedTimeOutsideStopWatchMs = elapsedTime == 0 ? TimeSpan.FromSeconds(480).TotalMilliseconds : elapsedTime;
+            // The timer interval is in milliseconds, and so the AuroraExplosionTime should be
             AuroraExplosionTimeMs = auroraExplosionTime ?? GenerateDeterministicAuroraTime(seed);
-
-            CreateTimer(AuroraExplosionTimeMs * 0.2d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
-            CreateTimer(AuroraExplosionTimeMs * 0.5d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning2");
-            CreateTimer(AuroraExplosionTimeMs * 0.8d - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning3");
-            // Story_AuroraWarning4 and Story_AuroraExplosion must occur at the same time
-            CreateTimer(AuroraExplosionTimeMs - ElapsedTimeMs, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning4");
-            CreateTimer(AuroraExplosionTimeMs - ElapsedTimeMs, StoryEventSend.EventType.EXTRA, "Story_AuroraExplosion");
-
+            AuroraWarningTimeMs = auroraWarningTime ?? ElapsedTimeMs;
+            CreateEventTimers();
             stopWatch.Start();
             Log.Debug($"Event Triggerer started! ElapsedTime={Math.Floor(ElapsedSeconds)}s");
+            Log.Debug($"Aurora will explode in {GetMinutesBeforeAuroraExplosion()} minutes");
+        }
+
+        /// <summary>
+        /// Creates every timer that will keep track of the time before we need to trigger an event
+        /// </summary>
+        private void CreateEventTimers()
+        {
+            double ExplosionCycleDuration = AuroraExplosionTimeMs - AuroraWarningTimeMs;
+            double TimePassedSinceWarning = ElapsedTimeMs - AuroraWarningTimeMs;
+            CreateTimer(ExplosionCycleDuration * 0.2d - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning1");
+            CreateTimer(ExplosionCycleDuration * 0.5d - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning2");
+            CreateTimer(ExplosionCycleDuration * 0.8d - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning3");
+            // Story_AuroraWarning4 and Story_AuroraExplosion must occur at the same time
+            CreateTimer(ExplosionCycleDuration - TimePassedSinceWarning, StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning4");
+            CreateTimer(ExplosionCycleDuration - TimePassedSinceWarning, StoryEventSend.EventType.EXTRA, "Story_AuroraExplosion");
         }
 
         /// <summary>
@@ -85,13 +120,77 @@ namespace NitroxServer.GameLogic
             eventTimers.Add(key, timer);
         }
 
-        //Copied from CrashedShipExploder.SetExplodeTime() and changed from seconds to ms
+        /// <summary>
+        /// Tell the players to start Aurora's explosion event
+        /// </summary>
+        /// <param name="cooldown">Wether we should make Aurora explode instantly or after a short countdown</param>
+        public void ExplodeAurora(bool cooldown)
+        {
+            ClearTimers();
+            AuroraExplosionTimeMs = ElapsedTimeMs;
+            // Explode aurora with a cooldown is like default game just before aurora is about to explode
+            if (cooldown)
+            {
+                // These lines should be filled with the same informations as in the constructor
+                playerManager.SendPacketToAllPlayers(new StoryEventSend(StoryEventSend.EventType.PDA_EXTRA, "Story_AuroraWarning4"));
+                playerManager.SendPacketToAllPlayers(new StoryEventSend(StoryEventSend.EventType.EXTRA, "Story_AuroraExplosion"));
+                Log.Info("Started Aurora's explosion sequence");
+            }
+            else
+            {
+                // This will make aurora explode instantly on clients
+                playerManager.SendPacketToAllPlayers(new AuroraExplodeNow());
+                Log.Info("Exploded Aurora");
+            }
+        }
+
+        /// <summary>
+        /// Tell the players to start Aurora's restoration event
+        /// </summary>
+        public void RestoreAurora()
+        {
+            ClearTimers();
+            AuroraExplosionTimeMs = GenerateDeterministicAuroraTime(seed) + ElapsedTimeMs;
+            AuroraWarningTimeMs = ElapsedTimeMs;
+            CreateEventTimers();
+            // We need to clear these entries from PdaLog and CompletedGoals to make sure that the client, when reconnecting, doesn't have false information
+            foreach (string timerKey in eventTimers.Keys)
+            {
+                PDALogEntry logEntry = pdaStateData.PdaLog.Find(entry => entry.Key == timerKey);
+                // Wether or not we found the entry doesn't matter
+                pdaStateData.PdaLog.Remove(logEntry);
+                storyGoalData.CompletedGoals.Remove(timerKey);
+            }
+            playerManager.SendPacketToAllPlayers(new AuroraRestore());
+            Log.Info($"Restored Aurora, will explode again in {GetMinutesBeforeAuroraExplosion()} minutes");
+        }
+
+        /// <summary>
+        /// Removes every timer that's still alive
+        /// </summary>
+        private void ClearTimers()
+        {
+            foreach (Timer timer in eventTimers.Values)
+            {
+                timer.Stop();
+                timer.Dispose();
+            }
+            eventTimers.Clear();
+        }
+
+        /// <summary>
+        /// Calculate the time at which we'll send last packets to trigger Aurora's explosion
+        /// </summary>
         private double GenerateDeterministicAuroraTime(string seed)
         {
+            // Copied from CrashedShipExploder.SetExplodeTime() and changed from seconds to ms
             DeterministicGenerator generator = new(seed, nameof(EventTriggerer));
             return elapsedTimeOutsideStopWatchMs + generator.NextDouble(2.3d, 4d) * 1200d * 1000d;
         }
 
+        /// <summary>
+        /// Makes every event timer start again
+        /// </summary>
         public void StartWorld()
         {
             stopWatch.Start();
@@ -101,6 +200,9 @@ namespace NitroxServer.GameLogic
             }
         }
 
+        /// <summary>
+        /// Makes every event timer pause
+        /// </summary>
         public void PauseWorld()
         {
             stopWatch.Stop();
@@ -110,11 +212,45 @@ namespace NitroxServer.GameLogic
             }
         }
 
+        /// <summary>
+        /// Lets an estimation fo the time before aurora explosion
+        /// </summary>
+        /// <returns>The time in minutes before aurora explodes or -1 if it already exploded</returns>
+        private double GetMinutesBeforeAuroraExplosion()
+        {
+            return AuroraExplosionTimeMs > ElapsedTimeMs ? Math.Round((AuroraExplosionTimeMs - ElapsedTimeMs) / 60000) : -1;
+        }
+
+        /// <summary>
+        /// Makes a nice status for the summary command for example
+        /// </summary>
+        public string GetAuroraState()
+        {
+            double minutesBeforeExplosion = GetMinutesBeforeAuroraExplosion();
+            if (minutesBeforeExplosion < 0)
+            {
+                return "already exploded";
+            }
+            string stateNumber = "";
+            if (eventTimers.Count > 0)
+            {
+                // Event timer events should always have a number at last character
+                string nextEventKey = eventTimers.ElementAt(0).Key;
+                stateNumber = $" [{nextEventKey[nextEventKey.Length - 1]}/4]";
+            }
+            
+            return $"explodes in {minutesBeforeExplosion} minutes{stateNumber}";
+        }
+
         internal void ResetWorld()
         {
             stopWatch.Reset();
         }
 
+        /// <summary>
+        /// Set current time (replication of SN's system)
+        /// </summary>
+        /// <param name="type">Type of the operation to apply</param>
         public void ChangeTime(TimeModification type)
         {
             switch (type)

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Timers;
 using NitroxModel.DataStructures.GameLogic;
-using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
 using NitroxServer.Helper;
 using NitroxServer.GameLogic.Unlockables;
@@ -24,7 +23,7 @@ namespace NitroxServer.GameLogic
         private string seed;
 
         public double AuroraExplosionTimeMs;
-        // Necessary to calculate correctly the timers' duration
+        // Necessary to calculate the timers correctly
         public double AuroraWarningTimeMs;
 
         private double elapsedTimeOutsideStopWatchMs;
@@ -68,7 +67,6 @@ namespace NitroxServer.GameLogic
             this.seed = seed;
             // Default time in Base SN is 480s
             elapsedTimeOutsideStopWatchMs = elapsedTime == 0 ? TimeSpan.FromSeconds(480).TotalMilliseconds : elapsedTime;
-            // The timer interval is in milliseconds, and so the AuroraExplosionTime should be
             AuroraExplosionTimeMs = auroraExplosionTime ?? GenerateDeterministicAuroraTime(seed);
             AuroraWarningTimeMs = auroraWarningTime ?? ElapsedTimeMs;
             CreateEventTimers();
@@ -126,7 +124,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Tell the players to start Aurora's explosion event
+        /// Tells the players to start Aurora's explosion event
         /// </summary>
         /// <param name="cooldown">Wether we should make Aurora explode instantly or after a short countdown</param>
         public void ExplodeAurora(bool cooldown)
@@ -150,7 +148,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Tell the players to start Aurora's restoration event
+        /// Tells the players to start Aurora's restoration event
         /// </summary>
         public void RestoreAurora()
         {
@@ -184,7 +182,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Calculate the time at which we'll send last packets to trigger Aurora's explosion
+        /// Calculate the future Aurora's explosion time in a deterministic manner
         /// </summary>
         private double GenerateDeterministicAuroraTime(string seed)
         {
@@ -194,7 +192,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Makes every event timer start again
+        /// Restarts every event timer
         /// </summary>
         public void StartWorld()
         {
@@ -206,7 +204,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Makes every event timer pause
+        /// Pauses every event timer
         /// </summary>
         public void PauseWorld()
         {
@@ -218,7 +216,7 @@ namespace NitroxServer.GameLogic
         }
 
         /// <summary>
-        /// Lets an estimation fo the time before aurora explosion
+        /// Calculates the time before the aurora explosion
         /// </summary>
         /// <returns>The time in minutes before aurora explodes or -1 if it already exploded</returns>
         private double GetMinutesBeforeAuroraExplosion()
@@ -229,7 +227,7 @@ namespace NitroxServer.GameLogic
         /// <summary>
         /// Makes a nice status for the summary command for example
         /// </summary>
-        public string GetAuroraState()
+        public string GetAuroraStateSummary()
         {
             double minutesBeforeExplosion = GetMinutesBeforeAuroraExplosion();
             if (minutesBeforeExplosion < 0)

--- a/NitroxServer/GameLogic/StoryTimingData.cs
+++ b/NitroxServer/GameLogic/StoryTimingData.cs
@@ -14,12 +14,16 @@ namespace NitroxServer.GameLogic
         [JsonProperty, ProtoMember(2)]
         public double? AuroraExplosionTime { get; set; }
 
+        [JsonProperty, ProtoMember(3)]
+        public double? AuroraWarningTime { get; set; }
+
         public static StoryTimingData From(EventTriggerer eventTriggerer)
         {
             return new StoryTimingData
             {
                 ElapsedTime = eventTriggerer.ElapsedTimeMs,
-                AuroraExplosionTime = eventTriggerer.AuroraExplosionTimeMs
+                AuroraExplosionTime = eventTriggerer.AuroraExplosionTimeMs,
+                AuroraWarningTime = eventTriggerer.AuroraWarningTimeMs,
             };
         }
     }

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -191,7 +191,7 @@ namespace NitroxServer.Serialization.World
                 Seed = seed
             };
 
-            world.EventTriggerer = new EventTriggerer(world.PlayerManager, seed, pWorldData.WorldData.GameData.StoryTiming.ElapsedTime, pWorldData.WorldData.GameData.StoryTiming.AuroraExplosionTime);
+            world.EventTriggerer = new EventTriggerer(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, seed, pWorldData.WorldData.GameData.StoryTiming.ElapsedTime, pWorldData.WorldData.GameData.StoryTiming.AuroraExplosionTime, pWorldData.WorldData.GameData.StoryTiming.AuroraWarningTime);
             world.VehicleManager = new VehicleManager(pWorldData.WorldData.VehicleData.Vehicles, world.InventoryManager);
             world.ScheduleKeeper = new ScheduleKeeper(pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.EventTriggerer, world.PlayerManager);
 

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -59,6 +59,7 @@ namespace NitroxServer
                 // Note for later additions: order these lines by their length
                 StringBuilder builder = new("\n");
                 builder.AppendLine($" - Save location: {Path.GetFullPath(serverConfig.SaveName)}");
+                builder.AppendLine($" - Aurora's state: {world.EventTriggerer.GetAuroraState()}");
                 builder.AppendLine($" - Current time: day {world.EventTriggerer.Day} ({Math.Floor(world.EventTriggerer.ElapsedSeconds)}s)");
                 builder.AppendLine($" - Scheduled goals stored: {world.GameData.StoryGoals.ScheduledGoals.Count}");
                 builder.AppendLine($" - Story goals completed: {world.GameData.StoryGoals.CompletedGoals.Count}");

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -59,7 +59,7 @@ namespace NitroxServer
                 // Note for later additions: order these lines by their length
                 StringBuilder builder = new("\n");
                 builder.AppendLine($" - Save location: {Path.GetFullPath(serverConfig.SaveName)}");
-                builder.AppendLine($" - Aurora's state: {world.EventTriggerer.GetAuroraState()}");
+                builder.AppendLine($" - Aurora's state: {world.EventTriggerer.GetAuroraStateSummary()}");
                 builder.AppendLine($" - Current time: day {world.EventTriggerer.Day} ({Math.Floor(world.EventTriggerer.ElapsedSeconds)}s)");
                 builder.AppendLine($" - Scheduled goals stored: {world.GameData.StoryGoals.ScheduledGoals.Count}");
                 builder.AppendLine($" - Story goals completed: {world.GameData.StoryGoals.CompletedGoals.Count}");


### PR DESCRIPTION
These are the 4 commands:
- ``countdownship`` (will explode aurora as if we were just skipping to the last warning, which means we have the 20s of audio that come with aurora explosion in normal time)
- ``explodeship`` (will explode aurora instantly)
- ``restoreship`` (will restore the base state of aurora and restart all warning countdowns)
- ``explodeforce`` (only shows FX)

We sync all of them except explodeforce which is not worse syncing (tell me if you disagree), tho it is also deactivated.
Also, aurora command can't be executed from the server's console.

- [x] Add aurora's state to the summary (images down there)
- [x] Add a dedicated command on server-side "aurora" for the 3 different actions (explode/restore/countdown)
- [x] Modified EventTriggerer functioning to be able to support restoring Aurora
- [x] Added a lot of documentation for EventTriggerer

![image](https://user-images.githubusercontent.com/24827220/156253408-dcf3706c-c766-436b-8da0-5e151109f889.png)
(Will show the number of the next warning to come)
![image](https://user-images.githubusercontent.com/24827220/156253419-b63085e3-dd5b-4e48-95ac-78ea14647fcd.png)