### PR TITLE
Fix remote player stuttering/teleporting when standing still or moving.

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/PlayerMovementProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerMovementProcessor.cs
@@ -1,5 +1,8 @@
-﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+﻿using System.Collections;
+using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
 using NitroxModel_Subnautica.DataStructures;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
@@ -18,15 +21,20 @@ public class PlayerMovementProcessor : ClientPacketProcessor<PlayerMovement>
     public override void Process(PlayerMovement movement)
     {
         Optional<RemotePlayer> remotePlayer = remotePlayerManager.Find(movement.PlayerId);
-
-        if (remotePlayer.HasValue)
+        if (!remotePlayer.HasValue)
         {
-            remotePlayer
-                .Value
-                .UpdatePosition(movement.Position.ToUnity(),
-                                movement.Velocity.ToUnity(),
-                                movement.BodyRotation.ToUnity(),
-                                movement.AimingRotation.ToUnity());
+            return;
         }
+
+        Multiplayer.Main.StartCoroutine(QueueForFixedUpdate(remotePlayer.Value, movement));
+    }
+
+    private IEnumerator QueueForFixedUpdate(RemotePlayer player, PlayerMovement movement)
+    {
+        yield return Yielders.WaitForFixedUpdate;
+        player.UpdatePosition(movement.Position.ToUnity(),
+                              movement.Velocity.ToUnity(),
+                              movement.BodyRotation.ToUnity(),
+                              movement.AimingRotation.ToUnity());
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
@@ -44,12 +44,12 @@ namespace NitroxClient.Communication.Packets.Processors
 
         IEnumerator DelayAnimationAndDisablePiloting(Vehicle vehicle, VehicleDockingBay vehicleDockingBay, NitroxId vehicleId, ushort playerId)
         {
-            yield return new WaitForSeconds(1.0f);
+            yield return Yielders.WaitFor1Second;
             // DockVehicle sets the rigid body kinematic of the vehicle to true, we don't want that behaviour
             // Therefore disable kinematic (again) to remove the bouncing behavior
             vehicleDockingBay.DockVehicle(vehicle);
             vehicle.useRigidbody.isKinematic = false;
-            yield return new WaitForSeconds(2.0f);
+            yield return Yielders.WaitFor2Seconds;
             vehicles.SetOnPilotMode(vehicleId, playerId, false);
             if (!vehicle.docked)
             {

--- a/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
@@ -68,7 +68,7 @@ namespace NitroxClient.Communication.Packets.Processors
 
         public IEnumerator StartUndockingAnimation(VehicleDockingBay vehicleDockingBay)
         {
-            yield return new WaitForSeconds(2.0f);
+            yield return Yielders.WaitFor2Seconds;
             vehicleDockingBay.vehicle_docked_param = false;
         }
 

--- a/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
+++ b/NitroxClient/GameLogic/Bases/Spawning/BasePiece/BasePieceSpawnProcessor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NitroxClient.MonoBehaviours;
+using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures;
 using UnityEngine;
 
@@ -84,7 +85,7 @@ namespace NitroxClient.GameLogic.Bases.Spawning.BasePiece
             {
                 yield break;
             }
-            yield return new WaitForSeconds(0.1f);
+            yield return Yielders.WaitFor100Milliseconds;
             if (!latestBase || !finishedPiece)
             {
                 // Happens that multiple delayed coroutine will be there at the same time so we just stop minding about them to let the newer do their job

--- a/NitroxClient/GameLogic/Cyclops.cs
+++ b/NitroxClient/GameLogic/Cyclops.cs
@@ -299,14 +299,13 @@ namespace NitroxClient.GameLogic
         private IEnumerator StartFireSuppressionSystem(SubFire fire)
         {
             fire.subRoot.voiceNotificationManager.PlayVoiceNotification(fire.subRoot.fireSupressionNotification, false, true);
-            yield return new WaitForSeconds(3f);
+            yield return Yielders.WaitFor3Seconds;
             fire.fireSuppressionActive = true;
             fire.subRoot.fireSuppressionState = true;
             fire.subRoot.BroadcastMessage("NewAlarmState", null, SendMessageOptions.DontRequireReceiver);
             fire.Invoke(nameof(SubFire.CancelFireSuppression), fire.fireSuppressionSystemDuration);
             float doorCloseDuration = 30f;
             fire.gameObject.BroadcastMessage("TemporaryLock", doorCloseDuration, SendMessageOptions.DontRequireReceiver);
-            yield break;
         }
 
 

--- a/NitroxClient/GameLogic/InitialSync/PlayerPreferencesInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPreferencesInitialSyncProcessor.cs
@@ -139,7 +139,7 @@ public class PlayerPreferencesInitialSyncProcessor : InitialSyncProcessor
 
     private static IEnumerator DelayPingKeyDetection(Action delayedAction)
     {
-        yield return new WaitForSeconds(0.5f);
+        yield return Yielders.WaitForHalfSecond;
         delayedAction();
     }
 }

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -47,7 +47,7 @@ namespace NitroxClient.GameLogic
             Permissions = Perms.PLAYER;
         }
 
-        public void UpdateLocation(Vector3 location, Vector3 velocity, Quaternion bodyRotation, Quaternion aimingRotation, Optional<VehicleMovementData> vehicle)
+        public void BroadcastLocation(Vector3 location, Vector3 velocity, Quaternion bodyRotation, Quaternion aimingRotation, Optional<VehicleMovementData> vehicle)
         {
             Movement movement;
             if (vehicle.HasValue)

--- a/NitroxClient/GameLogic/MovementHelper.cs
+++ b/NitroxClient/GameLogic/MovementHelper.cs
@@ -31,7 +31,7 @@ namespace NitroxClient.GameLogic
 
         public static Vector3 GetCorrectedVelocity(Vector3 remotePosition, Vector3 remoteVelocity, GameObject gameObject, float correctionTime)
         {
-            Vector3 difference = (remotePosition - gameObject.transform.position);
+            Vector3 difference = remotePosition - gameObject.transform.position;
             Vector3 velocityToMakeUpDifference = difference / correctionTime;
 
             float distance = difference.magnitude;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -126,8 +126,8 @@ namespace NitroxClient.GameLogic
                 bodyRotation = vehicleAngle * bodyRotation;
                 aimingRotation = vehicleAngle * aimingRotation;
             }
-            RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, Time.fixedDeltaTime);
-            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, Time.fixedDeltaTime);
+            RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, Time.fixedDeltaTime * (PlayerMovementBroadcaster.LOCATION_BROADCAST_TICK_SKIPS + 1));
+            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, Time.fixedDeltaTime * (PlayerMovementBroadcaster.LOCATION_BROADCAST_TICK_SKIPS + 1));
 
             AnimationController.AimingRotation = aimingRotation;
             AnimationController.UpdatePlayerAnimations = true;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -126,8 +126,8 @@ namespace NitroxClient.GameLogic
                 bodyRotation = vehicleAngle * bodyRotation;
                 aimingRotation = vehicleAngle * aimingRotation;
             }
-            RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovementBroadcaster.BROADCAST_INTERVAL);
-            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovementBroadcaster.BROADCAST_INTERVAL);
+            RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, Time.fixedDeltaTime);
+            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, Time.fixedDeltaTime);
 
             AnimationController.AimingRotation = aimingRotation;
             AnimationController.UpdatePlayerAnimations = true;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -55,6 +55,7 @@ namespace NitroxClient.GameLogic
 
             RigidBody = Body.AddComponent<Rigidbody>();
             RigidBody.useGravity = false;
+            RigidBody.interpolation = RigidbodyInterpolation.Interpolate;
 
             NitroxEntity.SetNewId(Body, playerContext.PlayerNitroxId);
 

--- a/NitroxClient/GameLogic/Terrain.cs
+++ b/NitroxClient/GameLogic/Terrain.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.Map;
+using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using NitroxModel_Subnautica.DataStructures;
@@ -37,7 +38,7 @@ namespace NitroxClient.GameLogic
 
         private IEnumerator WaitAndAddCell(Int3 batchId, Int3 cellId, int level)
         {
-            yield return new WaitForSeconds(0.5f);
+            yield return Yielders.WaitForHalfSecond;
 
             AbsoluteEntityCell cell = new AbsoluteEntityCell(batchId.ToDto(), cellId.ToDto(), level);
 
@@ -91,7 +92,7 @@ namespace NitroxClient.GameLogic
                     yield break;
                 }
 
-                yield return new WaitForSeconds(0.05f);
+                yield return null;
             }
         }
 

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -475,7 +475,7 @@ namespace NitroxClient.GameLogic
         */
         public IEnumerator AllowMovementPacketsAfterDockingAnimation(PacketSuppressor<PlayerMovement> playerMovementSuppressor, PacketSuppressor<VehicleMovement> vehicleMovementSuppressor)
         {
-            yield return new WaitForSeconds(3.0f);
+            yield return Yielders.WaitFor3Seconds;
             playerMovementSuppressor.Dispose();
             vehicleMovementSuppressor.Dispose();
         }

--- a/NitroxClient/MonoBehaviours/Discord/DiscordJoinRequestGui.cs
+++ b/NitroxClient/MonoBehaviours/Discord/DiscordJoinRequestGui.cs
@@ -9,7 +9,7 @@ namespace NitroxClient.MonoBehaviours.Discord;
 
 public class DiscordJoinRequestGui : uGUI_InputGroup
 {
-    private const int EXPIRE_TIME = 45;
+    private readonly WaitForSeconds expireTimeYielder = new(45);
 
     private static DiscordJoinRequestGui instance;
     private static User user;
@@ -98,7 +98,7 @@ public class DiscordJoinRequestGui : uGUI_InputGroup
 
     private IEnumerator OnRequestExpired()
     {
-        yield return new WaitForSeconds(EXPIRE_TIME);
+        yield return expireTimeYielder;
         CloseWindow(ActivityJoinRequestReply.Ignore);
     }
 }

--- a/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChat.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChat.cs
@@ -131,7 +131,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
                 while (canvasGroup.alpha < 1f)
                 {
                     canvasGroup.alpha += 0.01f;
-                    yield return new WaitForSeconds(0.0005f);
+                    yield return null;
                 }
             }
             else
@@ -139,7 +139,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
                 while (canvasGroup.alpha > 0f)
                 {
                     canvasGroup.alpha -= 0.01f;
-                    yield return new WaitForSeconds(0.005f);
+                    yield return null;
                 }
             }
         }

--- a/NitroxClient/MonoBehaviours/MultiplayerVehicleControl.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerVehicleControl.cs
@@ -39,10 +39,10 @@ namespace NitroxClient.MonoBehaviours
             SmoothPosition.FixedUpdate();
             SmoothVelocity.FixedUpdate();
             rigidbody.isKinematic = false; // we should maybe find a way to remove UWE's FreezeRigidBodyWhenFar component...tried removing it but caused a bunch of issues.
-            rigidbody.velocity = MovementHelper.GetCorrectedVelocity(SmoothPosition.Current, SmoothVelocity.Current, gameObject, PlayerMovementBroadcaster.BROADCAST_INTERVAL);
+            rigidbody.velocity = MovementHelper.GetCorrectedVelocity(SmoothPosition.Current, SmoothVelocity.Current, gameObject, Time.fixedDeltaTime);
             SmoothRotation.FixedUpdate();
             SmoothAngularVelocity.FixedUpdate();
-            rigidbody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(SmoothRotation.Current, SmoothAngularVelocity.Current, gameObject, PlayerMovementBroadcaster.BROADCAST_INTERVAL);
+            rigidbody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(SmoothRotation.Current, SmoothAngularVelocity.Current, gameObject, Time.fixedDeltaTime);
             
             WheelYawSetter(SmoothYaw.SmoothValue);
             WheelPitchSetter(SmoothPitch.SmoothValue);

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -18,7 +18,7 @@ public class PlayerMovementBroadcaster : MonoBehaviour
     public const int LOCATION_BROADCAST_TICK_SKIPS = 1;
 
     private LocalPlayer localPlayer;
-    private int locationBroadcastSkipCounter;
+    private int locationBroadcastSkipThreshold = LOCATION_BROADCAST_TICK_SKIPS;
 
     public void Awake()
     {
@@ -28,12 +28,12 @@ public class PlayerMovementBroadcaster : MonoBehaviour
     public void FixedUpdate()
     {
         // Throttle location broadcasts to not run on every physics tick.
-        if (locationBroadcastSkipCounter++ < LOCATION_BROADCAST_TICK_SKIPS)
+        if (locationBroadcastSkipThreshold-- > 0)
         {
             return;
         }
-        // Reset counter.
-        locationBroadcastSkipCounter = 0;
+        // Reset skip threshold.
+        locationBroadcastSkipThreshold = LOCATION_BROADCAST_TICK_SKIPS;
 
         // Freecam does disable main camera control
         // But it's also disabled when driving the cyclops through a cyclops camera (content.activeSelf is only true when controlling through a cyclops camera)

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -28,8 +28,7 @@ public class PlayerMovementBroadcaster : MonoBehaviour
     public void FixedUpdate()
     {
         // Throttle location broadcasts to not run on every physics tick.
-        locationBroadcastSkipCounter++;
-        if (locationBroadcastSkipCounter < LOCATION_BROADCAST_TICK_SKIPS)
+        if (locationBroadcastSkipCounter++ < LOCATION_BROADCAST_TICK_SKIPS)
         {
             return;
         }

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -11,7 +11,14 @@ namespace NitroxClient.MonoBehaviours;
 
 public class PlayerMovementBroadcaster : MonoBehaviour
 {
+    /// <summary>
+    ///     Amount of physics updates to skip for sending location broadcasts.
+    ///     TODO: Allow servers to set this value for clients. With many clients connected to the server, a higher value can be preferred.
+    /// </summary>
+    public const int LOCATION_BROADCAST_TICK_SKIPS = 1;
+
     private LocalPlayer localPlayer;
+    private int locationBroadcastSkipCounter;
 
     public void Awake()
     {
@@ -20,6 +27,15 @@ public class PlayerMovementBroadcaster : MonoBehaviour
 
     public void FixedUpdate()
     {
+        // Throttle location broadcasts to not run on every physics tick.
+        locationBroadcastSkipCounter++;
+        if (locationBroadcastSkipCounter < LOCATION_BROADCAST_TICK_SKIPS)
+        {
+            return;
+        }
+        // Reset counter.
+        locationBroadcastSkipCounter = 0;
+
         // Freecam does disable main camera control
         // But it's also disabled when driving the cyclops through a cyclops camera (content.activeSelf is only true when controlling through a cyclops camera)
         if (!MainCameraControl.main.isActiveAndEnabled &&
@@ -55,7 +71,7 @@ public class PlayerMovementBroadcaster : MonoBehaviour
             }
         }
 
-        localPlayer.UpdateLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation, vehicle);
+        localPlayer.BroadcastLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation, vehicle);
     }
 
     private Optional<VehicleMovementData> GetVehicleMovement()

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -11,7 +11,7 @@ namespace NitroxClient.MonoBehaviours;
 
 public class PlayerMovementBroadcaster : MonoBehaviour
 {
-    public const float BROADCAST_INTERVAL = 0.05f;
+    public const float BROADCAST_INTERVAL = 0.12f;
     private LocalPlayer localPlayer;
 
     private float time;

--- a/NitroxClient/Unity/Helper/Yielders.cs
+++ b/NitroxClient/Unity/Helper/Yielders.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace NitroxClient.Unity.Helper;
+
+/// <summary>
+///     Cache for yields in IEnumeration to reduce GC pressure.
+/// </summary>
+public static class Yielders
+{
+    public static readonly WaitForFixedUpdate WaitForFixedUpdate = new();
+    public static readonly WaitForSeconds WaitForHalfSecond = new(.5f);
+    public static readonly WaitForSeconds WaitFor100Milliseconds = new(.1f);
+    public static readonly WaitForSeconds WaitFor1Second = new(1);
+    public static readonly WaitForSeconds WaitFor2Seconds = new(2);
+    public static readonly WaitForSeconds WaitFor3Seconds = new(3);
+}
+

--- a/NitroxClient/Unity/Helper/Yielders.cs
+++ b/NitroxClient/Unity/Helper/Yielders.cs
@@ -8,8 +8,8 @@ namespace NitroxClient.Unity.Helper;
 public static class Yielders
 {
     public static readonly WaitForFixedUpdate WaitForFixedUpdate = new();
-    public static readonly WaitForSeconds WaitForHalfSecond = new(.5f);
     public static readonly WaitForSeconds WaitFor100Milliseconds = new(.1f);
+    public static readonly WaitForSeconds WaitForHalfSecond = new(.5f);
     public static readonly WaitForSeconds WaitFor1Second = new(1);
     public static readonly WaitForSeconds WaitFor2Seconds = new(2);
     public static readonly WaitForSeconds WaitFor3Seconds = new(3);

--- a/NitroxPatcher/Patches/Dynamic/PDAScanner_Scan_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAScanner_Scan_Patch.cs
@@ -64,6 +64,7 @@ namespace NitroxPatcher.Patches.Dynamic
         // Both in milliseconds
         public const int PACKET_SENDING_RATE = 500;
         public const int LAST_PACKET_SEND_DELAY = 2000;
+        private static readonly WaitForSeconds lastPacketSendDelay = new(LAST_PACKET_SEND_DELAY / 1000f);
 
         public static readonly PDAManagerEntry PDAManagerEntry = NitroxServiceLocator.LocateService<PDAManagerEntry>();
         public static Dictionary<NitroxId, ThrottledEntry> ThrottlingEntries = new Dictionary<NitroxId, ThrottledEntry>();
@@ -124,7 +125,7 @@ namespace NitroxPatcher.Patches.Dynamic
         {
             do
             {
-                yield return new WaitForSeconds(LAST_PACKET_SEND_DELAY / 1000);
+                yield return lastPacketSendDelay;
             }
             while (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() < throttledEntry.LatestProgressTime.ToUnixTimeMilliseconds() + LAST_PACKET_SEND_DELAY);
             


### PR DESCRIPTION
Nitrox uses a velocity-based system to update remote player locations.  This provides a fluid movement and doesn't incur large costs associated with setting the transform position over and over.  However, with the recent Subnautica update, it appears that we update the velocity too quickly.  Movement updates don't appear to apply velocity for multiple packets then cause the player to over correct.  It is likely that Nitrox is applying velocity updates too frequently for the physics engine to react (0.05s). 

In this PR, I've updated the frequency of movement packets to 0.12s.  This caused normal movement behavior; however, not very smooth.  To counteract this, I also enabled some interpolation to bring back the smoothness.  We can play with these a bit more; however, this configuration looks about the same as the last update to me.  

This change also has the added benefit of significantly reducing the amount of packets that Nitrox sends.