### PR TITLE
Fix duplicated items on death

### DIFF
--- a/Nitrox.Test/Patcher/Patches/Dynamic/Inventory_LoseItems_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/Inventory_LoseItems_PatchTest.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxTest.Patcher;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+[TestClass]
+public class Inventory_LoseItems_PatchTest
+{
+    [TestMethod]
+    public void Sanity()
+    {
+        List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
+        instructions.Add(new CodeInstruction(Inventory_LoseItems_Patch.INJECTION_OPCODE, Inventory_LoseItems_Patch.INJECTION_OPERAND));
+
+        IEnumerable<CodeInstruction> result = Inventory_LoseItems_Patch.Transpiler(null, instructions);
+        Assert.AreEqual(instructions.Count, result.Count());
+    }
+
+    [TestMethod]
+    public void InjectionSanity()
+    {
+        IEnumerable<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(Inventory_LoseItems_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> result = Inventory_LoseItems_Patch.Transpiler(Inventory_LoseItems_Patch.TARGET_METHOD, beforeInstructions);
+
+        Assert.IsTrue(beforeInstructions.Count() > result.Count());
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class Inventory_LoseItems_Patch : NitroxPatch, IDynamicPatch
+{
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((Inventory t) => t.LoseItems());
+
+    internal static readonly OpCode INJECTION_OPCODE = OpCodes.Call;
+    internal static readonly object INJECTION_OPERAND = Reflect.Method((Inventory t) => t.InternalDropItem(default, default));
+
+    public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codeInstructions = new(instructions);
+        for (int i = 0; i < codeInstructions.Count; i++)
+        {
+            CodeInstruction instruction = codeInstructions[i];
+            /* if (this.InternalDropItem(list[i].item, false))
+             * becomes:
+             * if (Inventory_LoseItems_Patch.DropAndDeleteItem(list[i].item))
+             */
+
+            // Clear some useless lines
+            if (instruction.opcode.Equals(OpCodes.Ldarg_0) &&
+                codeInstructions[i + 1].opcode.Equals(OpCodes.Ldloc_0) &&
+                codeInstructions[i - 1].opcode.Equals(OpCodes.Br))
+            {
+                // We still need to transfer these labels to the following instruction
+                codeInstructions[i + 1].labels.AddRange(instruction.labels);
+                continue;
+            }
+            if (instruction.opcode.Equals(OpCodes.Ldc_I4_0) &&
+                codeInstructions[i + 1].opcode.Equals(OpCodes.Call) &&
+                codeInstructions[i - 1].opcode.Equals(OpCodes.Callvirt))
+            {
+                continue;
+            }
+
+            // And modify the call instruction
+            if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
+            {
+                instruction.operand = Reflect.Method(() => DropAndDeleteItem(default));
+            }
+            yield return instruction;
+        }
+    }
+
+    public static bool DropAndDeleteItem(Pickupable pickupable)
+    {
+        if (Inventory.CanDropItemHere(pickupable, false))
+        {
+            // Here limit the part that spreads the stuff around by deactivating the rigidbody (for when we drop them)
+            pickupable.Drop(pickupable.transform.position, default, false);
+            // And we destroy the item to make sure that it won't stay after the zone unloads
+            UnityEngine.Object.Destroy(pickupable.gameObject);
+            return true;
+        }
+        return false;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchTranspiler(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
@@ -1,25 +1,23 @@
 ﻿using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
-using NitroxModel.Core;
 using NitroxModel.Helper;
 using UnityEngine;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class Pickupable_Drop_Patch : NitroxPatch, IDynamicPatch
 {
-    public class Pickupable_Drop_Patch : NitroxPatch, IDynamicPatch
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Pickupable t) => t.Drop(default, default, default));
+
+    public static void Postfix(Pickupable __instance, Vector3 dropPosition)
     {
-        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Pickupable t) => t.Drop(default(Vector3), default(Vector3), default(bool)));
+        Resolve<Item>().Dropped(__instance.gameObject, __instance.GetTechType(), dropPosition);
+    }
 
-        public static void Postfix(Pickupable __instance, Vector3 dropPosition)
-        {
-            NitroxServiceLocator.LocateService<Item>().Dropped(__instance.gameObject, __instance.GetTechType(), dropPosition);
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchPostfix(harmony, TARGET_METHOD);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
     }
 }
 


### PR DESCRIPTION
What the fix does is we delete the dropped items after they have sent a packet to the server.
Consequently, when we'll get back to the death place, we'll ONLY get the loaded items and not those that were left there by the drop instruction.

Fixes #1841 

To test this:
- just take two players (in survival possibly) and go a bit further than the lifepod.
- Clear your inventory on both players (so that you don't have overflowing stuff in your hands).
- Have one player gather some ores and take a screenshot of the inventory's contents when you're done
- Use /kill with the player that has the ores, WHILE the second player is watching so that he can acknowledge that the ores are dropped when he dies.
- Use /back with the player who died and notice that the ores are not duplicated.
> NB: We use ores in this example because they're an item that is not destroyed when you die with it (some items do be destroyed on death)