### PR TITLE
Sync fire extinguishers FX

### DIFF
--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -153,6 +153,7 @@ namespace NitroxClient
             containerBuilder.RegisterType<PlayerCinematics>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<NitroxPDATabManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<TimeManager>().InstancePerLifetimeScope();
+            containerBuilder.RegisterType<FireExtinguisherManager>().InstancePerLifetimeScope();
         }
 
         private void RegisterPacketProcessors(ContainerBuilder containerBuilder)

--- a/NitroxClient/Communication/Packets/Processors/FireExtinguisherUseProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FireExtinguisherUseProcessor.cs
@@ -1,0 +1,31 @@
+﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class FireExtinguisherUseProcessor : ClientPacketProcessor<FireExtinguisherUse>
+{
+    private readonly FireExtinguisherManager extinguisherManager;
+
+    public FireExtinguisherUseProcessor(FireExtinguisherManager extinguisherManager)
+    {
+        this.extinguisherManager = extinguisherManager;
+    }
+
+    public override void Process(FireExtinguisherUse packet)
+    {
+        if (NitroxEntity.TryGetComponentFrom(packet.ItemId, out FireExtinguisher fireExtinguisher))
+        {
+            if (packet.Activated)
+            {
+                extinguisherManager.StartUsing(packet.ItemId, fireExtinguisher);
+            }
+            else
+            {
+                extinguisherManager.StopUsing(packet.ItemId);
+            }
+        }
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
@@ -1,10 +1,11 @@
-﻿using System;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
+using System;
 using UnityEngine;
 
 namespace NitroxClient.Communication.Packets.Processors;
@@ -53,8 +54,8 @@ public class PlayerHeldItemChangedProcessor : ClientPacketProcessor<PlayerHeldIt
         ItemsContainer inventory = opPlayer.Value.Inventory;
         PlayerTool tool = item.GetComponent<PlayerTool>();
 
-        OnHeldItemChanged?.Invoke(previousItemId);
-        previousItemId = NitroxEntity.TryGetEntityFrom(opItem.Value, out NitroxEntity entity) ? entity.Id : null;
+        OnHeldItemChanged?.Invoke(Optional.OfNullable(previousItemId));
+        previousItemId = item.GetId().OrNull();
 
         // Copied from QuickSlots
         switch (packet.Type)

--- a/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
@@ -15,6 +15,10 @@ public class PlayerHeldItemChangedProcessor : ClientPacketProcessor<PlayerHeldIt
     private int viewModelLayer;
     private readonly PlayerManager playerManager;
 
+    private NitroxId previousItemId;
+    public delegate void HeldItemChanged(Optional<NitroxId> previousId);
+    public static event HeldItemChanged OnHeldItemChanged;
+
     public PlayerHeldItemChangedProcessor(PlayerManager playerManager)
     {
         this.playerManager = playerManager;
@@ -48,6 +52,9 @@ public class PlayerHeldItemChangedProcessor : ClientPacketProcessor<PlayerHeldIt
 
         ItemsContainer inventory = opPlayer.Value.Inventory;
         PlayerTool tool = item.GetComponent<PlayerTool>();
+
+        OnHeldItemChanged?.Invoke(previousItemId);
+        previousItemId = NitroxEntity.TryGetEntityFrom(opItem.Value, out NitroxEntity entity) ? entity.Id : null;
 
         // Copied from QuickSlots
         switch (packet.Type)

--- a/NitroxClient/GameLogic/FireExtinguisherManager.cs
+++ b/NitroxClient/GameLogic/FireExtinguisherManager.cs
@@ -1,7 +1,6 @@
-﻿using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.Abstract;
 using NitroxClient.Communication.Packets.Processors;
 using NitroxClient.GameLogic.PlayerLogic;
-using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using NitroxModel.Packets;
 using System.Collections.Generic;
@@ -47,7 +46,7 @@ public class FireExtinguisherManager
     {
         if (!latestRegisteredState.TryGetValue(extinguisherId, out bool previousValue) || previousValue != extinguisher.fxIsPlaying)
         {
-            FireExtinguisherUse packet = new(NitroxEntity.GetId(extinguisher.gameObject), extinguisher.fxIsPlaying);
+            FireExtinguisherUse packet = new(extinguisherId, extinguisher.fxIsPlaying);
             packetSender.Send(packet);
         }
         latestRegisteredState[extinguisherId] = extinguisher.fxIsPlaying;
@@ -62,10 +61,11 @@ public class FireExtinguisherManager
         if (num != fireExtinguisher.lastUnderwaterValue)
         {
             fireExtinguisher.lastUnderwaterValue = num;
-            if (fireExtinguisher.fmodIndexInWater < 0)
+            if (FMODUWE.IsInvalidParameterId(fireExtinguisher.fmodIndexInWater))
             {
                 fireExtinguisher.fmodIndexInWater = fireExtinguisher.soundEmitter.GetParameterIndex("in_water");
             }
+            // TODO: Only play sound if close enough
             fireExtinguisher.soundEmitter.SetParameterValue(fireExtinguisher.fmodIndexInWater, num);
         }
 
@@ -73,7 +73,8 @@ public class FireExtinguisherManager
         fireExtinguisher.fireTarget = null;
         Vector3 vector = default;
         GameObject gameObject = null;
-        UWE.Utils.TraceFPSTargetPosition(identifier.gameObject, 8f, ref gameObject, ref vector, true);
+        
+        TraceRemotePlayerTargetPosition(identifier.gameObject, 8f, ref gameObject, ref vector, true);
         if (gameObject)
         {
             Fire componentInHierarchy = UWE.Utils.GetComponentInHierarchy<Fire>(gameObject);
@@ -82,7 +83,12 @@ public class FireExtinguisherManager
                 fireExtinguisher.fireTarget = componentInHierarchy;
             }
         }
-        //
+        else
+        {
+            // Added line to make sure that the FX is in the right direction
+            fireExtinguisher.fxControl.transform.eulerAngles = identifier.RemotePlayer.AnimationController.AimingRotation.eulerAngles;
+        }
+        // end of UpdateTarget
 
         if (usedThisFrame)
         {
@@ -92,7 +98,7 @@ public class FireExtinguisherManager
                 fireExtinguisher.fxControl.Play(0);
                 fireExtinguisher.fxIsPlaying = true;
             }
-            //
+            // end of UseExtinguisher
             fireExtinguisher.soundEmitter.Play();
         }
         else
@@ -106,5 +112,38 @@ public class FireExtinguisherManager
         }
 
         fireExtinguisher.UpdateImpactFX();
+    }
+
+    /// <summary>
+    /// Replacement for <see cref="UWE.Utils.TraceFPSTargetPosition(GameObject, float, ref GameObject, ref Vector3, out Vector3, bool)"/>
+    /// because it originally uses the main camera while we want to use the remote player's view
+    /// </summary>
+    private static bool TraceRemotePlayerTargetPosition(GameObject ignoreObj, float maxDist, ref GameObject closestObj, ref Vector3 position, bool includeUseableTriggers = true)
+    {
+        // TODO: Make it so that the camera reference is replaced by the remote player's stuff
+        bool result = false;
+        Camera camera = MainCamera.camera;
+        Vector3 position2 = camera.transform.position;
+        int num = UWE.Utils.RaycastIntoSharedBuffer(new Ray(position2, camera.transform.forward), maxDist, -2097153);
+        if (num == 0)
+        {
+            num = UWE.Utils.SpherecastIntoSharedBuffer(position2, 0.7f, camera.transform.forward, maxDist, -2097153);
+        }
+
+        closestObj = null;
+        float num2 = 0f;
+        for (int i = 0; i < num; i++)
+        {
+            RaycastHit raycastHit = UWE.Utils.sharedHitBuffer[i];
+            if ((!(ignoreObj != null) || !UWE.Utils.IsAncestorOf(ignoreObj, raycastHit.collider.gameObject)) && (!raycastHit.collider || !raycastHit.collider.isTrigger || (includeUseableTriggers && raycastHit.collider.gameObject.layer == LayerMask.NameToLayer("Useable"))) && (closestObj == null || raycastHit.distance < num2))
+            {
+                closestObj = raycastHit.collider.gameObject;
+                num2 = raycastHit.distance;
+                position = raycastHit.point;
+                result = true;
+            }
+        }
+
+        return result;
     }
 }

--- a/NitroxClient/GameLogic/FireExtinguisherManager.cs
+++ b/NitroxClient/GameLogic/FireExtinguisherManager.cs
@@ -1,0 +1,110 @@
+﻿using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.Packets.Processors;
+using NitroxClient.GameLogic.PlayerLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Packets;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic;
+
+public class FireExtinguisherManager
+{
+    private readonly IPacketSender packetSender;
+
+    private readonly Dictionary<NitroxId, FireExtinguisher> remotelyUsedFireExtinguishers = new();
+    private readonly Dictionary<NitroxId, bool> latestRegisteredState = new();
+
+    public FireExtinguisherManager(IPacketSender packetSender)
+    {
+        this.packetSender = packetSender;
+
+        // When a player stops holding a fire extinguisher, we'll stop it. Even if we didn't receive a packet to notice that he's no longer using it, we'll make sure that we mark it as not used.
+        PlayerHeldItemChangedProcessor.OnHeldItemChanged += (previousId) =>
+        {
+            if (previousId.HasValue)
+            {
+                remotelyUsedFireExtinguishers.Remove(previousId.Value);
+            }
+        };
+    }
+
+    public void StartUsing(NitroxId extinguisherId, FireExtinguisher fireExtinguisher)
+    {
+        if (!remotelyUsedFireExtinguishers.ContainsKey(extinguisherId))
+        {
+            remotelyUsedFireExtinguishers.Add(extinguisherId, fireExtinguisher);
+        }
+    }
+
+    public void StopUsing(NitroxId extinguisherId)
+    {
+        remotelyUsedFireExtinguishers.Remove(extinguisherId);
+    }
+
+    public void BroadcastFireExtinguisherState(NitroxId extinguisherId, FireExtinguisher extinguisher)
+    {
+        if (!latestRegisteredState.TryGetValue(extinguisherId, out bool previousValue) || previousValue != extinguisher.fxIsPlaying)
+        {
+            FireExtinguisherUse packet = new(NitroxEntity.GetId(extinguisher.gameObject), extinguisher.fxIsPlaying);
+            packetSender.Send(packet);
+        }
+        latestRegisteredState[extinguisherId] = extinguisher.fxIsPlaying;
+    }
+
+    public void RemotelyUseFireExtinguisher(FireExtinguisher fireExtinguisher, RemotePlayerIdentifier identifier)
+    {
+        // Code mainly copied from FireExtinguisher.Update() but adapted to only keep the visual part
+        bool usedThisFrame = remotelyUsedFireExtinguishers.ContainsValue(fireExtinguisher);
+
+        int num = identifier.RemotePlayer.AnimationController["is_underwater"] ? 1 : 0;
+        if (num != fireExtinguisher.lastUnderwaterValue)
+        {
+            fireExtinguisher.lastUnderwaterValue = num;
+            if (fireExtinguisher.fmodIndexInWater < 0)
+            {
+                fireExtinguisher.fmodIndexInWater = fireExtinguisher.soundEmitter.GetParameterIndex("in_water");
+            }
+            fireExtinguisher.soundEmitter.SetParameterValue(fireExtinguisher.fmodIndexInWater, num);
+        }
+
+        // Equivalent of UpdateTarget but with references to the remote player
+        fireExtinguisher.fireTarget = null;
+        Vector3 vector = default;
+        GameObject gameObject = null;
+        UWE.Utils.TraceFPSTargetPosition(identifier.gameObject, 8f, ref gameObject, ref vector, true);
+        if (gameObject)
+        {
+            Fire componentInHierarchy = UWE.Utils.GetComponentInHierarchy<Fire>(gameObject);
+            if (componentInHierarchy)
+            {
+                fireExtinguisher.fireTarget = componentInHierarchy;
+            }
+        }
+        //
+
+        if (usedThisFrame)
+        {
+            // Equivalent of FireExtinguisher.UseExtinguisher() but only the FX part
+            if (fireExtinguisher.fxControl && !fireExtinguisher.fxIsPlaying)
+            {
+                fireExtinguisher.fxControl.Play(0);
+                fireExtinguisher.fxIsPlaying = true;
+            }
+            //
+            fireExtinguisher.soundEmitter.Play();
+        }
+        else
+        {
+            fireExtinguisher.soundEmitter.Stop();
+            if (fireExtinguisher.fxControl)
+            {
+                fireExtinguisher.fxControl.Stop(0);
+                fireExtinguisher.fxIsPlaying = false;
+            }
+        }
+
+        fireExtinguisher.UpdateImpactFX();
+    }
+}

--- a/NitroxModel/Packets/FireExtinguisherUse.cs
+++ b/NitroxModel/Packets/FireExtinguisherUse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using NitroxModel.DataStructures;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class FireExtinguisherUse : Packet
+{
+    public NitroxId ItemId { get; }
+    public bool Activated { get; }
+
+    public FireExtinguisherUse(NitroxId itemId, bool activated)
+    {
+        ItemId = itemId;
+        Activated = activated;
+    }
+}

--- a/NitroxModel/Packets/FireExtinguisherUse.cs
+++ b/NitroxModel/Packets/FireExtinguisherUse.cs
@@ -1,5 +1,5 @@
-﻿using System;
 using NitroxModel.DataStructures;
+using System;
 
 namespace NitroxModel.Packets;
 

--- a/NitroxPatcher/Patches/Dynamic/FireExtinguisher_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FireExtinguisher_Update_Patch.cs
@@ -1,14 +1,13 @@
-﻿using System.Reflection;
-using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.PlayerLogic;
-using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures;
 using NitroxModel.Helper;
+using System.Reflection;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
-public class FireExtinguisher_Update_Patch : NitroxPatch, IDynamicPatch
+public sealed partial class FireExtinguisher_Update_Patch : NitroxPatch, IDynamicPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((FireExtinguisher t) => t.Update());
 
@@ -32,14 +31,9 @@ public class FireExtinguisher_Update_Patch : NitroxPatch, IDynamicPatch
     public static void Postfix(FireExtinguisher __instance)
     {
         if (!__instance.transform.TryGetComponentInAscendance(2, out RemotePlayerIdentifier _) &&
-            NitroxEntity.TryGetEntityFrom(__instance.gameObject, out NitroxEntity entity))
+            __instance.TryGetNitroxId(out NitroxId extinguisherId))
         {
-            Resolve<FireExtinguisherManager>().BroadcastFireExtinguisherState(entity.Id, __instance);
+            Resolve<FireExtinguisherManager>().BroadcastFireExtinguisherState(extinguisherId, __instance);
         }
-    }
-
-    public override void Patch(Harmony harmony)
-    {
-        PatchMultiple(harmony, TARGET_METHOD, prefix: true, postfix: true);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FireExtinguisher_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FireExtinguisher_Update_Patch.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.PlayerLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class FireExtinguisher_Update_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((FireExtinguisher t) => t.Update());
+
+    /// <summary>
+    /// Cancel the Update() method of remote players' FireExtinguishers, and move their code to another place
+    /// </summary>
+    public static bool Prefix(FireExtinguisher __instance)
+    {
+        // Only for remote players' fire extinguishers
+        if (__instance.transform.TryGetComponentInAscendance(12, out RemotePlayerIdentifier identifier))
+        {
+            Resolve<FireExtinguisherManager>().RemotelyUseFireExtinguisher(__instance, identifier);
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Notice other players that LocalPlyaer is starting/stopping to use a fire extinguisher
+    /// </summary>
+    public static void Postfix(FireExtinguisher __instance)
+    {
+        if (!__instance.transform.TryGetComponentInAscendance(2, out RemotePlayerIdentifier _) &&
+            NitroxEntity.TryGetEntityFrom(__instance.gameObject, out NitroxEntity entity))
+        {
+            Resolve<FireExtinguisherManager>().BroadcastFireExtinguisherState(entity.Id, __instance);
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchMultiple(harmony, TARGET_METHOD, prefix: true, postfix: true);
+    }
+}


### PR DESCRIPTION
Only issue is player rotation. On the local player, we are able to turn around as much as we want and spray the fire extinguisher everywhere. But remote players don't have this rotation thing. They can only rotate to the lower side (a little angle is possible only). So we'll always see the extinguisher facing downwards.

EDIT: The fix is to only rotate the FX

~~And this branch is built on #1878~~

https://youtu.be/LyenVi8g9fk

To be reviewed and looked at after #2012