### PR TITLE
Fix remote players' lighting

### DIFF
--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -84,6 +84,7 @@ namespace NitroxClient.GameLogic
             playerModelManager.BeginApplyPlayerColor(this);
             playerModelManager.RegisterEquipmentVisibilityHandler(PlayerModel);
             UpdateEquipmentVisibility();
+            SetupSkyAppliers();
 
             ErrorMessage.AddMessage($"{PlayerName} joined the game.");
         }
@@ -161,6 +162,7 @@ namespace NitroxClient.GameLogic
         {
             if (SubRoot != newSubRoot)
             {
+                SkyEnvironmentChanged.Broadcast(Body, newSubRoot);
                 if (newSubRoot)
                 {
                     Attach(newSubRoot.transform, true);
@@ -267,6 +269,20 @@ namespace NitroxClient.GameLogic
         private void UpdateEquipmentVisibility()
         {
             playerModelManager.UpdateEquipmentVisibility(new ReadOnlyCollection<TechType>(equipment.ToList()));
+        }
+
+        /// <summary>
+        /// Allows the remote player model to have its lightings dynamicly adjusted
+        /// </summary>
+        private void SetupSkyAppliers()
+        {
+            // SkyAppliers are the components that apply the light effects on gameobjects
+            SkyApplier skyApplier = Body.AddComponent<SkyApplier>();
+            skyApplier.anchorSky = Skies.Auto;
+            skyApplier.emissiveFromPower = false;
+            skyApplier.dynamic = true;
+            skyApplier.renderers = Body.GetComponentsInChildren<SkinnedMeshRenderer>(true);
+            Log.Debug($"Successfully setup Sky Appliers on {PlayerName}");
         }
     }
 }

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -276,13 +276,12 @@ namespace NitroxClient.GameLogic
         /// </summary>
         private void SetupSkyAppliers()
         {
-            // SkyAppliers are the components that apply the light effects on gameobjects
+            // SkyAppliers apply the light effects of a lighting source on a set of renderers
             SkyApplier skyApplier = Body.AddComponent<SkyApplier>();
             skyApplier.anchorSky = Skies.Auto;
             skyApplier.emissiveFromPower = false;
             skyApplier.dynamic = true;
             skyApplier.renderers = Body.GetComponentsInChildren<SkinnedMeshRenderer>(true);
-            Log.Debug($"Successfully setup Sky Appliers on {PlayerName}");
         }
     }
 }


### PR DESCRIPTION
Some screenshots of the testing session in the thread ["light fix PR test session"](https://discord.com/channels/525437013403631617/975468417018658847)
(Tested with 3 players and seemed to work as expected)

How the fix works, we add a component named ``SkyApplier`` which goal is to adjust the lighting level of all the renderers inside a model depending on the lighting source.

Will fix #644 