### PR TITLE
Re-enable Windows 7 support for NitroxLauncher

### DIFF
--- a/NitroxLauncher/App.xaml
+++ b/NitroxLauncher/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ap="clr-namespace:NitroxLauncher.Models.Properties"
-             xmlns:pages="clr-namespace:NitroxLauncher.Pages" xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2"
+             xmlns:pages="clr-namespace:NitroxLauncher.Pages" xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero"
              xmlns:converters="clr-namespace:NitroxLauncher.Models.Converters"
              StartupUri="MainWindow.xaml" DispatcherUnhandledException="Application_DispatcherUnhandledException">
 

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -34,7 +34,7 @@
 
     <ItemGroup>
       <Reference Include="Microsoft.VisualBasic" />
-      <Reference Include="PresentationFramework.Aero2" />
+      <Reference Include="PresentationFramework.Aero" />
     </ItemGroup>
     
     <!-- Move assets from Subnautica assets to launcher.

--- a/NitroxLauncher/Pages/ServerPage.xaml
+++ b/NitroxLauncher/Pages/ServerPage.xaml
@@ -8,7 +8,7 @@
                 d:DesignHeight="650" d:DesignWidth="750"
                 DataContext="{Binding RelativeSource={RelativeSource Self}}"
                 Title="Server Page" xmlns:pages="clr-namespace:NitroxLauncher.Pages"
-                xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2">
+                xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero">
 
     <local:PageBase.Resources>
         <BitmapImage x:Key="ServerIllustration" UriSource="pack://application:,,,/Assets/Images/serverIllustration.png"/>


### PR DESCRIPTION
Re-enable Windows 7 support for NitroxLauncher by replacing the PresentationFramework.Aero2 references with PresentationFramework.Aero.