### PR TITLE
Fixed dispose of assemblies loaded via asset parsing on server

### DIFF
--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -12,12 +12,12 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using NitroxModel_Subnautica.DataStructures.GameLogic;
 using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel.Platforms.OS.Shared;
-using NitroxModel_Subnautica.DataStructures.GameLogic;
 using NitroxServer;
 using NitroxServer.ConsoleCommands.Processor;
 using NitroxServer.GameLogic.Vehicles;
@@ -213,6 +213,11 @@ public class Program
         {
             dllFileName += ".dll";
         }
+        // If available, return cached assembly
+        if (resolvedAssemblyCache.TryGetValue(dllFileName, out Assembly val))
+        {
+            return val;
+        }
 
         // Load DLLs where this program (exe) is located
         string dllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? "", "lib", dllFileName);
@@ -223,14 +228,9 @@ public class Program
             dllPath = Path.Combine(gameInstallDir.Value, "Subnautica_Data", "Managed", dllFileName);
         }
 
-        // If available, return cached assembly
-        if (resolvedAssemblyCache.TryGetValue(dllPath, out Assembly val))
-        {
-            return val;
-        }
         // Read assemblies as bytes as to not lock the file so that Nitrox can patch assemblies while server is running.
         Assembly assembly = Assembly.Load(File.ReadAllBytes(dllPath));
-        return resolvedAssemblyCache[dllPath] = assembly;
+        return resolvedAssemblyCache[dllFileName] = assembly;
     }
 
     /**

--- a/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
@@ -10,7 +10,7 @@ public abstract class AssetParser
     protected static readonly string rootPath;
     protected static readonly AssetsManager assetsManager;
     
-    private static readonly MonoCecilTempGenerator monoGenerator;
+    private static readonly ThreadSafeMonoCecilTempGenerator monoGen;
 
     static AssetParser()
     {
@@ -18,16 +18,12 @@ public abstract class AssetParser
         assetsManager = new AssetsManager();
         assetsManager.LoadClassPackage("classdata.tpk");
         assetsManager.LoadClassDatabaseFromPackage("2019.4.36f1");
-        monoGenerator = new MonoCecilTempGenerator(Path.Combine(rootPath, "Managed"));
-        assetsManager.SetMonoTempGenerator(monoGenerator);
+        assetsManager.SetMonoTempGenerator(monoGen = new ThreadSafeMonoCecilTempGenerator(Path.Combine(rootPath, "Managed")));
     }
 
     public static void Dispose()
     {
         assetsManager.UnloadAll(true);
-        foreach (KeyValuePair<string,AssemblyDefinition> pair in monoGenerator.loadedAssemblies)
-        {
-            pair.Value.Dispose();
-        }
+        monoGen.Dispose();
     }
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using AssetsTools.NET.Extra;
-using Mono.Cecil;
+using NitroxServer_Subnautica.Resources.Parsers.Helper;
 
 namespace NitroxServer_Subnautica.Resources.Parsers;
 
@@ -9,7 +8,7 @@ public abstract class AssetParser
 {
     protected static readonly string rootPath;
     protected static readonly AssetsManager assetsManager;
-    
+
     private static readonly ThreadSafeMonoCecilTempGenerator monoGen;
 
     static AssetParser()

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsBundleManager.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsBundleManager.cs
@@ -7,7 +7,7 @@ namespace NitroxServer_Subnautica.Resources.Parsers.Helper;
 
 public class AssetsBundleManager : AssetsManager
 {
-    public MonoCecilTempGenerator monoTempGenerator;
+    private ThreadSafeMonoCecilTempGenerator monoTempGenerator;
     private readonly string aaRootPath;
     private readonly Dictionary<AssetsFileInstance, string[]> dependenciesByAssetFileInst = new();
 
@@ -109,7 +109,7 @@ public class AssetsBundleManager : AssetsManager
 
     public new void SetMonoTempGenerator(IMonoBehaviourTemplateGenerator generator)
     {
-        monoTempGenerator = (MonoCecilTempGenerator)generator;
+        monoTempGenerator = (ThreadSafeMonoCecilTempGenerator)generator;
         base.SetMonoTempGenerator(generator);
     }
     /// <summary>
@@ -129,7 +129,11 @@ public class AssetsBundleManager : AssetsManager
     /// <inheritdoc cref="AssetsManager.UnloadAll"/>
     public new void UnloadAll(bool unloadClassData = false)
     {
-        base.UnloadAll(unloadClassData);
+        if (unloadClassData)
+        {
+            monoTempGenerator.Dispose();
+        }
         dependenciesByAssetFileInst.Clear();
+        base.UnloadAll(unloadClassData);
     }
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
@@ -4,7 +4,7 @@ using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using Mono.Cecil;
 
-namespace NitroxServer_Subnautica.Resources.Parsers;
+namespace NitroxServer_Subnautica.Resources.Parsers.Helper;
 
 public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator, IDisposable
 {
@@ -38,4 +38,3 @@ public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator,
         generator.loadedAssemblies.Clear();
     }
 }
-

--- a/NitroxServer-Subnautica/Resources/Parsers/PrefabPlaceholderGroupsParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/PrefabPlaceholderGroupsParser.cs
@@ -48,6 +48,8 @@ public class PrefabPlaceholderGroupsParser : IDisposable
 
         // Select only prefabs with a PrefabPlaceholdersGroups component in the root ans link them with their dependencyPaths
         ConcurrentDictionary<string, string[]> prefabPlaceholdersGroupPaths = GetAllPrefabPlaceholdersGroupsFast(loadAddressableCatalog);
+        // Do not remove: the internal cache list is slowing down the process more than loading a few assets again. There maybe is a better way in the new AssetToolsNetVersion but we need a byte to texture library bc ATNs sub-package is only for netstandard.
+        am.UnloadAll();
 
         // Get all needed data for the filtered PrefabPlaceholdersGroups to construct PrefabPlaceholdersGroupAssets and add them to the dictionary by classId
         ConcurrentDictionary<string, PrefabPlaceholdersGroupAsset> prefabPlaceholderGroupsByGroupClassId = GetPrefabPlaceholderGroupAssetsByGroupClassId(prefabPlaceholdersGroupPaths);

--- a/NitroxServer-Subnautica/Resources/Parsers/ThreadSafeMonoCecilTempGenerator.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/ThreadSafeMonoCecilTempGenerator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using AssetsTools.NET;
+using AssetsTools.NET.Extra;
+using Mono.Cecil;
+
+namespace NitroxServer_Subnautica.Resources.Parsers;
+
+public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator, IDisposable
+{
+    private readonly MonoCecilTempGenerator generator;
+    private readonly object locker = new();
+
+    public ThreadSafeMonoCecilTempGenerator(string managedPath)
+    {
+        generator = new MonoCecilTempGenerator(managedPath);
+    }
+
+    public AssetTypeTemplateField GetTemplateField(
+        AssetTypeTemplateField baseField,
+        string assemblyName,
+        string nameSpace,
+        string className,
+        UnityVersion unityVersion)
+    {
+        lock (locker)
+        {
+            return generator.GetTemplateField(baseField, assemblyName, nameSpace, className, unityVersion);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (KeyValuePair<string, AssemblyDefinition> pair in generator.loadedAssemblies)
+        {
+            pair.Value.Dispose();
+        }
+        generator.loadedAssemblies.Clear();
+    }
+}
+

--- a/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
+++ b/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
@@ -14,14 +14,17 @@ public static class ResourceAssetsParser
         {
             return resourceAssets;
         }
-        
-        resourceAssets = new ResourceAssets
+
+        using (PrefabPlaceholderGroupsParser prefabPlaceholderGroupsParser = new())
         {
-            WorldEntitiesByClassId = new WorldEntityInfoParser().ParseFile(),
-            LootDistributionsJson = new EntityDistributionsParser().ParseFile(),
-            PrefabPlaceholderGroupsByGroupClassId = new PrefabPlaceholderGroupsParser().ParseFile(),
-            NitroxRandom = new RandomStartParser().ParseFile()
-        };
+            resourceAssets = new ResourceAssets
+            {
+                WorldEntitiesByClassId = new WorldEntityInfoParser().ParseFile(),
+                LootDistributionsJson = new EntityDistributionsParser().ParseFile(),
+                PrefabPlaceholderGroupsByGroupClassId = prefabPlaceholderGroupsParser.ParseFile(),
+                NitroxRandom = new RandomStartParser().ParseFile()
+            };
+        }
         AssetParser.Dispose();
         
         ResourceAssets.ValidateMembers(resourceAssets);


### PR DESCRIPTION
Assemblies loaded by reference of the targeted asset assemblies can't be unloaded without changing AssetTools.NET code here. (We only have a reference to some of the assemblies, and can only dispose those):
https://github.com/nesrak1/AssetsTools.NET/blob/upd21-with-inst/AssetTools.NET/Extra/MonoDeserializer/MonoCecilTempGenerator.cs#L63-L69

**Preview of handles after full load of server**
![image](https://user-images.githubusercontent.com/1107063/210493418-29edd132-060f-4005-b376-b56ec8149497.png)
