### PR TITLE
Fix player color for different players

### DIFF
--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -159,7 +159,7 @@ namespace NitroxClient
                 .RegisterAssemblyTypes(currentAssembly)
                 .AssignableTo<IColorSwapManager>()
                 .As<IColorSwapManager>()
-                .InstancePerLifetimeScope();
+                .SingleInstance();
         }
 
         private void RegisterInitialSyncProcessors(ContainerBuilder containerBuilder)

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -34,6 +34,7 @@ namespace NitroxClient.GameLogic
         public string PlayerName => multiplayerSession.AuthenticationContext.Username;
         public ushort PlayerId => multiplayerSession.Reservation.PlayerId;
         public PlayerSettings PlayerSettings => multiplayerSession.PlayerSettings;
+
         public Perms Permissions;
         
         public LocalPlayer(IMultiplayerSession multiplayerSession, IPacketSender packetSender)
@@ -44,12 +45,6 @@ namespace NitroxClient.GameLogic
             playerModel = new Lazy<GameObject>(() => Body.RequireGameObject("player_view"));
             bodyPrototype = new Lazy<GameObject>(CreateBodyPrototype);
             Permissions = Perms.PLAYER;
-        }
-
-        public void BroadcastStats(float oxygen, float maxOxygen, float health, float food, float water, float infectionAmount)
-        {
-            PlayerStats playerStats = new PlayerStats(multiplayerSession.Reservation.PlayerId, oxygen, maxOxygen, health, food, water, infectionAmount);
-            packetSender.Send(playerStats);
         }
 
         public void UpdateLocation(Vector3 location, Vector3 velocity, Quaternion bodyRotation, Quaternion aimingRotation, Optional<VehicleMovementData> vehicle)
@@ -67,44 +62,21 @@ namespace NitroxClient.GameLogic
             packetSender.Send(movement);
         }
 
-        public void AnimationChange(AnimChangeType type, AnimChangeState state)
-        {
-            AnimationChangeEvent animEvent = new AnimationChangeEvent(multiplayerSession.Reservation.PlayerId, (int)type, (int)state);
-            packetSender.Send(animEvent);
-        }
+        public void AnimationChange(AnimChangeType type, AnimChangeState state) => packetSender.Send(new AnimationChangeEvent(multiplayerSession.Reservation.PlayerId, (int)type, (int)state));
 
-        public void BroadcastDeath(Vector3 deathPosition)
-        {
-            PlayerDeathEvent playerDeath = new PlayerDeathEvent(multiplayerSession.Reservation.PlayerId, deathPosition.ToDto());
-            packetSender.Send(playerDeath);
-        }
+        public void BroadcastStats(float oxygen, float maxOxygen, float health, float food, float water, float infectionAmount) => packetSender.Send(new PlayerStats(multiplayerSession.Reservation.PlayerId, oxygen, maxOxygen, health, food, water, infectionAmount));
 
-        public void BroadcastSubrootChange(Optional<NitroxId> subrootId)
-        {
-            SubRootChanged packet = new SubRootChanged(multiplayerSession.Reservation.PlayerId, subrootId);
-            packetSender.Send(packet);
-        }
-        public void BroadcastEscapePodChange(Optional<NitroxId> escapePodId)
-        {
-            EscapePodChanged packet = new EscapePodChanged(multiplayerSession.Reservation.PlayerId, escapePodId);
-            packetSender.Send(packet);
-        }
+        public void BroadcastDeath(Vector3 deathPosition) => packetSender.Send(new PlayerDeathEvent(multiplayerSession.Reservation.PlayerId, deathPosition.ToDto()));
 
-        public void BroadcastWeld(NitroxId id, float healthAdded)
-        {
-            WeldAction packet = new WeldAction(id, healthAdded);
-            packetSender.Send(packet);
-        }
+        public void BroadcastSubrootChange(Optional<NitroxId> subrootId) => packetSender.Send(new SubRootChanged(multiplayerSession.Reservation.PlayerId, subrootId));
 
-        public void BroadcastHeldItemChanged(NitroxId itemId, PlayerHeldItemChanged.ChangeType techType, NitroxTechType isFirstTime)
-        {
-            packetSender.Send(new PlayerHeldItemChanged(multiplayerSession.Reservation.PlayerId, itemId, techType, isFirstTime));
-        }
+        public void BroadcastEscapePodChange(Optional<NitroxId> escapePodId) => packetSender.Send(new EscapePodChanged(multiplayerSession.Reservation.PlayerId, escapePodId));
 
-        public void BroadcastQuickSlotsBindingChanged(List<string> binding)
-        {
-            packetSender.Send(new PlayerQuickSlotsBindingChanged(binding));
-        }
+        public void BroadcastWeld(NitroxId id, float healthAdded) => packetSender.Send(new WeldAction(id, healthAdded));
+
+        public void BroadcastHeldItemChanged(NitroxId itemId, PlayerHeldItemChanged.ChangeType techType, NitroxTechType isFirstTime) => packetSender.Send(new PlayerHeldItemChanged(multiplayerSession.Reservation.PlayerId, itemId, techType, isFirstTime));
+
+        public void BroadcastQuickSlotsBindingChanged(List<string> binding) => packetSender.Send(new PlayerQuickSlotsBindingChanged(binding));
 
         private GameObject CreateBodyPrototype()
         {
@@ -112,7 +84,7 @@ namespace NitroxClient.GameLogic
 
             // Cheap fix for showing head, much easier since male_geo contains many different heads
             prototype.GetComponentInParent<Player>().head.shadowCastingMode = ShadowCastingMode.On;
-            GameObject clone = Object.Instantiate(prototype, Multiplayer.Main.transform);
+            GameObject clone = Object.Instantiate(prototype, Multiplayer.Main.transform, false);
             prototype.GetComponentInParent<Player>().head.shadowCastingMode = ShadowCastingMode.ShadowsOnly;
 
             clone.SetActive(false);

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
+using NitroxModel_Subnautica.DataStructures;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
@@ -24,6 +25,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
         public void UpdateIndex(string indexKey, Color[] pixels)
         {
+            Log.Info($"[TEXTURE] : Updated INDEX k: {indexKey} v: {pixels.ToDto()}");
+
             lock (texturePixelIndexes)
             {
                 if (texturePixelIndexes.ContainsKey(indexKey))
@@ -69,17 +72,13 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
         private void ExecuteTask(object state)
         {
-            Action<ColorSwapAsyncOperation> task = state as Action<ColorSwapAsyncOperation>;
-
-            if (task == null)
+            if (state is not Action<ColorSwapAsyncOperation> task)
             {
                 //TODO: We need to handle job cancellation during stabilization to ensure that the client shuts down gracefully.
-
-                throw new ArgumentException(@"Cannot execute a null task.", nameof(task));
+                throw new ArgumentException("Cannot execute a null task.", nameof(state));
             }
 
             task.Invoke(this);
-
             Interlocked.Decrement(ref taskCount);
         }
     }

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
@@ -25,8 +25,6 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
         public void UpdateIndex(string indexKey, Color[] pixels)
         {
-            Log.Info($"[TEXTURE] : Updated INDEX k: {indexKey} v: {pixels.ToDto()}");
-
             lock (texturePixelIndexes)
             {
                 if (texturePixelIndexes.ContainsKey(indexKey))

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/HsvSwapper.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/HsvSwapper.cs
@@ -6,6 +6,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
     public class HsvSwapper
     {
         private readonly IColorSwapStrategy colorSwapStrategy;
+
         private ColorValueRange alphaValueRange;
         private ColorValueRange hueValueRange;
         private ColorValueRange saturationValueRange;

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RebreatherColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RebreatherColorSwapManager.cs
@@ -56,7 +56,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
             rebreatherRenderer.material.SetTexture("_MainTex", rebreatherRenderer.material.mainTexture);
             rebreatherRenderer.material.SetTexture("_SpecTex", rebreatherRenderer.material.mainTexture);
-            rebreatherRenderer.material.SetTexture("_BumpMap", rebreatherRenderer.material.GetTexture("player_mask_01_normal"));
+            rebreatherRenderer.material.SetTexture("_BumpMap", rebreatherRenderer.material.GetTexture("_BumpMap"));
 
             rebreatherRenderer.materials[2].shader = marmosetShader;
             rebreatherRenderer.materials[2].shaderKeywords = new List<string>

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -102,13 +102,9 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel
         private static IEnumerator ApplyPlayerColor(INitroxPlayer player, IEnumerable<IColorSwapManager> colorSwapManagers)
         {
             ColorSwapAsyncOperation swapOperation = new(player, colorSwapManagers);
+
             swapOperation.BeginColorSwap();
-
-            while (!swapOperation.IsColorSwapComplete())
-            {
-                yield return new WaitForSeconds(0.1f);
-            }
-
+            yield return new WaitUntil(() => swapOperation.IsColorSwapComplete());
             swapOperation.ApplySwappedColors();
         }
     }

--- a/NitroxClient/GameLogic/PlayerManager.cs
+++ b/NitroxClient/GameLogic/PlayerManager.cs
@@ -67,6 +67,7 @@ namespace NitroxClient.GameLogic
 
             GameObject remotePlayerBody = CloneLocalPlayerBodyPrototype();
             RemotePlayer remotePlayer;
+
             using (packetSender.Suppress<ItemContainerAdd>())
             {
                 remotePlayer = new RemotePlayer(remotePlayerBody, playerContext, equippedTechTypes, inventoryItems, playerModelManager);
@@ -92,10 +93,10 @@ namespace NitroxClient.GameLogic
             }
 
             playersById.Add(remotePlayer.PlayerId, remotePlayer);
-
-            DiscordClient.UpdatePartySize(GetTotalPlayerCount());
             onCreate(remotePlayer.PlayerId, remotePlayer);
 
+            DiscordClient.UpdatePartySize(GetTotalPlayerCount());
+            
             return remotePlayer;
         }
 
@@ -109,14 +110,15 @@ namespace NitroxClient.GameLogic
                     opPlayer.Value.Destroy();
                 }
                 playersById.Remove(playerId);
-                DiscordClient.UpdatePartySize(GetTotalPlayerCount());
                 onRemove(playerId, opPlayer.Value);
+                DiscordClient.UpdatePartySize(GetTotalPlayerCount());
             }
         }
 
         private GameObject CloneLocalPlayerBodyPrototype()
         {
-            GameObject clone = Object.Instantiate(localPlayer.BodyPrototype);
+            Log.Info("Cloning local body prototype");
+            GameObject clone = Object.Instantiate(localPlayer.BodyPrototype, Multiplayer.Main.transform, false);
             clone.SetActive(true);
             return clone;
         }

--- a/NitroxClient/GameLogic/PlayerManager.cs
+++ b/NitroxClient/GameLogic/PlayerManager.cs
@@ -117,7 +117,6 @@ namespace NitroxClient.GameLogic
 
         private GameObject CloneLocalPlayerBodyPrototype()
         {
-            Log.Info("Cloning local body prototype");
             GameObject clone = Object.Instantiate(localPlayer.BodyPrototype, Multiplayer.Main.transform, false);
             clone.SetActive(true);
             return clone;

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -178,6 +178,7 @@ namespace NitroxClient.MonoBehaviours
             ILocalNitroxPlayer localPlayer = NitroxServiceLocator.LocateService<ILocalNitroxPlayer>();
             IEnumerable<IColorSwapManager> colorSwapManagers = NitroxServiceLocator.LocateService<IEnumerable<IColorSwapManager>>();
 
+            // This is used to init the lazy GameObject in order to create a real default Body Prototype for other players
             GameObject body = localPlayer.BodyPrototype;
             Log.Info($"Init body prototype {body.name}");
 

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -178,9 +178,11 @@ namespace NitroxClient.MonoBehaviours
             ILocalNitroxPlayer localPlayer = NitroxServiceLocator.LocateService<ILocalNitroxPlayer>();
             IEnumerable<IColorSwapManager> colorSwapManagers = NitroxServiceLocator.LocateService<IEnumerable<IColorSwapManager>>();
 
+            GameObject body = localPlayer.BodyPrototype;
+            Log.Info($"Init body prototype {body.name}");
+
             ColorSwapAsyncOperation swapOperation = new ColorSwapAsyncOperation(localPlayer, colorSwapManagers).BeginColorSwap();
             yield return new WaitUntil(() => swapOperation.IsColorSwapComplete());
-
             swapOperation.ApplySwappedColors();
 
             // UWE developers added noisy logging for non-whitelisted components during serialization.

--- a/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
+++ b/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
@@ -17,9 +17,8 @@ namespace NitroxClient.MonoBehaviours
 
 #if DEBUG
             EnableDeveloperFeatures();
-#endif
-
             CreateDebugger();
+#endif
         }
 
         private void EnableDeveloperFeatures()

--- a/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
+++ b/NitroxClient/MonoBehaviours/NitroxBootstrapper.cs
@@ -17,8 +17,9 @@ namespace NitroxClient.MonoBehaviours
 
 #if DEBUG
             EnableDeveloperFeatures();
-            CreateDebugger();
 #endif
+
+            CreateDebugger();
         }
 
         private void EnableDeveloperFeatures()

--- a/NitroxModel/MultiplayerSession/PlayerSettings.cs
+++ b/NitroxModel/MultiplayerSession/PlayerSettings.cs
@@ -12,5 +12,10 @@ namespace NitroxModel.MultiplayerSession
         {
             PlayerColor = playerColor;
         }
+
+        public override string ToString()
+        {
+            return $"[{nameof(PlayerSettings)}: PlayerColor: {PlayerColor}]";
+        }
     }
 }


### PR DESCRIPTION
Fix an issue where joining players would have the same color as you while their ping has the correct color.

This is achieved by early init of the body prototype before the first color swapping operation. The body prototype shouldn't be colored in the first place since color swapping operations is mapped on the original texture pixels (which are orange)

PS: Might be worth to investigate in a cache for SwapColorOperation since it's the exact same process everytime