### PR TITLE
Removed PrepareForModding target from InitialTargets attr so that restore can happen

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project InitialTargets="PrepareForModding">
+<Project>
     <!-- Set default properties for all projects (can be overridden per project) -->
     <PropertyGroup>
         <Version>1.7.0.0</Version>


### PR DESCRIPTION
Steps to test (at least when using Rider IDE):
1. `git clean -xdf`
2. `dotnet restore`: throws error that says to run `Nitrox.BuildTool`
3. Try to run `Nitrox.BuildTool`: throws errors that it's missing nuget packages
4. Back to step 2..