### PR TITLE
Optimize packet handling in client and server by caching type to processor lookup

### DIFF
--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -37,6 +37,7 @@ namespace NitroxClient.MonoBehaviours
 
         public void Awake()
         {
+            NitroxServiceLocator.LifetimeScopeEnded += (_, _) => packetProcessorCache.Clear();
             multiplayerSession = NitroxServiceLocator.LocateService<IMultiplayerSession>();
             packetReceiver = NitroxServiceLocator.LocateService<PacketReceiver>();
             throttledPacketSender = NitroxServiceLocator.LocateService<ThrottledPacketSender>();

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -115,7 +115,7 @@ namespace NitroxClient.MonoBehaviours
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"Error processing packet {packet}");
+                    Log.Error(ex, $"Failed to find packet processor for packet {packet}");
                 }
 
                 return null;
@@ -123,7 +123,14 @@ namespace NitroxClient.MonoBehaviours
 
             foreach (Packet packet in packetReceiver.GetReceivedPackets())
             {
-                ResolveProcessor(packet)?.ProcessPacket(packet, null);
+                try
+                {
+                    ResolveProcessor(packet)?.ProcessPacket(packet, null);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, $"Error while processing packet {packet}");
+                }
             }
         }
 

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -24,7 +24,7 @@ namespace NitroxClient.MonoBehaviours
     public class Multiplayer : MonoBehaviour
     {
         public static Multiplayer Main;
-
+        private readonly Dictionary<Type, PacketProcessor> packetProcessorCache = new();
         private IMultiplayerSession multiplayerSession;
         private PacketReceiver packetReceiver;
         private ThrottledPacketSender throttledPacketSender;
@@ -34,6 +34,27 @@ namespace NitroxClient.MonoBehaviours
         ///     True if multiplayer is loaded and client is connected to a server.
         /// </summary>
         public static bool Active => Main != null && Main.multiplayerSession.Client.IsConnected;
+
+        public void Awake()
+        {
+            multiplayerSession = NitroxServiceLocator.LocateService<IMultiplayerSession>();
+            packetReceiver = NitroxServiceLocator.LocateService<PacketReceiver>();
+            throttledPacketSender = NitroxServiceLocator.LocateService<ThrottledPacketSender>();
+
+            Main = this;
+            DontDestroyOnLoad(gameObject);
+
+            Log.InGame(Language.main.Get("Nitrox_MultiplayerLoaded"));
+        }
+
+        public void Update()
+        {
+            if (multiplayerSession.CurrentState.CurrentStage != MultiplayerSessionConnectionStage.DISCONNECTED)
+            {
+                ProcessPackets();
+                throttledPacketSender.Update();
+            }
+        }
 
         public static event Action OnBeforeMultiplayerStart;
         public static event Action OnAfterMultiplayerEnd;
@@ -76,46 +97,32 @@ namespace NitroxClient.MonoBehaviours
             SetLoadingComplete();
         }
 
-        public void Awake()
-        {
-            Log.InGame(Language.main.Get("Nitrox_MultiplayerLoaded"));
-
-            multiplayerSession = NitroxServiceLocator.LocateService<IMultiplayerSession>();
-            packetReceiver = NitroxServiceLocator.LocateService<PacketReceiver>();
-            throttledPacketSender = NitroxServiceLocator.LocateService<ThrottledPacketSender>();
-
-            Main = this;
-            DontDestroyOnLoad(gameObject);
-        }
-
-        public void Update()
-        {
-            if (multiplayerSession.CurrentState.CurrentStage != MultiplayerSessionConnectionStage.DISCONNECTED)
-            {
-                ProcessPackets();
-                throttledPacketSender.Update();
-            }
-        }
-
         public void ProcessPackets()
         {
-            Queue<Packet> packets = packetReceiver.GetReceivedPackets();
-
-            foreach (Packet packet in packets)
+            PacketProcessor ResolveProcessor(Packet packet)
             {
+                Type packetType = packet.GetType();
+                if (packetProcessorCache.TryGetValue(packetType, out PacketProcessor processor))
+                {
+                    return processor;
+                }
+
                 try
                 {
-                    Type clientPacketProcessorType = typeof(ClientPacketProcessor<>);
-                    Type packetType = packet.GetType();
-                    Type packetProcessorType = clientPacketProcessorType.MakeGenericType(packetType);
-
-                    PacketProcessor processor = (PacketProcessor)NitroxServiceLocator.LocateService(packetProcessorType);
-                    processor.ProcessPacket(packet, null);
+                    Type packetProcessorType = typeof(ClientPacketProcessor<>).MakeGenericType(packetType);
+                    return packetProcessorCache[packetType] = (PacketProcessor)NitroxServiceLocator.LocateService(packetProcessorType);
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex, $"Error processing packet {packet}");
                 }
+
+                return null;
+            }
+
+            foreach (Packet packet in packetReceiver.GetReceivedPackets())
+            {
+                ResolveProcessor(packet)?.ProcessPacket(packet, null);
             }
         }
 

--- a/NitroxModel/Core/NitroxServiceLocator.cs
+++ b/NitroxModel/Core/NitroxServiceLocator.cs
@@ -3,141 +3,144 @@ using Autofac;
 using Autofac.Builder;
 using NitroxModel.DataStructures.Util;
 
-namespace NitroxModel.Core
+namespace NitroxModel.Core;
+
+/// <summary>
+///     Dependency Injection (DI) class for resolving types as defined in the DI registrar, implementing <see cref="IAutoFacRegistrar" />.
+/// </summary>
+public static class NitroxServiceLocator
 {
-    /// <summary>
-    ///     Dependency Injection (DI) class for resolving types as defined in the DI registrar, implementing <see cref="IAutoFacRegistrar"/>. 
-    /// </summary>
-    public static class NitroxServiceLocator
+    private static IContainer DependencyContainer { get; set; }
+    private static ILifetimeScope CurrentLifetimeScope { get; set; }
+    public static event EventHandler LifetimeScopeEnded;
+
+    public static void InitializeDependencyContainer(params IAutoFacRegistrar[] registrars)
     {
-        private static IContainer DependencyContainer { get; set; }
-        private static ILifetimeScope CurrentLifetimeScope { get; set; }
-
-        public static void InitializeDependencyContainer(params IAutoFacRegistrar[] registrars)
+        ContainerBuilder builder = new();
+        foreach (IAutoFacRegistrar registrar in registrars)
         {
-            ContainerBuilder builder = new();
-            foreach (IAutoFacRegistrar registrar in registrars)
-            {
-                registrar.RegisterDependencies(builder);
-            }
-
-            // IgnoreStartableComponents - Prevents "phantom" executions of the Start() method 
-            // on a MonoBehaviour because someone accidentally did something funky with a DI registration.
-            DependencyContainer = builder.Build(ContainerBuildOptions.IgnoreStartableComponents);
+            registrar.RegisterDependencies(builder);
         }
 
-        /// <summary>
-        ///     Starts a new life time scope. A single instance per registered service will be returned while this scope is active.
-        ///     Services can scoped to this life time using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope"/>. 
-        /// </summary>
-        /// <remarks>
-        ///     A life time scope should be created when the game leaves the main menu and loads a level with multiplayer.
-        ///     It should end when the game process unloads the level (e.g. player returns to the main menu).
-        /// </remarks>
-        public static void BeginNewLifetimeScope()
-        {
-            if (DependencyContainer == null)
-            {
-                throw new InvalidOperationException("You must install an Autofac container before initializing a new lifetime scope.");
-            }
+        // IgnoreStartableComponents - Prevents "phantom" executions of the Start() method
+        // on a MonoBehaviour because someone accidentally did something funky with a DI registration.
+        DependencyContainer = builder.Build(ContainerBuildOptions.IgnoreStartableComponents);
+    }
 
-            CurrentLifetimeScope?.Dispose();
-            CurrentLifetimeScope = DependencyContainer.BeginLifetimeScope();
+    /// <summary>
+    ///     Starts a new life time scope. A single instance per registered service will be returned while this scope is active.
+    ///     Services can scoped to this life time using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope" />.
+    /// </summary>
+    /// <remarks>
+    ///     A life time scope should be created when the game leaves the main menu and loads a level with multiplayer.
+    ///     It should end when the game process unloads the level (e.g. player returns to the main menu).
+    /// </remarks>
+    public static void BeginNewLifetimeScope()
+    {
+        if (DependencyContainer == null)
+        {
+            throw new InvalidOperationException("You must install an Autofac container before initializing a new lifetime scope.");
         }
 
-        /// <summary>
-        ///     Ends the life time scoped services that were registered using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope"/>.
-        /// </summary>
-        public static void EndCurrentLifetimeScope()
+        CurrentLifetimeScope?.Dispose();
+        CurrentLifetimeScope = DependencyContainer.BeginLifetimeScope();
+    }
+
+    /// <summary>
+    ///     Ends the life time scoped services that were registered using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope" />.
+    /// </summary>
+    public static void EndCurrentLifetimeScope()
+    {
+        CurrentLifetimeScope?.Dispose();
+        OnLifetimeScopeEnded();
+    }
+
+    /// <summary>
+    ///     Only locates the service in the container, pre-lifetime scope.
+    /// </summary>
+    public static T LocateServicePreLifetime<T>()
+    {
+        return DependencyContainer.Resolve<T>();
+    }
+
+    /// <summary>
+    ///     Retrieves a service which was registered into the DI container. Creates a new instance if required.<br />
+    /// </summary>
+    /// <remarks>
+    ///     This method should not be used if the constructor is available for defining a parameter where its type is the service to inject.
+    ///     For Unity monobehaviours the constructor is used by Unity and cannot be used to inject services. In this case, use this method.
+    /// </remarks>
+    public static T LocateService<T>()
+        where T : class
+    {
+        CheckServiceResolutionViability();
+        return CurrentLifetimeScope.Resolve<T>();
+    }
+
+    /// <summary>
+    ///     Non-generic alternative to <see cref="LocateService{T}" />.
+    /// </summary>
+    public static object LocateService(Type serviceType)
+    {
+        CheckServiceResolutionViability();
+        return CurrentLifetimeScope.Resolve(serviceType);
+    }
+
+    /// <summary>
+    ///     Tries to locate the service if it exists. Can return an <see cref="Optional{T}" /> without a value.
+    /// </summary>
+    /// <typeparam name="T">Type of service to try to locate.</typeparam>
+    /// <returns>Optional that might or might not hold the service instance.</returns>
+    public static Optional<T> LocateOptionalService<T>() where T : class
+    {
+        CheckServiceResolutionViability();
+        return Optional.OfNullable(CurrentLifetimeScope.ResolveOptional<T>());
+    }
+
+    /// <summary>
+    ///     Tries to locate the service if it exists. Can return an <see cref="Optional{T}" /> without a value.
+    /// </summary>
+    /// <param name="serviceType">Type of service to try to locate.</param>
+    /// <returns>Optional that might or might not hold the service instance.</returns>
+    public static Optional<object> LocateOptionalService(Type serviceType)
+    {
+        CheckServiceResolutionViability();
+        return Optional.OfNullable(CurrentLifetimeScope.ResolveOptional(serviceType));
+    }
+
+    /// <summary>
+    ///     Throws if a service is asked for but without a proper life time scope.
+    /// </summary>
+    private static void CheckServiceResolutionViability()
+    {
+        if (DependencyContainer == null)
         {
-            CurrentLifetimeScope?.Dispose();
+            throw new InvalidOperationException("You must install an Autofac container before resolving dependencies.");
         }
-
-        /// <summary>
-        ///     Only locates the service in the container, pre-lifetime scope.
-        /// </summary>
-        public static T LocateServicePreLifetime<T>()
+        if (CurrentLifetimeScope == null)
         {
-            return DependencyContainer.Resolve<T>();
+            throw new InvalidOperationException("You must begin a new lifetime scope before resolving dependencies.");
         }
+    }
+
+    private static void OnLifetimeScopeEnded() => LifetimeScopeEnded?.Invoke(null, EventArgs.Empty);
+
+    /// <summary>
+    ///     Generic static class to cache type with very fast lookups. Only use for singleton types.
+    /// </summary>
+    /// <typeparam name="T">Type in the cache, should be singleton.</typeparam>
+    public static class Cache<T> where T : class
+    {
+        private static T value;
+        public static T Value => value ??= LocateService<T>();
+        public static T ValuePreLifetime => value ??= LocateServicePreLifetime<T>();
 
         /// <summary>
-        ///     Retrieves a service which was registered into the DI container. Creates a new instance if required.<br/>
+        ///     Invalidates the cache for type <see cref="T" />. The next <see cref="Value" /> access will request from <see cref="NitroxServiceLocator" /> again.
         /// </summary>
-        /// <remarks>
-        ///     This method should not be used if the constructor is available for defining a parameter where its type is the service to inject.
-        ///     For Unity monobehaviours the constructor is used by Unity and cannot be used to inject services. In this case, use this method.
-        /// </remarks>
-        public static T LocateService<T>()
-            where T : class
+        public static void Invalidate()
         {
-            CheckServiceResolutionViability();
-            return CurrentLifetimeScope.Resolve<T>();
-        }
-
-        /// <summary>
-        ///     Non-generic alternative to <see cref="LocateService{T}"/>.
-        /// </summary>
-        public static object LocateService(Type serviceType)
-        {
-            CheckServiceResolutionViability();
-            return CurrentLifetimeScope.Resolve(serviceType);
-        }
-
-        /// <summary>
-        ///     Tries to locate the service if it exists. Can return an <see cref="Optional{T}" /> without a value.
-        /// </summary>
-        /// <typeparam name="T">Type of service to try to locate.</typeparam>
-        /// <returns>Optional that might or might not hold the service instance.</returns>
-        public static Optional<T> LocateOptionalService<T>() where T : class
-        {
-            CheckServiceResolutionViability();
-            return Optional.OfNullable(CurrentLifetimeScope.ResolveOptional<T>());
-        }
-
-        /// <summary>
-        ///     Tries to locate the service if it exists. Can return an <see cref="Optional{T}" /> without a value.
-        /// </summary>
-        /// <param name="serviceType">Type of service to try to locate.</param>
-        /// <returns>Optional that might or might not hold the service instance.</returns>
-        public static Optional<object> LocateOptionalService(Type serviceType)
-        {
-            CheckServiceResolutionViability();
-            return Optional.OfNullable(CurrentLifetimeScope.ResolveOptional(serviceType));
-        }
-
-        /// <summary>
-        ///     Throws if a service is asked for but without a proper life time scope.
-        /// </summary>
-        private static void CheckServiceResolutionViability()
-        {
-            if (DependencyContainer == null)
-            {
-                throw new InvalidOperationException("You must install an Autofac container before resolving dependencies.");
-            }
-            if (CurrentLifetimeScope == null)
-            {
-                throw new InvalidOperationException("You must begin a new lifetime scope before resolving dependencies.");
-            }
-        }
-
-        /// <summary>
-        ///     Generic static class to cache type with very fast lookups. Only use for singleton types.
-        /// </summary>
-        /// <typeparam name="T">Type in the cache, should be singleton.</typeparam>
-        public static class Cache<T> where T : class
-        {
-            private static T value;
-            public static T Value => value ??= LocateService<T>();
-            public static T ValuePrelifetime => value ??= LocateServicePreLifetime<T>();
-
-            /// <summary>
-            ///     Invalidates the cache for type <see cref="T"/>. The next <see cref="Value"/> access will request from <see cref="NitroxServiceLocator"/> again.
-            /// </summary>
-            public static void Invalidate()
-            {
-                value = null;
-            }
+            value = null;
         }
     }
 }

--- a/NitroxPatcher/Patches/NitroxPatch.cs
+++ b/NitroxPatcher/Patches/NitroxPatch.cs
@@ -52,7 +52,7 @@ public abstract class NitroxPatch : INitroxPatch
     /// <returns>The requested type or null if not available.</returns>
     protected static T Resolve<T>(bool prelifeTime = false) where T : class
     {
-        return prelifeTime ? NitroxServiceLocator.Cache<T>.ValuePrelifetime : NitroxServiceLocator.Cache<T>.Value;
+        return prelifeTime ? NitroxServiceLocator.Cache<T>.ValuePreLifetime : NitroxServiceLocator.Cache<T>.Value;
     }
 
     protected void PatchFinalizer(Harmony harmony, MethodBase targetMethod, string finalizerMethod = "Finalizer")


### PR DESCRIPTION
Performance difference can be seen here, where `.MakeGenericType(...)` lookups take ~0.2ms and cached lookups ~0.-0005 to ~0.001ms. A **~400x speedup** but only for the lookup part, not the processing itself.

This should reduce latency issues.

```log
[11:36:57.897] [DBG] Perf: Processor lookup took 0.2477ms
[11:37:38.220] [DBG] Perf: Processor lookup took 0.3134ms
[11:37:38.221] [DBG] Perf: Processor lookup took 0.2795ms
[11:37:38.237] [DBG] Perf: Processor lookup took 0.0077ms
[11:37:38.237] [DBG] Perf: Processor lookup took 0.0003ms
[11:37:38.246] [DBG] Perf: Processor lookup took 0.0005ms
[11:37:38.246] [DBG] Perf: Processor lookup took 0.0003ms
[11:37:38.295] [DBG] Perf: Processor lookup took 0.0006ms
[11:37:38.338] [DBG] Perf: Processor lookup took 0.4232ms
[11:37:38.812] [DBG] Perf: Processor lookup took 0.0007ms
```