### PR TITLE
Fix some occurrences of player inventory clear

### DIFF
--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -65,5 +65,5 @@
     "Nitrox_WaitingPassword": "Waiting for server password input…",
     "Nitrox_WaitingUserInput": "Waiting for user input…",
     "Nitrox_WorldSettling": "Awaiting World Settling…",
-    "RemotePlayerObstacle": "Another player's either inside or too close to the deconstructable target."
+    "Nitrox_RemotePlayerObstacle": "Another player's either inside or too close to the deconstructable target."
 }

--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -64,5 +64,6 @@
     "Nitrox_Waiting": "Waiting in join queue…",
     "Nitrox_WaitingPassword": "Waiting for server password input…",
     "Nitrox_WaitingUserInput": "Waiting for user input…",
-    "Nitrox_WorldSettling": "Awaiting World Settling…"
+    "Nitrox_WorldSettling": "Awaiting World Settling…",
+    "RemotePlayerObstacle": "Another player's either inside or too close to the deconstructable target."
 }

--- a/NitroxClient/Communication/Packets/Processors/AnimationProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AnimationProcessor.cs
@@ -20,7 +20,7 @@ namespace NitroxClient.Communication.Packets.Processors
             Optional<RemotePlayer> opPlayer = remotePlayerManager.Find(animEvent.PlayerId);
             if (opPlayer.HasValue)
             {
-                opPlayer.Value.UpdateAnimation((AnimChangeType)animEvent.Type, (AnimChangeState)animEvent.State);
+                opPlayer.Value.UpdateAnimationAndCollider((AnimChangeType)animEvent.Type, (AnimChangeState)animEvent.State);
             }
         }
     }

--- a/NitroxClient/GameLogic/InitialSync/RemotePlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/RemotePlayerInitialSyncProcessor.cs
@@ -39,7 +39,7 @@ namespace NitroxClient.GameLogic.InitialSync
 
                 if (!IsSwimming(playerData.Position.ToUnity(), playerData.SubRootId))
                 {
-                    player.UpdateAnimation(AnimChangeType.UNDERWATER, AnimChangeState.OFF);
+                    player.UpdateAnimationAndCollider(AnimChangeType.UNDERWATER, AnimChangeState.OFF);
                 }
                 remotePlayersSynced++;
                 yield return null;

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -1,5 +1,6 @@
 ﻿using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.PlayerLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures;
@@ -21,6 +22,12 @@ namespace NitroxClient.GameLogic
 
         public void BroadcastItemAdd(Pickupable pickupable, Transform containerTransform)
         {
+            // We don't want to broadcast that event if it's from another player's inventory
+            if (containerTransform.GetComponentInParent<RemotePlayerIdentifier>(true))
+            {
+                return;
+            }
+
             NitroxId itemId = NitroxEntity.GetId(pickupable.gameObject);
             byte[] bytes = SerializationHelper.GetBytesWithoutParent(pickupable.gameObject);
             NitroxId ownerId = InventoryContainerHelper.GetOwnerId(containerTransform);
@@ -45,6 +52,12 @@ namespace NitroxClient.GameLogic
 
         public void BroadcastItemRemoval(Pickupable pickupable, Transform containerTransform)
         {
+            // We don't want to broadcast that event if it's from another player's inventory
+            if (containerTransform.GetComponentInParent<RemotePlayerIdentifier>(true))
+            {
+                return;
+            }
+            
             NitroxId itemId = NitroxEntity.GetId(pickupable.gameObject);
             if (packetSender.Send(new ItemContainerRemove(InventoryContainerHelper.GetOwnerId(containerTransform), itemId)))
             {

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -99,12 +99,15 @@ namespace NitroxClient.GameLogic
                 Log.Error($"Could not find item container behaviour on object {owner.GetFullHierarchyPath()} with id {ownerId}");
                 return;
             }
-
             ItemsContainer container = opContainer.Value;
             Pickupable pickupable = item.RequireComponent<Pickupable>();
             using (packetSender.Suppress<ItemContainerRemove>())
             {
-                container.RemoveItem(pickupable, true);
+                if (container.RemoveItem(pickupable, true) && container._label.StartsWith("NitroxInventoryStorage_"))
+                {
+                    // If we don't destroy the item here, it will stay forever in the remote player's inventory
+                    Object.Destroy(item);
+                }
                 Log.Debug($"Received: Removed item {pickupable.GetTechType()} to container {owner.GetFullHierarchyPath()}");
             }
         }

--- a/NitroxClient/GameLogic/PlayerLogic/RemotePlayerIdentifier.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/RemotePlayerIdentifier.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace NitroxClient.GameLogic.PlayerLogic;
+
+/// <summary>
+/// Attached to a RemotePlayer. Useful to determine that this script's GameObject is in the root of a RemotePlayer.
+/// </summary>
+public class RemotePlayerIdentifier : MonoBehaviour, IObstacle
+{
+    public RemotePlayer RemotePlayer;
+
+    public bool CanDeconstruct(out string reason)
+    {
+        reason = Language.main.Get("RemotePlayerObstacle");
+        return false;
+    }
+}

--- a/NitroxClient/GameLogic/PlayerLogic/RemotePlayerIdentifier.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/RemotePlayerIdentifier.cs
@@ -3,15 +3,18 @@
 namespace NitroxClient.GameLogic.PlayerLogic;
 
 /// <summary>
-/// Attached to a RemotePlayer. Useful to determine that this script's GameObject is in the root of a RemotePlayer.
+/// Attached to a RemotePlayer. Useful to determine that this script's GameObject is in the EntityRoot of a RemotePlayer.
 /// </summary>
+/// <remarks>
+/// The EntityRoot of an object is defined as the top most GameObject as when an object hierarchy first was spawned in. Either from a prefab, or in Nitrox' case, a cloned root game object.
+/// </remarks>
 public class RemotePlayerIdentifier : MonoBehaviour, IObstacle
 {
     public RemotePlayer RemotePlayer;
 
     public bool CanDeconstruct(out string reason)
     {
-        reason = Language.main.Get("RemotePlayerObstacle");
+        reason = Language.main.Get("Nitrox_RemotePlayerObstacle");
         return false;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Base_OnPreDestroy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_OnPreDestroy_Patch.cs
@@ -2,12 +2,11 @@
 using HarmonyLib;
 using NitroxClient.GameLogic.PlayerLogic;
 using NitroxModel.Helper;
-using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
 /// <summary>
-/// Before a base gets destroyed, we eventually remove any remote player that would be inside so that their GameObjects don't get destroyed
+/// Before a base gets destroyed, we eventually detach/exit any remote player's object that would be inside so that their GameObjects don't get destroyed
 /// </summary>
 public class Base_OnPreDestroy_Patch : NitroxPatch, IDynamicPatch
 {
@@ -18,7 +17,6 @@ public class Base_OnPreDestroy_Patch : NitroxPatch, IDynamicPatch
         foreach (RemotePlayerIdentifier remotePlayerIdentifier in __instance.GetComponentsInChildren<RemotePlayerIdentifier>(true))
         {
             remotePlayerIdentifier.RemotePlayer.Detach();
-            SkyEnvironmentChanged.Broadcast(remotePlayerIdentifier.RemotePlayer.Body, (GameObject)null);
         }
     }
 

--- a/NitroxPatcher/Patches/Dynamic/Base_OnPreDestroy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Base_OnPreDestroy_Patch.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic.PlayerLogic;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Before a base gets destroyed, we eventually remove any remote player that would be inside so that their GameObjects don't get destroyed
+/// </summary>
+public class Base_OnPreDestroy_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Base t) => t.OnPreDestroy());
+
+    public static void Prefix(Base __instance)
+    {
+        foreach (RemotePlayerIdentifier remotePlayerIdentifier in __instance.GetComponentsInChildren<RemotePlayerIdentifier>(true))
+        {
+            remotePlayerIdentifier.RemotePlayer.Detach();
+            SkyEnvironmentChanged.Broadcast(remotePlayerIdentifier.RemotePlayer.Body, (GameObject)null);
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Utils_GetEntityRoot_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Utils_GetEntityRoot_Patch.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic.PlayerLogic;
+using NitroxClient.Unity.Helper;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// When looking for an EntityRoot, we want to make sure that the player can be recognized as one
+/// </summary>
+public class Utils_GetEntityRoot_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => UWE.Utils.GetEntityRoot(default));
+
+    public static bool Prefix(GameObject go, ref GameObject __result)
+    {
+        if (go.TryGetComponent(out RemotePlayerIdentifier remotePlayerIdentifier) || go.TryGetComponentInParent(out remotePlayerIdentifier))
+        {
+            __result = remotePlayerIdentifier.gameObject;
+        }
+        return __result == null;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Utils_GetEntityRoot_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Utils_GetEntityRoot_Patch.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace NitroxPatcher.Patches.Dynamic;
 
 /// <summary>
-/// When looking for an EntityRoot, we want to make sure that the player can be recognized as one
+/// When looking for an EntityRoot, we want to make sure that remote players can be recognized as one.
 /// </summary>
 public class Utils_GetEntityRoot_Patch : NitroxPatch, IDynamicPatch
 {
@@ -19,8 +19,9 @@ public class Utils_GetEntityRoot_Patch : NitroxPatch, IDynamicPatch
         if (go.TryGetComponent(out RemotePlayerIdentifier remotePlayerIdentifier) || go.TryGetComponentInParent(out remotePlayerIdentifier))
         {
             __result = remotePlayerIdentifier.gameObject;
+            return false;
         }
-        return __result == null;
+        return true;
     }
 
     public override void Patch(Harmony harmony)


### PR DESCRIPTION
- [x] Prevent players to build on other players, or to destroy a building with players inside
> When the RemotePlayer object is destroyed, all of its inventory is destroyed too and will send parasite packets with fake informations (like item removal)
- [x] Prevent a player to modify another player's inventory