### PR TITLE
Fix many building bugs

### DIFF
--- a/Nitrox.Test/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Serialization/WorldPersistenceTest.cs
@@ -387,7 +387,7 @@ namespace NitroxTest.Serialization
                     },
                     PartiallyConstructedPieces = new List<BasePiece>()
                     {
-                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<BuilderMetadata>.Of(new AnchoredFaceBuilderMetadata(new NitroxInt3(1,2,3), 1, 2))),
+                        new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<BuilderMetadata>.Of(new AnchoredFaceBuilderMetadata(new NitroxInt3(1,2,3), 1, 2, new()))),
                         new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<BuilderMetadata>.Of(new BaseModuleBuilderMetadata(new NitroxInt3(1,2,3), 1))),
                         new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<BuilderMetadata>.Of(new CorridorBuilderMetadata(new NitroxVector3(1,2,3),2, false, default))),
                         new BasePiece(new NitroxId(), NitroxVector3.One, NitroxQuaternion.Identity, NitroxVector3.One, NitroxQuaternion.Identity, new NitroxTechType("BasePiece2"), Optional.Empty, false, Optional<BuilderMetadata>.Of(new MapRoomBuilderMetadata(0x20, 2)))

--- a/NitroxClient/Communication/Packets/Processors/DeconstructionCompletedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DeconstructionCompletedProcessor.cs
@@ -1,4 +1,5 @@
-﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic.Bases;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.Packets;
@@ -9,10 +10,12 @@ namespace NitroxClient.Communication.Packets.Processors;
 public class DeconstructionCompletedProcessor : ClientPacketProcessor<DeconstructionCompleted>
 {
     private readonly GeometryRespawnManager geometryRespawnManager;
+    private readonly IPacketSender packetSender;
 
-    public DeconstructionCompletedProcessor(GeometryRespawnManager geometryRespawnManager)
+    public DeconstructionCompletedProcessor(GeometryRespawnManager geometryRespawnManager, IPacketSender packetSender)
     {
         this.geometryRespawnManager = geometryRespawnManager;
+        this.packetSender = packetSender;
     }
     public override void Process(DeconstructionCompleted packet)
     {
@@ -20,7 +23,10 @@ public class DeconstructionCompletedProcessor : ClientPacketProcessor<Deconstruc
         if (deconstructing.TryGetComponent(out Constructable constructable))
         {
             constructable.constructedAmount = 0;
-            constructable.Deconstruct();
+            using (packetSender.Suppress<DeconstructionCompleted>())
+            {
+                constructable.Deconstruct();
+            }
         }
         else
         {

--- a/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
+++ b/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
@@ -110,14 +110,14 @@ public class GeometryRespawnManager
                    Equals(rotation, other.rotation);
         }
 
-        public bool Equals(Vector3 _position, Vector3 otherPosition)
+        public bool Equals(Vector3 position, Vector3 otherPosition)
         {
-            return Vector3.SqrMagnitude(_position - otherPosition) < 0.1f;
+            return Vector3.SqrMagnitude(position - otherPosition) < 0.1f;
         }
 
-        public bool Equals(Quaternion _rotation, Quaternion otherRotation)
+        public bool Equals(Quaternion rotation, Quaternion otherRotation)
         {
-            return Math.Abs(Quaternion.Angle(_rotation, otherRotation)) < 0.1f;
+            return Math.Abs(Quaternion.Angle(rotation, otherRotation)) < 0.1f;
         }
 
         public override bool Equals(object obj)

--- a/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
+++ b/NitroxClient/GameLogic/Bases/GeometryRespawnManager.cs
@@ -29,23 +29,18 @@ public class GeometryRespawnManager
 
         foreach (Transform cellObject in cellObjects)
         {
-            if (cellObject != null)
+            if (!cellObject)
             {
-                for (int i = 0; i < cellObject.childCount; i++)
-                {
-                    Transform child = cellObject.GetChild(i);
+                continue;
+            }
 
-                    if (child != null && child.gameObject != null)
-                    {
-                        // Ensure there is already a nitrox id, we don't want to go creating one
-                        // which happens if you call GetId directly and it is missing.
-                        if (child.gameObject.GetComponent<NitroxEntity>() != null)
-                        {
-                            NitroxId id = NitroxEntity.GetId(child.gameObject);
-                            ObjectKey key = GetObjectKey(child.gameObject);
-                            nitroxIdByObjectKey[key] = id;
-                        }
-                    }
+            foreach (Transform child in cellObject)
+            {
+                // We only want to save NitroxIds
+                if (child.gameObject.TryGetComponent(out NitroxEntity nitroxEntity))
+                {
+                    ObjectKey key = GetObjectKey(child.gameObject);
+                    nitroxIdByObjectKey[key] = nitroxEntity.Id;
                 }
             }
         }
@@ -61,7 +56,10 @@ public class GeometryRespawnManager
     {
         // face based pieces are handled a bit differently on respawn as the BaseDeconstructable is not
         // yet attached to the game object.  So we'll pass in the known fields instead.
-        ObjectKey key = new(gameObject.name, gameObject.transform.position, faceCell, direction);
+        ObjectKey key = new(gameObject.name,
+                            gameObject.transform.parent.position,
+                            gameObject.transform.localPosition,
+                            gameObject.transform.localRotation);
         UpdateBasePieceIdIfPossible(gameObject, key);
     }
 
@@ -81,44 +79,45 @@ public class GeometryRespawnManager
         }
     }
 
-    private static ObjectKey GetObjectKey(GameObject gameObject)
+    public static ObjectKey GetObjectKey(GameObject gameObject)
     {
-        BaseDeconstructable deconstructable = gameObject.GetComponentInChildren<BaseDeconstructable>();
-
-        Int3 faceCell = default(Int3);
-        Base.Direction? faceDirection = null;
-
-        if (deconstructable && deconstructable.face.HasValue)
-        {
-            Base.Face face = deconstructable.face.Value;
-            faceCell = face.cell;
-            faceDirection = face.direction;
-        }
-        
-        return new ObjectKey(gameObject.name, gameObject.transform.position, faceCell, faceDirection);
+        return new ObjectKey(gameObject.name,
+                             gameObject.transform.parent.position,
+                             gameObject.transform.localPosition,
+                             gameObject.transform.localRotation);
     }
 
-    private readonly struct ObjectKey : IEquatable<ObjectKey>
+    public readonly struct ObjectKey : IEquatable<ObjectKey>
     {
         private readonly string name;
+        private readonly Vector3 parentCellPosition;
         private readonly Vector3 position;
-        private readonly Int3 faceCell;
-        private readonly Base.Direction? direction;
+        private readonly Quaternion rotation;
 
-        public ObjectKey(string name, Vector3 position, Int3 faceCell, Base.Direction? direction)
+        public ObjectKey(string name, Vector3 parentCellPosition, Vector3 position, Quaternion rotation)
         {
             this.name = name;
+            this.parentCellPosition = parentCellPosition;
             this.position = position;
-            this.faceCell = faceCell;
-            this.direction = direction;
+            this.rotation = rotation;
         }
-        
+
         public bool Equals(ObjectKey other)
         {
-            return name == other.name && 
-                   position.Equals(other.position) && 
-                   faceCell.Equals(other.faceCell) && 
-                   direction == other.direction;
+            return name == other.name &&
+                   Equals(parentCellPosition, other.parentCellPosition) &&
+                   Equals(position, other.position) &&
+                   Equals(rotation, other.rotation);
+        }
+
+        public bool Equals(Vector3 _position, Vector3 otherPosition)
+        {
+            return Vector3.SqrMagnitude(_position - otherPosition) < 0.1f;
+        }
+
+        public bool Equals(Quaternion _rotation, Quaternion otherRotation)
+        {
+            return Math.Abs(Quaternion.Angle(_rotation, otherRotation)) < 0.1f;
         }
 
         public override bool Equals(object obj)
@@ -131,11 +130,16 @@ public class GeometryRespawnManager
             unchecked
             {
                 int hashCode = (name != null ? name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ parentCellPosition.GetHashCode();
                 hashCode = (hashCode * 397) ^ position.GetHashCode();
-                hashCode = (hashCode * 397) ^ faceCell.GetHashCode();
-                hashCode = (hashCode * 397) ^ direction.GetHashCode();
+                hashCode = (hashCode * 397) ^ rotation.GetHashCode();
                 return hashCode;
             }
+        }
+
+        public override string ToString()
+        {
+            return $"[Name: {name}, Position: {position}, Rotation: {rotation}]";
         }
     }
 }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using NitroxClient.MonoBehaviours;
+﻿using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures;
 using UnityEngine;
@@ -35,16 +34,6 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
 
             NitroxId moduleId = reactorId.Increment();
             NitroxEntity.SetNewId(bioReactorModule.gameObject, moduleId);
-        }
-
-        private IEnumerator DelayModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
-        {
-            if (!finishedPiece)
-            {
-                yield break;
-            }
-            yield return new WaitForSeconds(0.1f);
-            SpawnPostProcess(latestBase, latestCell, finishedPiece);
         }
     }
 }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseBioReactorSpawnProcessor.cs
@@ -28,7 +28,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             // When reruning the spawn processor, the module will not be found at first so we need to delay its detection
             if (!bioReactorModule)
             {
-                latestBase.StartCoroutine(DelayModuleDetection(latestBase, latestCell, finishedPiece));
+                DelayModuleDetection(latestBase, latestCell, finishedPiece);
                 return;
             }
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
@@ -14,6 +14,8 @@ public class BaseLadderSpawnProcessor : BasePieceSpawnProcessor
         TechType.BaseLadder
     };
 
+    protected override bool ShouldRerunSpawnProcessor => false;
+
     protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
     {
         bool builtLadderOnFloor = finishedPiece.name.Contains("Bottom");

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseLadderSpawnProcessor.cs
@@ -14,8 +14,6 @@ public class BaseLadderSpawnProcessor : BasePieceSpawnProcessor
         TechType.BaseLadder
     };
 
-    protected override bool ShouldRerunSpawnProcessor => false;
-
     protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
     {
         bool builtLadderOnFloor = finishedPiece.name.Contains("Bottom");

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseMoonpoolSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseMoonpoolSpawnProcessor.cs
@@ -12,6 +12,8 @@ public class BaseMoonpoolSpawnProcessor : BasePieceSpawnProcessor
         TechType.BaseMoonpool
     };
 
+    protected override bool ShouldRerunSpawnProcessor => true;
+
     protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
     {
         NitroxId moonpoolId = NitroxEntity.GetId(finishedPiece);

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnPrioritizer.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnPrioritizer.cs
@@ -127,7 +127,6 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
                 pieces[index] = specificBasePieces[index - minIndex];
             }
             
-            i = 0;
             return pieces;
         }
     }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -17,7 +18,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         /// <summary>
         /// Some processors don't need to be rerun because the modifications they apply aren't reset when base geometry is rebuilt
         /// </summary>
-        protected abstract bool ShouldRerunSpawnProcessor { get; }
+        protected virtual bool ShouldRerunSpawnProcessor { get; }
 
         static BasePieceSpawnProcessor()
         {
@@ -70,6 +71,17 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             {
                 RunSpawnProcessor(basePieceSpawnInfos.TechType, basePieceSpawnInfos.LatestBase, basePieceSpawnInfos.LatestCell, finishedPiece, true);
             }
+        }
+
+        // Processors may be executed before the finished piece has entirely spawned
+        protected IEnumerator DelayModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        {
+            if (!finishedPiece)
+            {
+                yield break;
+            }
+            yield return new WaitForSeconds(0.1f);
+            SpawnPostProcess(latestBase, latestCell, finishedPiece);
         }
 
         internal struct BasePieceSpawnInfos

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -14,6 +14,10 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         private static readonly Dictionary<NitroxId, BasePieceSpawnInfos> spawnProcessorsApplied = new();
 
         protected abstract TechType[] ApplicableTechTypes { get; }
+        /// <summary>
+        /// Some processors don't need to be rerun because the modifications they apply aren't reset when base geometry is rebuilt
+        /// </summary>
+        protected abstract bool ShouldRerunSpawnProcessor { get; }
 
         static BasePieceSpawnProcessor()
         {
@@ -37,20 +41,25 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         public static void RunSpawnProcessor(BaseDeconstructable baseDeconstructable, Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             TechType techType = baseDeconstructable.recipe;
-            if (finishedPiece.TryGetComponent(out NitroxEntity nitroxEntity))
+            
+            if (RunSpawnProcessor(techType, latestBase, latestCell, finishedPiece))
             {
-                spawnProcessorsApplied[nitroxEntity.Id] = new BasePieceSpawnInfos(techType, latestBase, latestCell);
+                if (finishedPiece.TryGetComponent(out NitroxEntity nitroxEntity))
+                {
+                    spawnProcessorsApplied[nitroxEntity.Id] = new BasePieceSpawnInfos(techType, latestBase, latestCell);
+                }
             }
-            RunSpawnProcessor(techType, latestBase, latestCell, finishedPiece);
         }
 
-        private static void RunSpawnProcessor(TechType techType, Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        private static bool RunSpawnProcessor(TechType techType, Base latestBase, Int3 latestCell, GameObject finishedPiece, bool isReRun = false)
         {
-            if (processorsByType.TryGetValue(techType, out BasePieceSpawnProcessor processor))
+            if (processorsByType.TryGetValue(techType, out BasePieceSpawnProcessor processor) && (!isReRun || processor.ShouldRerunSpawnProcessor))
             {
                 Log.Info($"Found custom BasePieceSpawnProcessor for {techType}");
                 processor.SpawnPostProcess(latestBase, latestCell, finishedPiece);
+                return true;
             }
+            return false;
         }
 
         // Each time an element is built in a base, all the geometries are rebuilt and therefore the modifications done in the SpawnProcessors are erased
@@ -59,7 +68,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         {
             if (spawnProcessorsApplied.TryGetValue(nitroxId, out BasePieceSpawnInfos basePieceSpawnInfos))
             {
-                RunSpawnProcessor(basePieceSpawnInfos.TechType, basePieceSpawnInfos.LatestBase, basePieceSpawnInfos.LatestCell, finishedPiece);
+                RunSpawnProcessor(basePieceSpawnInfos.TechType, basePieceSpawnInfos.LatestBase, basePieceSpawnInfos.LatestCell, finishedPiece, true);
             }
         }
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using UnityEngine;
-using UWE;
 
 namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
 {
@@ -57,7 +56,6 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         {
             if (processorsByType.TryGetValue(techType, out BasePieceSpawnProcessor processor) && (!isReRun || processor.ShouldRerunSpawnProcessor))
             {
-                Log.Info($"Found custom BasePieceSpawnProcessor for {techType}");
                 processor.SpawnPostProcess(latestBase, latestCell, finishedPiece);
                 return true;
             }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -87,6 +87,11 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
                 yield break;
             }
             yield return new WaitForSeconds(0.1f);
+            if (!latestBase || !finishedPiece)
+            {
+                // Happens that multiple delayed coroutine will be there at the same time so we just stop minding about them to let the newer do their job
+                yield break;
+            }
             SpawnPostProcess(latestBase, latestCell, finishedPiece);
         }
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using UnityEngine;
+using UWE;
 
 namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
 {
@@ -73,8 +74,13 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             }
         }
 
+        protected void DelayModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        {
+            latestBase.StartCoroutine(DelayedModuleDetection(latestBase, latestCell, finishedPiece));
+        }
+
         // Processors may be executed before the finished piece has entirely spawned
-        protected IEnumerator DelayModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
+        protected IEnumerator DelayedModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             if (!finishedPiece)
             {

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
@@ -54,15 +54,5 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
                 Log.Debug($"BaseRoomWaterParkProcessor: Created new Waterpark {newWaterparkId} and Planter {newPlanterId}");
             }
         }
-
-        private IEnumerator DelayModuleDetection(Base latestBase, Int3 latestCell, GameObject finishedPiece)
-        {
-            if (!finishedPiece)
-            {
-                yield break;
-            }
-            yield return new WaitForSeconds(0.1f);
-            SpawnPostProcess(latestBase, latestCell, finishedPiece);
-        }
     }
 }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BaseWaterParkProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using NitroxClient.MonoBehaviours;
+﻿using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 using UnityEngine;

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
@@ -18,6 +18,8 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             TechType.BaseMapRoom
         };
 
+        protected override bool ShouldRerunSpawnProcessor => false;
+
         protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             NitroxId mapRoomGeometryPieceId = NitroxEntity.GetId(finishedPiece);
@@ -40,7 +42,6 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
                     return child.gameObject;
                 }
             }
-
             throw new ArgumentException($"Unable to locate recently built map room with {latestBase}");
         }
     }

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
@@ -18,8 +18,6 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             TechType.BaseMapRoom
         };
 
-        protected override bool ShouldRerunSpawnProcessor => false;
-
         protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             NitroxId mapRoomGeometryPieceId = NitroxEntity.GetId(finishedPiece);

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/MapRoomSpawnProcessor.cs
@@ -21,7 +21,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
         protected override void SpawnPostProcess(Base latestBase, Int3 latestCell, GameObject finishedPiece)
         {
             NitroxId mapRoomGeometryPieceId = NitroxEntity.GetId(finishedPiece);
-            GameObject mapRoomFunctionality = FindUntaggedMapRoomFunctionality(latestBase);
+            GameObject mapRoomFunctionality = FindMapRoomFunctionality(latestBase, finishedPiece);
 
             NitroxId mapRoomFunctionalityId = mapRoomGeometryPieceId.Increment();
             NitroxEntity.SetNewId(mapRoomFunctionality, mapRoomFunctionalityId);
@@ -31,13 +31,20 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             NitroxEntity.SetNewId(mapRoomModules, mapRoomModulesId);
         }
 
-        private static GameObject FindUntaggedMapRoomFunctionality(Base latestBase)
+        private static GameObject FindMapRoomFunctionality(Base latestBase, GameObject finishedPiece)
         {
             foreach (Transform child in latestBase.transform)
             {
-                if (child.GetComponent<MapRoomFunctionality>() && !child.GetComponent<NitroxEntity>())
+                MapRoomFunctionality mapRoomFunctionality = child.GetComponent<MapRoomFunctionality>();
+                if (mapRoomFunctionality && !child.GetComponent<NitroxEntity>())
                 {
-                    return child.gameObject;
+                    // Because we lack a direct link between the piece and the MapRoomFunctionality, we need another way of associating them
+                    Int3 @int = latestBase.NormalizeCell(latestBase.WorldToGrid(mapRoomFunctionality.transform.position));
+                    Int3 current = latestBase.NormalizeCell(latestBase.WorldToGrid(finishedPiece.transform.position));
+                    if (@int == @current)
+                    {
+                        return child.gameObject;
+                    }
                 }
             }
             throw new ArgumentException($"Unable to locate recently built map room with {latestBase}");

--- a/NitroxClient/GameLogic/Building.cs
+++ b/NitroxClient/GameLogic/Building.cs
@@ -132,7 +132,7 @@ namespace NitroxClient.GameLogic
 
             // For base pieces, we must switch the id from the ghost to the newly constructed piece.
             // Furniture just uses the same game object as the ghost for the final product.
-            if (ghost.GetComponent<ConstructableBase>())
+            if (ghost.TryGetComponent(out ConstructableBase constructableBase))
             {
                 Int3 latestCell = lastTargetBaseOffset;
                 Base latestBase = lastTargetBase.HasValue ? lastTargetBase.Value : ((GameObject)opConstructedBase.Value).GetComponent<Base>();
@@ -157,7 +157,7 @@ namespace NitroxClient.GameLogic
                     cellTransform = latestBase.GetCellObject(latestCell);
                     if (cellTransform != null)
                     {
-                        placedPiece = FindFinishedPiece(cellTransform, id);
+                        placedPiece = ThrottledBuilder.FindFinishedPiece(cellTransform, id, constructableBase.techType);
                     }
                 }
 
@@ -170,7 +170,7 @@ namespace NitroxClient.GameLogic
                     cellTransform = latestBase.GetCellObject(position);       
 
                     Validate.NotNull(cellTransform, "Unable to find cell transform at " + latestCell);
-                    placedPiece = FindFinishedPiece(cellTransform, id);
+                    placedPiece = ThrottledBuilder.FindFinishedPiece(cellTransform, id, constructableBase.techType);
                 }
                 
                 Validate.NotNull(placedPiece, $"Could not find finished piece in cell {latestCell}");
@@ -192,24 +192,7 @@ namespace NitroxClient.GameLogic
             ConstructionCompleted constructionCompleted = new ConstructionCompleted(id, baseId);
             packetSender.Send(constructionCompleted);
         }
-        
-        // There can be multiple objects in a cell (such as a corridor with hatches built into it)
-        // we look for a object that is able to be deconstructed that hasn't been tagged yet.
-        internal static GameObject FindFinishedPiece(Transform cellTransform, NitroxId pieceId)
-        {
-            foreach (Transform child in cellTransform)
-            {
-                bool isFinishedPiece = (!child.TryGetComponent(out NitroxEntity entity) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector")) ||
-                                        entity?.Id == pieceId;
-                
-                if (isFinishedPiece)
-                {
-                    return child.gameObject;
-                }
-            }
 
-            return null;
-        }
 
         public void DeconstructionBegin(NitroxId id)
         {

--- a/NitroxClient/GameLogic/Building.cs
+++ b/NitroxClient/GameLogic/Building.cs
@@ -157,7 +157,7 @@ namespace NitroxClient.GameLogic
                     cellTransform = latestBase.GetCellObject(latestCell);
                     if (cellTransform != null)
                     {
-                        placedPiece = FindFinishedPiece(cellTransform);
+                        placedPiece = FindFinishedPiece(cellTransform, id);
                     }
                 }
 
@@ -170,7 +170,7 @@ namespace NitroxClient.GameLogic
                     cellTransform = latestBase.GetCellObject(position);       
 
                     Validate.NotNull(cellTransform, "Unable to find cell transform at " + latestCell);
-                    placedPiece = FindFinishedPiece(cellTransform);
+                    placedPiece = FindFinishedPiece(cellTransform, id);
                 }
                 
                 Validate.NotNull(placedPiece, $"Could not find finished piece in cell {latestCell}");
@@ -195,13 +195,14 @@ namespace NitroxClient.GameLogic
         
         // There can be multiple objects in a cell (such as a corridor with hatches built into it)
         // we look for a object that is able to be deconstructed that hasn't been tagged yet.
-        internal static GameObject FindFinishedPiece(Transform cellTransform)
+        internal static GameObject FindFinishedPiece(Transform cellTransform, NitroxId pieceId)
         {
             foreach (Transform child in cellTransform)
             {
-                bool isNewBasePiece = !child.TryGetComponent(out NitroxEntity _) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector");
+                bool isFinishedPiece = (!child.TryGetComponent(out NitroxEntity entity) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector")) ||
+                                        entity?.Id == pieceId;
                 
-                if (isNewBasePiece)
+                if (isFinishedPiece)
                 {
                     return child.gameObject;
                 }

--- a/NitroxClient/MonoBehaviours/Overrides/MultiplayerBuilder.cs
+++ b/NitroxClient/MonoBehaviours/Overrides/MultiplayerBuilder.cs
@@ -191,17 +191,14 @@ namespace NitroxClient.MonoBehaviours.Overrides
             {
                 default:
                     flag2 = baseGhost.UpdatePlacement(camera, placeMaxDistance, out positionFound, out flag, componentInParent);
-                    Log.Debug($"faceGhost: {positionFound}, {flag}");
                     break;
             }
 
-            Log.Debug($"Returned: {flag2}");
             return flag2;
         }
 
         private static void ApplyRotationMetadata(BaseGhost baseGhost, BuilderMetadata builderMetadata)
         {
-            Log.Debug($"Found BaseGhost of type: {baseGhost.GetType()}, {baseGhost}");
             switch (baseGhost)
             {
                 case BaseAddCorridorGhost corridor when builderMetadata is CorridorBuilderMetadata corridorRotationMetadata:
@@ -229,7 +226,6 @@ namespace NitroxClient.MonoBehaviours.Overrides
                 }
                 case BaseAddFaceGhost faceGhost when builderMetadata is AnchoredFaceBuilderMetadata baseModuleRotationMetadata:
                 {
-                    Log.Debug($"Applying AnchoredFaceBuilderMetadata: {baseModuleRotationMetadata}");
                     Base.Face face = new(baseModuleRotationMetadata.Cell.ToUnity(), (Base.Direction)baseModuleRotationMetadata.Direction);
                     if (faceGhost.targetBase.GetAnchor() != baseModuleRotationMetadata.Anchor.ToUnity())
                     {

--- a/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
+++ b/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
@@ -280,9 +280,23 @@ namespace NitroxClient.MonoBehaviours
 
         private static bool AreSameTechType(TechType actual, TechType expected)
         {
-            return actual.Equals(expected) || // normal case
-                   (actual.Equals(TechType.BaseConnector) && expected.Equals(TechType.BaseCorridor)) || // a specific case
-                   expected.ToString().Contains(actual.ToString()); // for cases like: actual = BaseCorridor but expected = BaseCorridorT
+            // Normal case
+            if (actual.Equals(expected))
+            {
+                return true;
+            }
+            // Specificity for this structure
+            if (actual.Equals(TechType.BaseConnector) && expected.Equals(TechType.BaseCorridor))
+            {
+                return true;
+            }
+            // In certain cases the actual type has one more letter than the expected type
+            // e.g. actual = BaseCorridor but expected = BaseCorridorT
+            if (expected.ToString().Contains(actual.ToString()))
+            {
+                return true;
+            }
+            return false;
         }
 
         private void LaterConstructionCompleted(LaterConstructionCompletedEvent laterConstructionCompleted)

--- a/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
+++ b/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
@@ -212,7 +212,7 @@ namespace NitroxClient.MonoBehaviours
 
                     if (cellTransform)
                     {
-                        placedPiece = FindFinishedPiece(cellTransform);
+                        placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId);
                     }
                 }
                 
@@ -222,7 +222,7 @@ namespace NitroxClient.MonoBehaviours
                     cellTransform = latestBase.GetCellObject(position);                        
                     Validate.NotNull(cellTransform, "Unable to find cell transform at " + position);
                     
-                    placedPiece = FindFinishedPiece(cellTransform);
+                    placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId);
                 }
                 
                 Validate.NotNull(placedPiece, $"Could not find placed Piece in cell {latestCell} when constructing {constructionCompleted.PieceId}");
@@ -260,12 +260,13 @@ namespace NitroxClient.MonoBehaviours
         
         // There can be multiple objects in a cell (such as a corridor with hatches built into it)
         // we look for a object that is able to be deconstructed that hasn't been tagged yet.
-        private static GameObject FindFinishedPiece(Transform cellTransform)
+        private static GameObject FindFinishedPiece(Transform cellTransform, NitroxId pieceId)
         {
             foreach (Transform child in cellTransform)
             {
-                bool isNewBasePiece = !child.TryGetComponent(out NitroxEntity _) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector");
-                if (isNewBasePiece)
+                bool isFinishedPiece = (!child.TryGetComponent(out NitroxEntity entity) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector")) ||
+                                        entity?.Id == pieceId;
+                if (isFinishedPiece)
                 {
                     return child.gameObject;
                 }

--- a/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
+++ b/NitroxClient/MonoBehaviours/ThrottledBuilder.cs
@@ -212,19 +212,19 @@ namespace NitroxClient.MonoBehaviours
 
                     if (cellTransform)
                     {
-                        placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId);
+                        placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId, constructableBase.techType);
                     }
                 }
                 
                 if (!placedPiece)
                 {
                     Int3 position = latestBase.WorldToGrid(constructableBase.transform.position);
-                    cellTransform = latestBase.GetCellObject(position);                        
+                    cellTransform = latestBase.GetCellObject(position);
                     Validate.NotNull(cellTransform, "Unable to find cell transform at " + position);
                     
-                    placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId);
+                    placedPiece = FindFinishedPiece(cellTransform, constructionCompleted.PieceId, constructableBase.techType);
                 }
-                
+
                 Validate.NotNull(placedPiece, $"Could not find placed Piece in cell {latestCell} when constructing {constructionCompleted.PieceId}");
                 
                 // This destroy instruction must be executed now, else it won't be able to happen in the case the action will have a later completion
@@ -257,15 +257,18 @@ namespace NitroxClient.MonoBehaviours
                 ConfigureNewlyConstructedBase(constructionCompleted.BaseId);
             }
         }
-        
+
         // There can be multiple objects in a cell (such as a corridor with hatches built into it)
         // we look for a object that is able to be deconstructed that hasn't been tagged yet.
-        private static GameObject FindFinishedPiece(Transform cellTransform, NitroxId pieceId)
+        // NB: The object in question MUST have the expected tech type so that this won't tag a wrong piece (e.g. BaseWaterPark hatches)
+        internal static GameObject FindFinishedPiece(Transform cellTransform, NitroxId pieceId, TechType techType)
         {
             foreach (Transform child in cellTransform)
             {
-                bool isFinishedPiece = (!child.TryGetComponent(out NitroxEntity entity) && child.GetComponent<BaseDeconstructable>() && !child.name.Contains("CorridorConnector")) ||
+                bool isFinishedPiece = (!child.TryGetComponent(out NitroxEntity entity) && child.TryGetComponent(out BaseDeconstructable baseDeconstructable) && AreSameTechType(baseDeconstructable.recipe, techType) &&
+                                        !child.name.Contains("CorridorConnector")) ||
                                         entity?.Id == pieceId;
+
                 if (isFinishedPiece)
                 {
                     return child.gameObject;
@@ -273,6 +276,13 @@ namespace NitroxClient.MonoBehaviours
             }
 
             return null;
+        }
+
+        private static bool AreSameTechType(TechType actual, TechType expected)
+        {
+            return actual.Equals(expected) || // normal case
+                   (actual.Equals(TechType.BaseConnector) && expected.Equals(TechType.BaseCorridor)) || // a specific case
+                   expected.ToString().Contains(actual.ToString()); // for cases like: actual = BaseCorridor but expected = BaseCorridorT
         }
 
         private void LaterConstructionCompleted(LaterConstructionCompletedEvent laterConstructionCompleted)

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/AnchoredFaceBuilderMetadata.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/Metadata/AnchoredFaceBuilderMetadata.cs
@@ -18,21 +18,25 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation.Met
         [ProtoMember(3)]
         public int FaceType { get; set; }
 
+        [ProtoMember(4)]
+        public NitroxInt3 Anchor { get; set; }
+
         protected AnchoredFaceBuilderMetadata() : base(typeof(BaseAddFaceGhost))
         {
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
 
-        public AnchoredFaceBuilderMetadata(NitroxInt3 cell, int faceDirection, int faceType) : base(typeof(BaseAddFaceGhost))
+        public AnchoredFaceBuilderMetadata(NitroxInt3 cell, int faceDirection, int faceType, NitroxInt3 anchor) : base(typeof(BaseAddFaceGhost))
         {
             Cell = cell;
             Direction = faceDirection;
             FaceType = faceType;
+            Anchor = anchor;
         }
 
         public override string ToString()
         {
-            return $"[AnchoredFaceRotationMetadata - Cell: {Cell}, Direction: {Direction}, FaceType: {FaceType}]";
+            return $"[AnchoredFaceBuilderMetadata - Cell: {Cell}, Direction: {Direction}, FaceType: {FaceType}, Anchor: {Anchor}]";
         }
     }
 }

--- a/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/SubnauticaRotationMetadataFactory.cs
+++ b/NitroxModel-Subnautica/DataStructures/GameLogic/Buildings/Rotation/SubnauticaRotationMetadataFactory.cs
@@ -1,7 +1,5 @@
 ﻿using NitroxModel.DataStructures.GameLogic.Buildings.Rotation;
-using NitroxModel.DataStructures.Unity;
 using NitroxModel.DataStructures.Util;
-using NitroxModel.Helper;
 using NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation.Metadata;
 using UnityEngine;
 
@@ -42,7 +40,7 @@ namespace NitroxModel_Subnautica.DataStructures.GameLogic.Buildings.Rotation
                 case BaseAddFaceGhost faceGhost:
                 {
                     Base.Face anchoredFace = faceGhost.anchoredFace!.Value;
-                    builderMetadata = new AnchoredFaceBuilderMetadata(anchoredFace.cell.ToDto(), (int)anchoredFace.direction, (int)faceGhost.faceType);
+                    builderMetadata = new AnchoredFaceBuilderMetadata(anchoredFace.cell.ToDto(), (int)anchoredFace.direction, (int)faceGhost.faceType, faceGhost.targetBase.GetAnchor().ToDto());
                     break;
                 }
             }

--- a/NitroxModel/Packets/DeconstructionCompleted.cs
+++ b/NitroxModel/Packets/DeconstructionCompleted.cs
@@ -7,10 +7,12 @@ namespace NitroxModel.Packets
     public class DeconstructionCompleted : Packet
     {
         public NitroxId Id { get; }
+        public bool Absolute { get; }
 
-        public DeconstructionCompleted(NitroxId id)
+        public DeconstructionCompleted(NitroxId id, bool absolute = false)
         {
             Id = id;
+            Absolute = absolute;
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Base_CopyFrom_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_CopyFrom_Patch.cs
@@ -1,33 +1,72 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using HarmonyLib;
+using NitroxClient.Communication.Abstract;
 using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
 using NitroxModel.Helper;
+using NitroxModel.Packets;
+using UnityEngine;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class Base_CopyFrom_Patch : NitroxPatch, IDynamicPatch
 {
-    class Base_CopyFrom_Patch : NitroxPatch, IDynamicPatch
+    public readonly MethodInfo TARGET_METHOD = Reflect.Method((Base t) => t.CopyFrom(default, default, default));
+
+    // TODO: In the future, if faces are directly manipulated, we need to make sure that TrackDeletedFaces is accordingly set
+    public static bool TrackDeletedFaces => Multiplayer.Main.InitialSyncCompleted;
+    public static Dictionary<Base, List<NitroxId>> DeletedFaces = new();
+
+    public static void Prefix(Base __instance, Base sourceBase)
     {
-        public readonly MethodInfo TARGET_METHOD = Reflect.Method((Base t) => t.CopyFrom(default(Base), default(Int3.Bounds), default(Int3)));
+        NitroxEntity entity = sourceBase.GetComponent<NitroxEntity>();
 
-        public static void Prefix(Base __instance, Base sourceBase)
+        // The game will clone the base when doing things like rebuilding gemometry or placing a new
+        // piece.  The copy is normally between a base ghost and a base - and vise versa.  When building
+        // a face piece, such as a window, this will clone a ghost base to stage the change which is later
+        // integrated into the real base.  For now, prevent guid copies to these staging ghost bases; however,
+        // there is still a pending edge case when a base converts to a BaseGhost for deconstruction.
+        if (entity != null && __instance.gameObject.name != "BaseGhost")
         {
-            NitroxEntity entity = sourceBase.GetComponent<NitroxEntity>();
+            Log.Debug("Transfering base id : " + entity.Id + " from " + sourceBase.name + " to " + __instance.name);
+            NitroxEntity.SetNewId(__instance.gameObject, entity.Id);
+        }
 
-            // The game will clone the base when doing things like rebuilding gemometry or placing a new
-            // piece.  The copy is normally between a base ghost and a base - and vise versa.  When building
-            // a face piece, such as a window, this will clone a ghost base to stage the change which is later
-            // integrated into the real base.  For now, prevent guid copies to these staging ghost bases; however,
-            // there is still a pending edge case when a base converts to a BaseGhost for deconstruction.
-            if (entity != null && __instance.gameObject.name != "BaseGhost")
+        if (TrackDeletedFaces)
+        {
+            DeletedFaces[__instance] = new();
+        }
+    }
+
+    public static void Postfix(Base __instance)
+    {
+        if (!DeletedFaces.TryGetValue(__instance, out List<NitroxId> deletedFaces))
+        {
+            return;
+        }
+
+        // At the end of the base rebuilding, we'll make sure that the deleted stuff is for sure deleted
+        foreach (NitroxId id in deletedFaces)
+        {
+            if (!NitroxEntity.TryGetObjectFrom(id, out GameObject faceObject) || !faceObject || !faceObject.transform.parent)
             {
-                Log.Debug("Transfering base id : " + entity.Id + " from " + sourceBase.name + " to " + __instance.name);
-                NitroxEntity.SetNewId(__instance.gameObject, entity.Id);
+                // We can assume that the object was successfully deleted from now
+                Resolve<IPacketSender>().Send(new DeconstructionCompleted(id, true));
+                Log.Debug($"Face object with the id {id} was successfully deleted");
+            }
+            else
+            {
+                Log.Debug($"Falsely detected a deleted face object: {id}");
             }
         }
 
-        public override void Patch(Harmony harmony)
-        {
-            PatchPrefix(harmony, TARGET_METHOD);
-        }
+        DeletedFaces[__instance] = null;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+        PatchPostfix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Base_SetFace_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_SetFace_Patch.cs
@@ -1,0 +1,117 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class Base_SetFace_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((Base t) => t.SetFace(default, default));
+
+    public static void Prefix(Base __instance, Base.Face face, Base.FaceType faceType)
+    {
+        // We don't want to track events that will happen during BuildingInitialSync or certain other defined times
+        if (!Base_CopyFrom_Patch.TrackDeletedFaces)
+        {
+            return;
+        }
+
+        // We won't handle calls from other places than Base.CopyFrom()
+        if (!Base_CopyFrom_Patch.DeletedFaces.ContainsKey(__instance))
+        {
+            return;
+        }
+
+        int index = __instance.baseShape.GetIndex(face.cell);
+        if (index == -1)
+        {
+            return;
+        }
+
+        // It's the only type of replacement we can detect
+        if (faceType != Base.FaceType.None)
+        {
+            return;
+        }
+
+        Base.FaceType oldFaceType = __instance.faces[__instance.GetNormalizedFaceIndex(index, face.direction)];
+        bool replaced = false;
+        // List of FaceTypes that could be replaced by a corridor
+        switch (oldFaceType)
+        {
+            case Base.FaceType.Window:
+            case Base.FaceType.Hatch:
+            case Base.FaceType.Reinforcement:
+            case Base.FaceType.Planter:
+            case Base.FaceType.FiltrationMachine:
+            case Base.FaceType.UpgradeConsole:
+                replaced = true;
+                break;
+        }
+
+        if (replaced)
+        {
+            // TOREMOVE: Log.Debug($"SetFace({face},{faceType}) {oldFaceType} replaced index: {index}");
+            GameObject faceObject = FindFaceObject(__instance, face, oldFaceType);
+            if (faceObject)
+            {
+                // TOREMOVE: Log.Debug($"Found an object corresponding to the face: {faceObject.name}");
+                if (NitroxEntity.TryGetEntityFrom(faceObject, out NitroxEntity entity))
+                {
+                    // To make sure we don't accidentally delete some part, we'll add another check
+                    Base_CopyFrom_Patch.DeletedFaces[__instance].Add(entity.Id);
+                }
+            }
+            else
+            {
+                Log.Warn($"Corresponding object to the face {face} could not be found");
+            }
+        }
+    }
+
+    private static GameObject FindFaceObject(Base @base, Base.Face face, Base.FaceType faceType, bool retry = true)
+    {
+        // TOREMOVE: Log.Debug($"FindFaceObject({face},{retry})");
+        // TOREMOVE: Log.Debug($"Base's anchor: {@base.GetAnchor()}");
+
+        // Pretty much the same loop as in Base.BindCellObjects but we need to do it this way
+        foreach (BaseCell baseCell in @base.GetComponentsInChildren<BaseCell>(true))
+        {
+            // TOREMOVE: Log.Debug($"Looking inside baseCell: {baseCell.name}");
+            if (baseCell.transform.parent == @base.transform)
+            {
+                Int3 @int = @base.WorldToGrid(baseCell.transform.position);
+                int index = @base.baseShape.GetIndex(@int);
+                if (index == -1)
+                {
+                    continue;
+                }
+                foreach (BaseDeconstructable deconstructable in baseCell.GetComponentsInChildren<BaseDeconstructable>(true))
+                {
+                    // TOREMOVE: Log.Debug($"Found BaseDeconstructable: {deconstructable.name}, face: {deconstructable.face}, bounds: {deconstructable.bounds}");
+                    if (deconstructable.face.HasValue &&
+                        deconstructable.face.Value == face &&
+                        deconstructable.faceType == faceType)
+                    {
+                        return deconstructable.gameObject;
+                    }
+                }
+            }
+        }
+
+        if (retry)
+        {
+            // TOREMOVE: Log.Debug("FindFaceObject failed, will retry with the adjacent face");
+            // If we don't get it the first try (probably because the face direction is West or South), we'll just retry once with the adjacent cell
+            return FindFaceObject(@base, new(Base.GetAdjacent(face.cell, face.direction), face.direction), faceType, false);
+        }
+        return null;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Base_SetFace_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_SetFace_Patch.cs
@@ -53,11 +53,9 @@ public class Base_SetFace_Patch : NitroxPatch, IDynamicPatch
 
         if (replaced)
         {
-            // TOREMOVE: Log.Debug($"SetFace({face},{faceType}) {oldFaceType} replaced index: {index}");
             GameObject faceObject = FindFaceObject(__instance, face, oldFaceType);
             if (faceObject)
             {
-                // TOREMOVE: Log.Debug($"Found an object corresponding to the face: {faceObject.name}");
                 if (NitroxEntity.TryGetEntityFrom(faceObject, out NitroxEntity entity))
                 {
                     // To make sure we don't accidentally delete some part, we'll add another check
@@ -73,13 +71,9 @@ public class Base_SetFace_Patch : NitroxPatch, IDynamicPatch
 
     private static GameObject FindFaceObject(Base @base, Base.Face face, Base.FaceType faceType, bool retry = true)
     {
-        // TOREMOVE: Log.Debug($"FindFaceObject({face},{retry})");
-        // TOREMOVE: Log.Debug($"Base's anchor: {@base.GetAnchor()}");
-
         // Pretty much the same loop as in Base.BindCellObjects but we need to do it this way
         foreach (BaseCell baseCell in @base.GetComponentsInChildren<BaseCell>(true))
         {
-            // TOREMOVE: Log.Debug($"Looking inside baseCell: {baseCell.name}");
             if (baseCell.transform.parent == @base.transform)
             {
                 Int3 @int = @base.WorldToGrid(baseCell.transform.position);
@@ -90,7 +84,6 @@ public class Base_SetFace_Patch : NitroxPatch, IDynamicPatch
                 }
                 foreach (BaseDeconstructable deconstructable in baseCell.GetComponentsInChildren<BaseDeconstructable>(true))
                 {
-                    // TOREMOVE: Log.Debug($"Found BaseDeconstructable: {deconstructable.name}, face: {deconstructable.face}, bounds: {deconstructable.bounds}");
                     if (deconstructable.face.HasValue &&
                         deconstructable.face.Value == face &&
                         deconstructable.faceType == faceType)
@@ -103,7 +96,6 @@ public class Base_SetFace_Patch : NitroxPatch, IDynamicPatch
 
         if (retry)
         {
-            // TOREMOVE: Log.Debug("FindFaceObject failed, will retry with the adjacent face");
             // If we don't get it the first try (probably because the face direction is West or South), we'll just retry once with the adjacent cell
             return FindFaceObject(@base, new(Base.GetAdjacent(face.cell, face.direction), face.direction), faceType, false);
         }

--- a/NitroxServer/Communication/Packets/Processors/DeconstructionCompletedPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DeconstructionCompletedPacketProcessor.cs
@@ -18,6 +18,12 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(DeconstructionCompleted packet, Player player)
         {
+            if (packet.Absolute)
+            {
+                // In this case we don't want to notify other clients as they already processed the modifications on their own
+                baseManager.BasePieceForceDeconstruct(packet.Id);
+                return;
+            }
             baseManager.BasePieceDeconstructionCompleted(packet.Id);
             playerManager.SendPacketToOtherPlayers(packet, player);
         }

--- a/NitroxServer/GameLogic/Bases/BaseManager.cs
+++ b/NitroxServer/GameLogic/Bases/BaseManager.cs
@@ -97,6 +97,18 @@ namespace NitroxServer.GameLogic.Bases
             }
         }
 
+        public void BasePieceForceDeconstruct(NitroxId id)
+        {
+            lock (completedBasePieceHistory)
+            {
+                BasePiece basePiece = completedBasePieceHistory.Find(piece => piece.Id == id);
+                if (basePiece != null)
+                {
+                    completedBasePieceHistory.Remove(basePiece);
+                }
+            }
+        }
+
         public void BasePieceDeconstructionBegin(NitroxId id)
         {
             BasePiece basePiece;


### PR DESCRIPTION
- [x] Fix ``BasePieceSpawnProcessor`` when they are rerun
- [x] Fix an issue where an object being built already has the NitroxId that is being added to it
- [x] Investigate about geometry respawning causing NRE for Multiplayer cinematic components
- [x] Change the way of identifying GameObjects
- [x] Fix hatches not correctly building on alien containments
- [x] Fix hatches not correctly building on MapRooms with something already built onto them
- [x] Could be cool to investigate more about building that replaces stuff which is not counted as deleted (e.g building a corridor on a window) **[FIXED]**
- ~~Repair an instance of ladders not being built on reconnection only~~

**This may need more testing.**
Concerning the `AreSameTechType()` part, I've tested manually for all the pieces.
Also I've made a messy reordering function in `BasePieceSpawnPrioritizer.cs` because I didn't know how to make it, can someone indicate me a better way of doing this please ?
The ladders issue will remain since it can happen and not happen in the same conditions, I won't look more into it