### PR TITLE
Bump assembly version to v1.7.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project InitialTargets="PrepareForModding">
     <!-- Set default properties for all projects (can be overridden per project) -->
     <PropertyGroup>
-        <Version>1.6.0.1</Version>
+        <Version>1.7.0.0</Version>
         <LangVersion>10</LangVersion>
         <TestLibrary>false</TestLibrary>
         <NitroxLibrary>false</NitroxLibrary>

--- a/NitroxServer/Serialization/World/WorldManager.cs
+++ b/NitroxServer/Serialization/World/WorldManager.cs
@@ -69,7 +69,7 @@ public static class WorldManager
                 }
 
                 // Change the paramaters here to define what save file versions are eligible for use/upgrade
-                bool isValidVersion = version >= new Version(1, 6, 0, 1) && version <= NitroxEnvironment.Version;
+                bool isValidVersion = version >= new Version(1, 7, 0, 0) && version <= NitroxEnvironment.Version;
 
                 savesCache.Add(new Listing
                 {


### PR DESCRIPTION
- Bumped version to v1.7.0.0
- Bumped minimum save file version allowed to v1.7.0.0 (since saves from v1.6.0.1 and under are not supported anymore)