### PR TITLE
Fix player lighting when entering lifepods

### DIFF
--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -180,6 +180,7 @@ namespace NitroxClient.GameLogic
         {
             if (EscapePod != newEscapePod)
             {
+                SkyEnvironmentChanged.Broadcast(Body, newEscapePod);
                 if (newEscapePod)
                 {
                     Attach(newEscapePod.transform, true);


### PR DESCRIPTION
Little reminder that lifepods aren't considered as subroots