### PR TITLE
Several stabilization changes to get us closer to a playable build, including:

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/CellEntitiesProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CellEntitiesProcessor.cs
@@ -1,6 +1,7 @@
-﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel.Packets;
+using UWE;
 
 namespace NitroxClient.Communication.Packets.Processors
 {
@@ -15,7 +16,7 @@ namespace NitroxClient.Communication.Packets.Processors
 
         public override void Process(CellEntities packet)
         {
-            entities.SpawnAsync(packet.Entities);
+            CoroutineHost.StartCoroutine(entities.SpawnAsync(packet.Entities));
         }
     }
 }

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.Spawning;
@@ -79,15 +79,7 @@ namespace NitroxClient.GameLogic
                 }
                 else
                 {
-                    Optional<GameObject> parent = null;
-                    try
-                    {
-                        parent = NitroxEntity.GetObjectFrom(entity.ParentId);
-                    }
-                    catch (OptionalEmptyException<GameObject> e)
-                    {
-                        Log.Error($"Failed to get Entity {entity.Id}, a {entity.TechType}: {e.Message}");
-                    }
+                    Optional<GameObject> parent = NitroxEntity.GetObjectFrom(entity.ParentId);
                     yield return SpawnAsync(entity, parent);
                     yield return SpawnAnyPendingChildrenAsync(entity);
                 }

--- a/NitroxClient/GameLogic/HUD/Components/uGUI_PlayerPingEntry.cs
+++ b/NitroxClient/GameLogic/HUD/Components/uGUI_PlayerPingEntry.cs
@@ -74,7 +74,6 @@ public class uGUI_PlayerPingEntry : uGUI_PingEntry
         this.parent = parent;
 
         gameObject.SetActive(true);
-        visibility.isOn = true;
         visibilityIcon.sprite = spriteVisible;
         icon.SetForegroundSprite(SpriteManager.Get(SpriteManager.Group.Tab, "TabInventory"));
         showPing = true;

--- a/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
@@ -38,8 +38,10 @@ public class uGUI_PlayerListTab : uGUI_PingTab
         packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
         // Need to reassign manually these variables and get rid of the objects we don't need
         content = gameObject.FindChild("Content").GetComponent<CanvasGroup>();
-        pingManagerLabel = gameObject.FindChild("PingManagerLabel").GetComponent<TextMeshProUGUI>();
+        pingManagerLabel = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+        scrollRect = gameObject.GetComponentInChildren<ScrollRect>();
         pingCanvas = (RectTransform)content.transform.Find("ScrollView/Viewport/ScrollCanvas");
+
         pool = new PrefabPool<uGUI_PlayerPingEntry>(prefabEntry, pingCanvas, 8, 4, delegate (uGUI_PlayerPingEntry entry)
         {
             entry.Uninitialize();

--- a/NitroxClient/GameLogic/HUD/PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PlayerListTab.cs
@@ -27,10 +27,12 @@ public class PlayerListTab : NitroxPDATab
         GameObject tabCopy = GameObject.Instantiate(pingTabObject, pdaScreen.transform.Find("Content"));
         tabCopy.name = "PlayerListTab";
 
-        // We add a uGUI_PlayerListTab instead of a uGUI_PingTab
+        // Set the tab inactive to suppress the uGUI_PlayerListTab awake().  We first need to set the 
+        // prefab, which is used inside the awake method and the base class awake method.
+        tabCopy.SetActive(false);
         uGUI_PlayerListTab newTab = tabCopy.AddComponent<uGUI_PlayerListTab>();
         newTab.MakePrefab(pingTab.prefabEntry);
-        GameObject.Destroy(tabCopy.GetComponent<uGUI_PingTab>());
+        tabCopy.SetActive(true);
 
         tab = newTab;
     }

--- a/NitroxClient/GameLogic/Helper/InventoryContainerHelper.cs
+++ b/NitroxClient/GameLogic/Helper/InventoryContainerHelper.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
+using NitroxClient.GameLogic.PlayerLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
 using NitroxModel.Core;
@@ -34,7 +35,7 @@ namespace NitroxClient.GameLogic.Helper
             {
                 return Optional.Of(Inventory.Get().container);
             }
-            if (owner.GetComponentInChildren<PingInstance>().GetLabel().StartsWith("Player "))
+            if (owner.GetComponent<RemotePlayerIdentifier>())
             {
                 if (playerManager == null)
                 {

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -72,6 +72,7 @@ public class PlayerModelManager
         signalBase.SetActive(true);
 
         PingInstance ping = signalBase.GetComponent<PingInstance>();
+        ping.Initialize();
         ping.SetLabel($"Player {player.PlayerName}");
         ping.pingType = PingType.Signal;
         // ping will be moved to the player list tab
@@ -85,7 +86,7 @@ public class PlayerModelManager
     {
         PDA localPlayerPda = Player.main.GetPDA();
         GameObject pdaScreenGameObject = localPlayerPda.ui.gameObject;
-        GameObject pingTabGameObject = pdaScreenGameObject.transform.Find("Content/PingManagerTab").gameObject;
+        GameObject pingTabGameObject = pdaScreenGameObject.transform.Find("Content/PingTab").gameObject;
         uGUI_PingTab pingTab = pingTabGameObject.GetComponent<uGUI_PingTab>();
 
         pingTab.UpdateEntries();

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -78,23 +78,7 @@ public class PlayerModelManager
         // ping will be moved to the player list tab
         ping.displayPingInManager = false;
 
-        UpdateLocalPlayerPda();
         SetInGamePingColor(player, ping);
-    }
-
-    private static void UpdateLocalPlayerPda()
-    {
-        PDA localPlayerPda = Player.main.GetPDA();
-        GameObject pdaScreenGameObject = localPlayerPda.ui.gameObject;
-        GameObject pingTabGameObject = pdaScreenGameObject.transform.Find("Content/PingTab").gameObject;
-        uGUI_PingTab pingTab = pingTabGameObject.GetComponent<uGUI_PingTab>();
-
-        pingTab.UpdateEntries();
-
-        if (!localPlayerPda.isInUse)
-        {
-            pdaScreenGameObject.gameObject.SetActive(false);
-        }
     }
 
     private static void SetInGamePingColor(INitroxPlayer player, PingInstance ping)

--- a/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
@@ -57,11 +57,9 @@ namespace NitroxClient.GameLogic.Spawning
 
         IEnumerator CreateGameObject(TechType techType, string classId, TaskResult<GameObject> result)
         {
-            GameObject prefab = null;
-
             IPrefabRequest prefabCoroutine = PrefabDatabase.GetPrefabAsync(classId);
             yield return prefabCoroutine;
-            prefabCoroutine.TryGetPrefab(out prefab);
+            prefabCoroutine.TryGetPrefab(out GameObject prefab);
 
             if (prefab == null)
             {

--- a/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/DefaultEntitySpawner.cs
@@ -58,10 +58,10 @@ namespace NitroxClient.GameLogic.Spawning
         IEnumerator CreateGameObject(TechType techType, string classId, TaskResult<GameObject> result)
         {
             GameObject prefab = null;
-            if (PrefabDatabase.TryGetPrefabFilename(classId, out string filename))
-            {
-                prefab = Resources.Load<GameObject>(filename);
-            }
+
+            IPrefabRequest prefabCoroutine = PrefabDatabase.GetPrefabAsync(classId);
+            yield return prefabCoroutine;
+            prefabCoroutine.TryGetPrefab(out prefab);
 
             if (prefab == null)
             {

--- a/NitroxClient/MonoBehaviours/Gui/HUD/RemotePlayerVitals.cs
+++ b/NitroxClient/MonoBehaviours/Gui/HUD/RemotePlayerVitals.cs
@@ -139,7 +139,7 @@ namespace NitroxClient.MonoBehaviours.Gui.HUD
                     newBar.borderColor = OXYGEN_BAR_BORDER_COLOR;
                     cloned.transform.localPosition = new Vector3(-0.025f, 0.35f, 0f);
                     cloned.name = $"{playerName}'s Oxygen";
-                    cloned.RequireTransform("OxygenTextLabel").localRotation = Quaternion.Euler(0f, 270f, 0f);
+                    cloned.RequireTransform("Icon").localRotation = Quaternion.Euler(0f, 270f, 0f);
                     Destroy(cloned.GetComponent<uGUI_OxygenBar>());
                     cloned.transform.localScale = new Vector3(0.0003f, 0.0003f, 0.0003f);
                     break;

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -211,6 +211,7 @@ public class JoinServer : MonoBehaviour
                 preferencesManager.Save();
 
 #pragma warning disable CS0618 // God Damn it UWE...
+                Multiplayer.SubnauticaLoadingStarted();
                 IEnumerator startNewGame = uGUI_MainMenu.main.StartNewGame(GameMode.Survival);
 #pragma warning restore CS0618 // God damn it UWE...
                 StartCoroutine(startNewGame);

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -38,6 +38,11 @@ namespace NitroxClient.MonoBehaviours
         public static event Action OnBeforeMultiplayerStart;
         public static event Action OnAfterMultiplayerEnd;
 
+        public static void SubnauticaLoadingStarted()
+        {
+            OnBeforeMultiplayerStart?.Invoke();
+        }
+
         public static void SubnauticaLoadingCompleted()
         {
             if (Active)
@@ -116,7 +121,6 @@ namespace NitroxClient.MonoBehaviours
 
         public IEnumerator StartSession()
         {
-            OnBeforeMultiplayerStart?.Invoke();
             yield return StartCoroutine(InitializeLocalPlayerState());
             multiplayerSession.JoinSession();
             InitMonoBehaviours();

--- a/NitroxModel/Logger/Log.cs
+++ b/NitroxModel/Logger/Log.cs
@@ -33,7 +33,8 @@ namespace NitroxModel.Logger
         {
             if (isSetup)
             {
-                throw new Exception($"{nameof(Log)} setup should only be executed once.");
+                Log.Warn($"{nameof(Log)} setup should only be executed once.");
+                return;
             }
             isSetup = true;
             

--- a/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxModel.Helper;
+using UWE;
+
+/// <summary>
+/// Don't allow the game to spawn initial supplies in the escape pod.
+/// </summary>
+namespace NitroxPatcher.Patches.Dynamic
+{
+    public class SpawnEscapePodSupplies_OnNewBorn_Patch : NitroxPatch, IDynamicPatch
+    {
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SpawnEscapePodSupplies t) => t.OnNewBorn());
+
+        public static bool Prefix()
+        {
+            return false;
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            PatchPrefix(harmony, TARGET_METHOD);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
@@ -1,25 +1,23 @@
+namespace NitroxPatcher.Patches.Dynamic;
+
 using System.Reflection;
 using HarmonyLib;
 using NitroxModel.Helper;
-using UWE;
 
 /// <summary>
 /// Don't allow the game to spawn initial supplies in the escape pod.
 /// </summary>
-namespace NitroxPatcher.Patches.Dynamic
+public class SpawnEscapePodSupplies_OnNewBorn_Patch : NitroxPatch, IDynamicPatch
 {
-    public class SpawnEscapePodSupplies_OnNewBorn_Patch : NitroxPatch, IDynamicPatch
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SpawnEscapePodSupplies t) => t.OnNewBorn());
+
+    public static bool Prefix()
     {
-        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SpawnEscapePodSupplies t) => t.OnNewBorn());
+        return false;
+    }
 
-        public static bool Prefix()
-        {
-            return false;
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchPrefix(harmony, TARGET_METHOD);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3238547/209426386-45bfd19c-49ce-4a88-a5ce-d822c7b8b0e6.png)

Entities are mostly spawning - still some slowness in starting chunks though.  It also looks like simulation ownership system is working fine.  This PR does have some benign unauthenticated packets due to moving the dynamic patching location - we can work through these with suppression when we get to them. 

* Changed dynamic patching hook to be earlier on.  This allows patches that require early initialization to function (such as uGUI_PDA)
* Fixed several bugs in entity spawning async transformation
* Fixes to allow users to spawn alongside their remote vitals
* Prevented PDA from erroring out initial syncs with multiple players
* Added a new patch to prevent escape pod supplies from spawning
* Small tweak to logger to only log a warning instead of throwing when attempting to re-initialize.
* Fixed a bug preventing us from finding the remote player's inventory.