### PR TITLE
Aurora events calculations fix

### DIFF
--- a/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
+++ b/Nitrox.Test/Server/GameLogic/EventTriggererTest.cs
@@ -45,5 +45,24 @@ namespace NitroxServer.GameLogic
             eventTriggerer.ElapsedTimeMs += TimeSpan.FromMinutes(2).TotalMilliseconds;
             Assert.AreEqual(interval - TimeSpan.FromMinutes(2).TotalMilliseconds, eventTriggerer.eventTimers["Story_AuroraExplosion"].Interval);
         }
+
+        [TestMethod]
+        public void TestAuroraEventsCalculations()
+        {
+            EventTriggerer eventTriggerer = new(null, null, null, seed, 890000, 2400000, 480000);
+            eventTriggerer.PauseWorld();
+
+            Assert.AreEqual(4, eventTriggerer.eventTimers.Count);
+
+            eventTriggerer = new(null, null, null, seed, 1500000, 2400000, 480000);
+            eventTriggerer.PauseWorld();
+
+            Assert.AreEqual(3, eventTriggerer.eventTimers.Count);
+
+            eventTriggerer = new(null, null, null, seed, 2016000, 2400000, 480000);
+            eventTriggerer.PauseWorld();
+
+            Assert.AreEqual(2, eventTriggerer.eventTimers.Count);
+        }
     }
 }

--- a/NitroxServer/GameLogic/EventTriggerer.cs
+++ b/NitroxServer/GameLogic/EventTriggerer.cs
@@ -82,7 +82,7 @@ namespace NitroxServer.GameLogic
         {
             double ExplosionCycleDuration = AuroraExplosionTimeMs - AuroraWarningTimeMs;
             // If aurora's warning is set to later than explosion's time, we don't want to create any timer
-            if (ExplosionCycleDuration > 0)
+            if (ExplosionCycleDuration < 0)
             {
                 return;
             }


### PR DESCRIPTION
A small mistake of mine:
`AuroraExplosionTimeMs` is always supposed to be greater than `AuroraWarningTimeMs` but I was testing the opposite 