### PR TITLE
Upgraded analyzer package to align with modern C# SDK

### DIFF
--- a/Nitrox.Analyzers/Extensions/DebugExtensions.cs
+++ b/Nitrox.Analyzers/Extensions/DebugExtensions.cs
@@ -18,6 +18,11 @@ public static class DebugExtensions
     [Conditional("DEBUG")]
     public static void Log(this object analyzer, string message)
     {
+        if (analyzer == null)
+        {
+            return;
+        }
+
         logQueue.Enqueue((analyzer, message));
         Task.Run(() =>
         {

--- a/Nitrox.Analyzers/Nitrox.Analyzers.csproj
+++ b/Nitrox.Analyzers/Nitrox.Analyzers.csproj
@@ -7,10 +7,13 @@
 
   <ItemGroup>
     <!-- DO NOT UPDATE ANALYZER PACKAGES UNLESS..
-     both latest Microsoft Visual Studio and JetBrains Rider support it. Otherwise errors happen like: 
+     both latest Microsoft Visual Studio and JetBrains Rider support it. Otherwise errors happen like:
      - Generated code not updating on project rebuild via IDE (only via CLI)
-     - No IDE support/squiggles for analyzer reported problems. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
+     - No IDE support/squiggles for analyzer reported problems.
+
+     See this link when to upgrade: https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022
+     -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Nitrox.BuildTool/Program.cs
+++ b/Nitrox.BuildTool/Program.cs
@@ -109,11 +109,10 @@ namespace Nitrox.BuildTool
             {
                 await Publicizer.PublicizeAsync(dllsToPublicize, "", Path.Combine(GeneratedOutputDir, "publicized_assemblies"));
             }
-            catch (Exception)
+            finally
             {
                 sw.Stop();
                 Publicizer.LogReceived -= LogReceived;
-                throw;
             }
             Console.WriteLine($"Publicized {dllsToPublicize.Length} DLL(s) in {Math.Round(sw.Elapsed.TotalSeconds, 2)}s");
         }

--- a/Nitrox.BuildTool/Publicizer.cs
+++ b/Nitrox.BuildTool/Publicizer.cs
@@ -61,10 +61,9 @@ public static class Publicizer
                 {
                     typeCount = ExecuteSingle(file, assemblyReaderParams, outputSuffix, outputPath);
                 }
-                catch (Exception)
+                finally
                 {
                     sw.Stop();
-                    throw;
                 }
                 OnLogReceived($"Publicized '{file}' with {typeCount} types in {Math.Round(sw.Elapsed.TotalSeconds, 2)}s");
             }));


### PR DESCRIPTION
Used symbol lookup and compare in localization to make it match exactly the right type (`Language` in `Assembly-Csharp`). This change required upgrade to roslyn 4.2.0 for `Compilation.GetTypesByMetadataName` API.

Tested analyzers still work in VS and Rider when using latest versions of either.
See: https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 for compatible IDEs with the roslyn nuget package.