### PR TITLE
Fix cyclops not moving while controlling it through a camera

### DIFF
--- a/NitroxClient/MonoBehaviours/PlayerMovement.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovement.cs
@@ -31,7 +31,9 @@ namespace NitroxClient.MonoBehaviours
                 time = 0;
 
                 // Freecam does disable main camera control
-                if (!MainCameraControl.main.isActiveAndEnabled)
+                // But it's also disabled when driving the cyclops through a cyclops camera (content.activeSelf is only true when controlling through a cyclops camera)
+                if (!MainCameraControl.main.isActiveAndEnabled &&
+                    !uGUI_CameraCyclops.main.content.activeSelf)
                 {
                     return;
                 }


### PR DESCRIPTION
The check for freecam detection may be not enough precise