### PR TITLE
Fixed Reflect API for out parameters

### DIFF
--- a/NitroxModel/Helper/Reflect.cs
+++ b/NitroxModel/Helper/Reflect.cs
@@ -2,127 +2,134 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace NitroxModel.Helper
+namespace NitroxModel.Helper;
+
+/// <summary>
+///     Utility class for reflection API.
+/// </summary>
+/// <remarks>
+///     This class should be used when requiring <see cref="MethodInfo" /> or <see cref="MemberInfo" /> like information from code. This will ensure that compilation only succeeds
+///     when reflection is used properly.
+/// </remarks>
+public static class Reflect
 {
-    /// <summary>
-    ///     Utility class for reflection API.
-    /// </summary>
-    /// <remarks>
-    ///     This class should be used when requiring <see cref="MethodInfo" /> or <see cref="MemberInfo" /> like information from code. This will ensure that compilation only succeeds
-    ///     when reflection is used properly.
-    /// </remarks>
-    public static class Reflect
+    private static readonly BindingFlags BINDING_FLAGS_ALL = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+    public static ConstructorInfo Constructor(Expression<Action> expression)
     {
-        private static readonly BindingFlags BINDING_FLAGS_ALL = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-        
-        public static ConstructorInfo Constructor(Expression<Action> expression)
-        {
-            return (ConstructorInfo)GetMemberInfo(expression);
-        }
-        
-        /// <summary>
-        ///     Given a lambda expression that calls a method, returns the method info.
-        ///     If method has parameters then anything can be supplied, the actual method won't be called.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="expression">The expression.</param>
-        /// <returns></returns>
-        public static MethodInfo Method(Expression<Action> expression)
-        {
-            return (MethodInfo)GetMemberInfo(expression);
-        }
+        return (ConstructorInfo)GetMemberInfo(expression);
+    }
 
-        /// <summary>
-        ///     Given a lambda expression that calls a method, returns the method info.
-        ///     If method has parameters then anything can be supplied, the actual method won't be called.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="expression">The expression.</param>
-        /// <returns></returns>
-        public static MethodInfo Method<T>(Expression<Action<T>> expression) where T : class
-        {
-            return (MethodInfo)GetMemberInfo(expression, typeof(T));
-        }
+    /// <summary>
+    ///     Given a lambda expression that calls a method, returns the method info.
+    ///     If method has parameters then anything can be supplied, the actual method won't be called.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="expression">The expression.</param>
+    /// <returns></returns>
+    public static MethodInfo Method(Expression<Action> expression)
+    {
+        return (MethodInfo)GetMemberInfo(expression);
+    }
 
-        /// <summary>
-        ///     Given a lambda expression that calls a method, returns the method info.
-        ///     If method has parameters then anything can be supplied, the actual method won't be called.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <param name="expression">The expression.</param>
-        /// <returns></returns>
-        public static MethodInfo Method<T, TResult>(Expression<Func<T, TResult>> expression) where T : class
-        {
-            return (MethodInfo)GetMemberInfo(expression, typeof(T));
-        }
+    /// <summary>
+    ///     Given a lambda expression that calls a method, returns the method info.
+    ///     If method has parameters then anything can be supplied, the actual method won't be called.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="expression">The expression.</param>
+    /// <returns></returns>
+    public static MethodInfo Method<T>(Expression<Action<T>> expression) where T : class
+    {
+        return (MethodInfo)GetMemberInfo(expression, typeof(T));
+    }
 
-        public static FieldInfo Field<T>(Expression<Func<T>> expression)
+    /// <summary>
+    ///     Given a lambda expression that calls a method, returns the method info.
+    ///     If method has parameters then anything can be supplied, the actual method won't be called.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="expression">The expression.</param>
+    /// <returns></returns>
+    public static MethodInfo Method<T, TResult>(Expression<Func<T, TResult>> expression) where T : class
+    {
+        return (MethodInfo)GetMemberInfo(expression, typeof(T));
+    }
+
+    public static FieldInfo Field<T>(Expression<Func<T>> expression)
+    {
+        return (FieldInfo)GetMemberInfo(expression);
+    }
+
+    public static FieldInfo Field<T>(Expression<Func<T, object>> expression) where T : class
+    {
+        return (FieldInfo)GetMemberInfo(expression);
+    }
+
+    public static PropertyInfo Property<T>(Expression<Func<T>> expression)
+    {
+        return (PropertyInfo)GetMemberInfo(expression);
+    }
+
+    public static PropertyInfo Property<T>(Expression<Func<T, object>> expression) where T : class
+    {
+        return (PropertyInfo)GetMemberInfo(expression);
+    }
+
+    private static MemberInfo GetMemberInfo(LambdaExpression expression, Type implementingType = null)
+    {
+        Expression currentExpression = expression.Body;
+        while (true)
         {
-            return (FieldInfo)GetMemberInfo(expression);
-        }
-        
-        public static FieldInfo Field<T>(Expression<Func<T, object>> expression) where T : class
-        {
-            return (FieldInfo)GetMemberInfo(expression);
-        }
-        
-        public static PropertyInfo Property<T>(Expression<Func<T>> expression)
-        {
-            return (PropertyInfo)GetMemberInfo(expression);
-        }
-        
-        public static PropertyInfo Property<T>(Expression<Func<T, object>> expression) where T : class
-        {
-            return (PropertyInfo)GetMemberInfo(expression);
-        }
-        
-        private static MemberInfo GetMemberInfo(LambdaExpression expression, Type implementingType = null)
-        {
-            Expression currentExpression = expression.Body;
-            while (true)
+            switch (currentExpression.NodeType)
             {
-                switch (currentExpression.NodeType)
-                {
-                    case ExpressionType.MemberAccess:
-                        // If it cannot be unwrapped further, return this member.
-                        MemberExpression exp = (MemberExpression)currentExpression;
-                        if (exp.Expression is null or ParameterExpression)
+                case ExpressionType.MemberAccess:
+                    // If it cannot be unwrapped further, return this member.
+                    MemberExpression exp = (MemberExpression)currentExpression;
+                    if (exp.Expression is null or ParameterExpression)
+                    {
+                        return exp.Member;
+                    }
+                    currentExpression = exp.Expression;
+                    break;
+                case ExpressionType.UnaryPlus:
+                    currentExpression = ((UnaryExpression)currentExpression).Operand;
+                    break;
+                case ExpressionType.New:
+                    return ((NewExpression)currentExpression).Constructor;
+                case ExpressionType.Call:
+                    MethodInfo method = ((MethodCallExpression)currentExpression).Method;
+                    // Expression does not know which type the MethodInfo belongs to if it's virtual.
+                    if (implementingType != null && implementingType != method.ReflectedType)
+                    {
+                        ParameterInfo[] parameters = method.GetParameters();
+                        Type[] args = new Type[parameters.Length];
+                        for (int i = 0; i < parameters.Length; i++)
                         {
-                            return exp.Member;
+                            args[i] = parameters[i].ParameterType;
                         }
-                        currentExpression = exp.Expression;
-                        break;
-                    case ExpressionType.UnaryPlus:
-                        currentExpression = ((UnaryExpression)currentExpression).Operand;
-                        break;
-                    case ExpressionType.New:
-                        return ((NewExpression)currentExpression).Constructor;
-                    case ExpressionType.Call:
-                        MethodInfo method = ((MethodCallExpression)currentExpression).Method;
-                        // Expression does not know which type the MethodInfo belongs to if it's virtual.
-                        if (implementingType != null && implementingType != method.ReflectedType)
-                        {
-                            ParameterInfo[] parameters = method.GetParameters();
-                            Type[] args = new Type[parameters.Length];
-                            for (int i = 0; i < parameters.Length; i++)
-                            {
-                                args[i] = parameters[i].ParameterType;
-                            }
-                            return implementingType.GetMethod(method.Name, BINDING_FLAGS_ALL, null, args, null);
-                        }
-                        return method;
-                    case ExpressionType.Convert:
-                    case ExpressionType.ConvertChecked:
-                        currentExpression = ((UnaryExpression)currentExpression).Operand;
-                        break;
-                    case ExpressionType.Invoke:
-                        currentExpression = ((InvocationExpression)currentExpression).Expression;
-                        break;
-                    default:
-                        throw new ArgumentException($"Lambda expression '{expression}' does not target a member");
-                }
+                        return implementingType.GetMethod(method.Name, BINDING_FLAGS_ALL, null, args, null);
+                    }
+                    return method;
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    currentExpression = ((UnaryExpression)currentExpression).Operand;
+                    break;
+                case ExpressionType.Invoke:
+                    currentExpression = ((InvocationExpression)currentExpression).Expression;
+                    break;
+                default:
+                    throw new ArgumentException($"Lambda expression '{expression}' does not target a member");
             }
         }
+    }
+
+    /// <summary>
+    ///     Used to supplement ref/out/in parameters when using the <see cref="Reflect" /> API.
+    /// </summary>
+    public struct Ref<T>
+    {
+        public static T Field;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/BaseAddBulkheadGhost_UpdatePlacement_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseAddBulkheadGhost_UpdatePlacement_Patch.cs
@@ -12,11 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class BaseAddBulkheadGhost_UpdatePlacement_Patch : NitroxPatch, IDynamicPatch
     {
-        /// <summary>
-        ///     Unable to use <see cref="Reflect.Method" /> here because expression trees do not support out parameters (yet).
-        /// </summary>
-        public static readonly MethodInfo TARGET_METHOD = typeof(BaseAddBulkheadGhost).GetMethod(nameof(BaseAddBulkheadGhost.UpdatePlacement), BindingFlags.Public | BindingFlags.Instance, null,
-                                                                                                 new[] { typeof(Transform), typeof(float), typeof(bool).MakeByRefType(), typeof(bool).MakeByRefType(), typeof(ConstructableBase) }, null);
+        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((BaseAddBulkheadGhost t) => t.UpdatePlacement(default(Transform), default(float), out Reflect.Ref<bool>.Field, out Reflect.Ref<bool>.Field, default(ConstructableBase)));
 
         public static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
         public static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
@@ -35,15 +31,15 @@ namespace NitroxPatcher.Patches.Dynamic
 
             /**
              * When placing some modules in multiplayer it throws an exception because it tries to validate
-             * that the current player is in the subroot.  We want to skip over this code if we are placing 
+             * that the current player is in the subroot.  We want to skip over this code if we are placing
              * a multiplayer piece:
-             * 
+             *
              * if (main == null || main.currentSub == null || !main.currentSub.isBase)
-             * 
+             *
              * Injected code:
-             * 
+             *
              * if (!MultiplayerBuilder.isPlacing && (main == null || main.currentSub == null || !main.currentSub.isBase))
-             *    
+             *
              */
             for (int i = 0; i < instructionList.Count; i++)
             {

--- a/NitroxPatcher/Patches/Dynamic/BaseAddModuleGhost_UpdatePlacement_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseAddModuleGhost_UpdatePlacement_Patch.cs
@@ -12,11 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class BaseAddModuleGhost_UpdatePlacement_Patch : NitroxPatch, IDynamicPatch
     {
-        /// <summary>
-        ///     Unable to use <see cref="Reflect.Method" /> here because expression trees do not support out parameters (yet).
-        /// </summary>
-        private static readonly MethodInfo TARGET_METHOD = typeof(BaseAddModuleGhost).GetMethod(nameof(BaseAddModuleGhost.UpdatePlacement), BindingFlags.Public | BindingFlags.Instance, null,
-                                                                                                new[] { typeof(Transform), typeof(float), typeof(bool).MakeByRefType(), typeof(bool).MakeByRefType(), typeof(ConstructableBase) }, null);
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((BaseAddModuleGhost t) => t.UpdatePlacement(default(Transform), default(float), out Reflect.Ref<bool>.Field, out Reflect.Ref<bool>.Field, default(ConstructableBase)));
 
         private static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
 
@@ -36,15 +32,15 @@ namespace NitroxPatcher.Patches.Dynamic
 
             /**
              * When placing some modules in multiplayer it throws an exception because it tries to validate
-             * that the current player is in the subroot.  We want to skip over this code if we are placing 
+             * that the current player is in the subroot.  We want to skip over this code if we are placing
              * a multiplayer piece:
-             * 
+             *
              * if (main == null || main.currentSub == null || !main.currentSub.isBase)
-             * 
+             *
              * Injected code:
-             * 
+             *
              * if (!MultiplayerBuilder.isPlacing && (main == null || main.currentSub == null || !main.currentSub.isBase))
-             *    
+             *
              */
             for (int i = 0; i < instructionList.Count; i++)
             {

--- a/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_TryUse_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ExosuitClawArm_TryUse_Patch.cs
@@ -8,10 +8,7 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     class ExosuitClawArm_TryUse_Patch : NitroxPatch, IDynamicPatch
     {
-        /// <summary>
-        ///     Unable to use <see cref="Reflect.Method" /> here because expression trees do not support out parameters (yet).
-        /// </summary>
-        private static readonly MethodInfo TARGET_METHOD = typeof(ExosuitClawArm).GetMethod(nameof(ExosuitClawArm.TryUse), BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(float).MakeByRefType() }, null);
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((ExosuitClawArm t) => t.TryUse(out Reflect.Ref<float>.Field));
 
         public static void Postfix(bool __result, ExosuitClawArm __instance, float ___cooldownTime)
         {

--- a/NitroxPatcher/Patches/Persistent/Language_LoadLanguageFile_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/Language_LoadLanguageFile_Patch.cs
@@ -50,10 +50,10 @@ public class Language_LoadLanguageFile_Patch : NitroxPatch, IPersistentPatch
 
             foreach (string key in json.Keys)
             {
-                JsonData jsonKey = json[key];
-                if (jsonKey.IsString)
+                JsonData entry = json[key];
+                if (entry.IsString)
                 {
-                    strings[key] = (string)jsonKey;
+                    strings[key] = (string)entry;
                 }
             }
 


### PR DESCRIPTION
Expressions can't create and capture variables. But they can refer to a preexisting variable.