### PR TITLE
Added first .NET analyzer for validating packet deserialization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,7 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ImplicitUsings>disable</ImplicitUsings>
         <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
     </PropertyGroup>
     
     <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^Nitrox.*$'))">

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -8,6 +8,13 @@
     <ItemGroup>
         <PackageReference Include="Autofac" Version="4.9.4" />
         <PackageReference Include="LiteNetLib" Version="0.8.3.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0">
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Net.Compilers" Version="4.2.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="Mono.Nat" Version="3.0.2" />
         <PackageReference Include="Serilog" Version="2.10.0" />


### PR DESCRIPTION
- [x] Ensure build fails when analyzer emits an error. [This is broken by design when using project referenced analyzer.](https://github.com/dotnet/roslyn/issues/6195#issuecomment-149951740)
- [x] Solution rebuild should not cause "file not found" for analyzer project (analyzer project should be rebuilt first).

Might be that to fix both these issues we need to move this analyzer to another repo and deploy on NuGet. But I wonder if this will make it harder to iterate while developing the analyzers.

Feature request for allowing project referenced analyzers to work: https://github.com/dotnet/roslyn/issues/18093