### PR TITLE
Persisting and syncing quick bind slots

### DIFF
--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -222,7 +222,7 @@ public class WorldPersistenceTest
             Assert.AreEqual(playerData.Name, playerDataAfter.Name);
 
             Assert.IsTrue(playerData.UsedItems.SequenceEqual(playerDataAfter.UsedItems));
-            Assert.IsTrue(playerData.QuickSlotsBinding.SequenceEqual(playerDataAfter.QuickSlotsBinding));
+            Assert.IsTrue(playerData.QuickSlotsBindingIds.SequenceEqual(playerDataAfter.QuickSlotsBindingIds));
             AssertHelper.IsListEqual(playerData.EquippedItems.OrderBy(x => x.ItemId), playerDataAfter.EquippedItems.OrderBy(x => x.ItemId), ItemDataTest);
             AssertHelper.IsListEqual(playerData.Modules.OrderBy(x => x.ItemId), playerDataAfter.Modules.OrderBy(x => x.ItemId), ItemDataTest);
 
@@ -467,7 +467,7 @@ public class WorldPersistenceTest
                         SubRootId = null,
                         CurrentStats = new PlayerStatsData(45, 45, 40, 39, 28, 1),
                         UsedItems = new List<NitroxTechType>(0),
-                        QuickSlotsBinding = new List<string>(0),
+                        QuickSlotsBindingIds = new NitroxId[] { new NitroxId() },
                         EquippedItems = new List<EquippedItemData>(0),
                         Modules = new List<EquippedItemData>(0),
                         PlayerPreferences = new(new(), new())
@@ -483,7 +483,7 @@ public class WorldPersistenceTest
                         SubRootId = new NitroxId(),
                         CurrentStats = new PlayerStatsData(40, 40, 30, 29, 28, 0),
                         UsedItems = new List<NitroxTechType> { new NitroxTechType("Knife"), new NitroxTechType("Flashlight") },
-                        QuickSlotsBinding = new List<string> { "Test1", "Test2" },
+                        QuickSlotsBindingIds = new NitroxId[] { new NitroxId(), new NitroxId() },
                         EquippedItems = new List<EquippedItemData>
                         {
                             new EquippedItemData(new NitroxId(), new NitroxId(), new byte[] { 0x30, 0x40 }, "Slot3", new NitroxTechType("Flashlight")),

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -138,7 +138,7 @@ namespace NitroxClient.GameLogic
             {
                 if (!entitySpawner.SpawnsOwnChildren(entity))
                 {
-                    SpawnChildren(entity);
+                    yield return SpawnChildren(entity);
                 }
 
                 yield return AwaitAnyRequiredEntitySetup(gameObject.Value);

--- a/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic.InitialSync.Base;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Packets;
+
+namespace NitroxClient.GameLogic.InitialSync;
+
+public class QuickSlotInitialSyncProcessor : InitialSyncProcessor
+{
+    private readonly IPacketSender packetSender;
+
+    public QuickSlotInitialSyncProcessor(IPacketSender packetSender)
+    {
+        this.packetSender = packetSender;
+
+        DependentProcessors.Add(typeof(PlayerInitialSyncProcessor));  // the player needs to be configured before we can set quick slots.
+        DependentProcessors.Add(typeof(EquippedItemInitialSyncProcessor)); // we need to have the items spawned into our inventory before we can quick slot them.
+    }
+
+    public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    {
+        int nonEmptySlots = 0;
+
+        for (int i = 0; i < packet.QuickSlotsBindingIds.Length; i++)
+        {
+            waitScreenItem.SetProgress(i, packet.QuickSlotsBindingIds.Length);
+
+            NitroxId id = packet.QuickSlotsBindingIds[i];
+            Optional<InventoryItem> item = getItem(id);
+
+            if (item.HasValue)
+            {
+                Inventory.main.quickSlots.binding[i] = item.Value;
+                Inventory.main.quickSlots.NotifyBind(i, state: true);
+            }
+
+            yield return null;
+        }
+
+        Log.Info($"Recieved initial sync with {nonEmptySlots} quick slots populated with items");
+    }
+
+    private Optional<InventoryItem> getItem(NitroxId id)
+    {
+        if (id == null)
+        {
+            return Optional.Empty;
+        }
+
+        foreach (InventoryItem inventoryItem in Inventory.main.container)
+        {
+            if (inventoryItem.item && id == NitroxEntity.GetId(inventoryItem.item.gameObject))
+            {
+                return Optional.Of(inventoryItem);
+            }
+        }
+
+        return Optional.Empty;
+    }
+}

--- a/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
@@ -31,6 +31,7 @@ public class QuickSlotInitialSyncProcessor : InitialSyncProcessor
             {
                 Inventory.main.quickSlots.binding[i] = inventoryItem;
                 Inventory.main.quickSlots.NotifyBind(i, state: true);
+                nonEmptySlots++;
             }
             else
             {
@@ -41,7 +42,7 @@ public class QuickSlotInitialSyncProcessor : InitialSyncProcessor
             yield return null;
         }
 
-        Log.Info($"Recieved initial sync with {nonEmptySlots} quick slots populated with items");
+        Log.Info($"Received initial sync with {nonEmptySlots} quick slots populated with items");
     }
 
     private Dictionary<NitroxId, InventoryItem> GetItemsById()

--- a/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
@@ -32,6 +32,11 @@ public class QuickSlotInitialSyncProcessor : InitialSyncProcessor
                 Inventory.main.quickSlots.binding[i] = inventoryItem;
                 Inventory.main.quickSlots.NotifyBind(i, state: true);
             }
+            else
+            {
+                // Unbind any default stuff from equipment addition.
+                Inventory.main.quickSlots.Unbind(i);
+            }
 
             yield return null;
         }

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -2,6 +2,7 @@
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
+using NitroxClient.Helpers;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
 using NitroxModel_Subnautica.DataStructures;
@@ -13,7 +14,6 @@ using NitroxModel.Packets;
 using UnityEngine;
 using UnityEngine.Rendering;
 using Object = UnityEngine.Object;
-using NitroxClient.Helpers;
 
 namespace NitroxClient.GameLogic
 {

--- a/NitroxClient/GameLogic/Spawning/InventoryItemEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InventoryItemEntitySpawner.cs
@@ -53,6 +53,7 @@ public class InventoryItemEntitySpawner : EntitySpawner<InventoryItemEntity>
         pickupable.Initialize();
 
         using (packetSender.Suppress<EntityReparented>())
+        using (packetSender.Suppress<PlayerQuickSlotsBindingChanged>())
         {
             container.UnsafeAdd(new InventoryItem(pickupable));
             Log.Debug($"Received: Added item {pickupable.GetTechType()} ({entity.Id}) to container {owner.Value.GetFullHierarchyPath()}");

--- a/NitroxModel/Packets/InitialPlayerSync.cs
+++ b/NitroxModel/Packets/InitialPlayerSync.cs
@@ -18,7 +18,7 @@ namespace NitroxModel.Packets
         public List<BasePiece> BasePieces { get; }
         public List<ItemData> StorageSlotItems { get; }
         public List<NitroxTechType> UsedItems { get; }
-        public List<string> QuickSlotsBinding { get; }
+        public NitroxId[] QuickSlotsBindingIds { get; }
         public NitroxId PlayerGameObjectId { get; }
         public bool FirstTimeConnecting { get; }
         public InitialPDAData PDAData { get; }
@@ -42,7 +42,7 @@ namespace NitroxModel.Packets
             IEnumerable<BasePiece> basePieces,
             IEnumerable<ItemData> storageSlotItems,
             IEnumerable<NitroxTechType> usedItems,
-            IEnumerable<string> quickSlotsBinding,
+            NitroxId[] quickSlotsBindingIds,
             InitialPDAData pdaData,
             InitialStoryGoalData storyGoalData,
             NitroxVector3 playerSpawnData,
@@ -64,7 +64,7 @@ namespace NitroxModel.Packets
             BasePieces = basePieces.ToList();
             StorageSlotItems = storageSlotItems.ToList();
             UsedItems = usedItems.ToList();
-            QuickSlotsBinding = quickSlotsBinding.ToList();
+            QuickSlotsBindingIds = quickSlotsBindingIds;
             PDAData = pdaData;
             StoryGoalData = storyGoalData;
             PlayerSpawnData = playerSpawnData;
@@ -87,7 +87,7 @@ namespace NitroxModel.Packets
             List<BasePiece> basePieces,
             List<ItemData> storageSlotItems,
             List<NitroxTechType> usedItems,
-            List<string> quickSlotsBinding,
+            NitroxId[] quickSlotsBindingIds,
             NitroxId playerGameObjectId,
             bool firstTimeConnecting,
             InitialPDAData pdaData,
@@ -111,7 +111,7 @@ namespace NitroxModel.Packets
             BasePieces = basePieces;
             StorageSlotItems = storageSlotItems;
             UsedItems = usedItems;
-            QuickSlotsBinding = quickSlotsBinding;
+            QuickSlotsBindingIds = quickSlotsBindingIds;
             PDAData = pdaData;
             StoryGoalData = storyGoalData;
             PlayerSpawnData = playerSpawnData;

--- a/NitroxModel/Packets/PlayerQuickSlotsBindingChanged.cs
+++ b/NitroxModel/Packets/PlayerQuickSlotsBindingChanged.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
+using NitroxModel.DataStructures;
 
-namespace NitroxModel.Packets
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class PlayerQuickSlotsBindingChanged : Packet
 {
-    [Serializable]
-    public class PlayerQuickSlotsBindingChanged : Packet
-    {
-        public List<string> Binding { get; }
+    public NitroxId[] SlotItemIds { get; }
 
-        public PlayerQuickSlotsBindingChanged(List<string> binding)
-        {
-            Binding = binding;
-        }
+    public PlayerQuickSlotsBindingChanged(NitroxId[] slotItemIds)
+    {
+        SlotItemIds = slotItemIds;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/QuickSlots_Bind_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/QuickSlots_Bind_Patch.cs
@@ -1,34 +1,35 @@
-﻿using System.Linq;
 using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
-using NitroxModel.Core;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class QuickSlots_Bind_Patch : NitroxPatch, IDynamicPatch
 {
-    public class QuickSlots_Bind_Patch : NitroxPatch, IDynamicPatch
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((QuickSlots t) => t.Bind(default(int), default(InventoryItem)));
+
+    public static void Postfix(QuickSlots __instance)
     {
-        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((QuickSlots t) => t.Bind(default(int), default(InventoryItem)));
-        private static LocalPlayer player;
+        NitroxId[] slotItemIds = new NitroxId[__instance.binding.Length];
 
-        public static void Postfix(QuickSlots __instance)
+        for (int i = 0; i < __instance.binding.Length; i++)
         {
-            // TODO: The binding should only be send on a timer and/or on disconnect. But this functionality/framework is not implemented yet.
-            string[] binding = __instance.SaveBinding();
+            InventoryItem inventoryItem = __instance.binding[i];
 
-            for (int i = 0; i < binding.Length; i++)
+            if (inventoryItem != null && inventoryItem.item)
             {
-                binding[i] ??= "null"; // ProtoBuf can't handle null objects in Lists
+                slotItemIds[i] = NitroxEntity.GetId(inventoryItem.item.gameObject);
             }
-
-            player.BroadcastQuickSlotsBindingChanged(binding.ToList());
         }
 
-        public override void Patch(Harmony harmony)
-        {
-            player = NitroxServiceLocator.LocateService<LocalPlayer>();
-            PatchPostfix(harmony, TARGET_METHOD);
-        }
+        Resolve<LocalPlayer>().BroadcastQuickSlotsBindingChanged(slotItemIds);
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -74,7 +74,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 world.BaseManager.GetBasePiecesForNewlyConnectedPlayer(),
                 world.InventoryManager.GetAllStorageSlotItems(),
                 player.UsedItems,
-                player.QuickSlotsBinding,
+                player.QuickSlotsBindingIds,
                 world.GameData.PDAState.GetInitialPDAData(),
                 world.GameData.StoryGoals.GetInitialStoryGoalData(scheduleKeeper, player),
                 player.Position,

--- a/NitroxServer/Communication/Packets/Processors/PlayerQuickSlotsBindingChangedProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerQuickSlotsBindingChangedProcessor.cs
@@ -1,4 +1,3 @@
-﻿using NitroxModel.DataStructures;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 
@@ -8,7 +7,7 @@ namespace NitroxServer.Communication.Packets.Processors
     {
         public override void Process(PlayerQuickSlotsBindingChanged packet, Player player)
         {
-            player.QuickSlotsBinding = new ThreadSafeList<string>(packet.Binding);
+            player.QuickSlotsBindingIds = packet.SlotItemIds;
         }
     }
 }

--- a/NitroxServer/GameLogic/PlayerManager.cs
+++ b/NitroxServer/GameLogic/PlayerManager.cs
@@ -197,7 +197,7 @@ namespace NitroxServer.GameLogic
                     serverConfig.DefaultPlayerPerm,
                     serverConfig.DefaultPlayerStats,
                     new List<NitroxTechType>(),
-                    Array.Empty<string>(),
+                    new NitroxId[0],
                     new List<EquippedItemData>(),
                     new List<EquippedItemData>(),
                     new Dictionary<string, float>(),

--- a/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
+++ b/NitroxServer/GameLogic/Players/PersistedPlayerData.cs
@@ -18,7 +18,7 @@ public class PersistedPlayerData
     public List<NitroxTechType> UsedItems { get; set; } = new List<NitroxTechType>();
 
     [DataMember(Order = 3)]
-    public List<string> QuickSlotsBinding { get; set; } = new List<string>();
+    public NitroxId[] QuickSlotsBindingIds { get; set; } = new NitroxId[0];
 
     [DataMember(Order = 4)]
     public List<EquippedItemData> EquippedItems { get; set; } = new List<EquippedItemData>();
@@ -73,7 +73,7 @@ public class PersistedPlayerData
                           Permissions,
                           CurrentStats,
                           UsedItems,
-                          QuickSlotsBinding,
+                          QuickSlotsBindingIds,
                           EquippedItems,
                           Modules,
                           PersonalCompletedGoalsWithTimestamp,
@@ -87,7 +87,7 @@ public class PersistedPlayerData
         {
             Name = player.Name,
             UsedItems = player.UsedItems?.ToList(),
-            QuickSlotsBinding = player.QuickSlotsBinding?.ToList(),
+            QuickSlotsBindingIds = player.QuickSlotsBindingIds,
             EquippedItems = player.GetEquipment(),
             Modules = player.GetModules(),
             Id = player.Id,

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -18,7 +18,7 @@ namespace NitroxServer
         private readonly ThreadSafeSet<AbsoluteEntityCell> visibleCells;
 
         public ThreadSafeList<NitroxTechType> UsedItems { get; }
-        public ThreadSafeList<string> QuickSlotsBinding { get; set; }
+        public NitroxId[] QuickSlotsBindingIds { get; set; }
 
         public NitroxConnection Connection { get; set; }
         public PlayerSettings PlayerSettings => PlayerContext.PlayerSettings;
@@ -40,7 +40,7 @@ namespace NitroxServer
 
         public Player(ushort id, string name, bool isPermaDeath, PlayerContext playerContext, NitroxConnection connection,
                       NitroxVector3 position, NitroxQuaternion rotation, NitroxId playerId, Optional<NitroxId> subRootId, Perms perms, PlayerStatsData stats,
-                      IEnumerable<NitroxTechType> usedItems, IEnumerable<string> quickSlotsBinding,
+                      IEnumerable<NitroxTechType> usedItems, NitroxId[] quickSlotsBindingIds,
                       IEnumerable<EquippedItemData> equippedItems, IEnumerable<EquippedItemData> modules, IDictionary<string, float> personalCompletedGoalsWithTimestamp, IDictionary<string, PingInstancePreference> pingInstancePreferences, IList<int> pinnedRecipePreferences)
         {
             Id = id;
@@ -57,7 +57,7 @@ namespace NitroxServer
             LastStoredPosition = null;
             LastStoredSubRootID = Optional.Empty;
             UsedItems = new ThreadSafeList<NitroxTechType>(usedItems);
-            QuickSlotsBinding = new ThreadSafeList<string>(quickSlotsBinding);
+            QuickSlotsBindingIds = quickSlotsBindingIds;
             this.equippedItems = new ThreadSafeList<EquippedItemData>(equippedItems);
             this.modules = new ThreadSafeList<EquippedItemData>(modules);
             visibleCells = new ThreadSafeSet<AbsoluteEntityCell>();


### PR DESCRIPTION
This should be another new feature.  Nitrox existing code for recording quick slot bindings; however, these never got replayed during the initial sync.  Also, this existing code recorded UWE unique identifiers so needed some slight refactoring to use nitrox ids.

Example adding several duplicate items, setting them into quick slots 1/2 and 3/5, then reloading the server several times:

![image](https://user-images.githubusercontent.com/3238547/219850468-42d0c34a-cfca-489b-b73b-a2cb29560960.png)
 