### PR TITLE
Adding fixes for multiple small bugs.

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/SimulationOwnershipChangeProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/SimulationOwnershipChangeProcessor.cs
@@ -29,7 +29,7 @@ public class SimulationOwnershipChangeProcessor : ClientPacketProcessor<Simulati
                     EntityPositionBroadcaster.WatchEntity(simulatedEntity.Id);
                 }
 
-                simulationOwnershipManager.SimulateEntity(simulatedEntity.Id, SimulationLockType.TRANSIENT);
+                simulationOwnershipManager.SimulateEntity(simulatedEntity.Id, simulatedEntity.LockType);
             }
             else if (simulationOwnershipManager.HasAnyLockType(simulatedEntity.Id))
             {

--- a/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NitroxClient.Communication.Abstract;
@@ -165,7 +165,7 @@ public class uGUI_PlayerListTab : uGUI_PingTab
         GameObject newPrefab = Instantiate(basePrefab);
         newPrefab.name = "PlayerEntry";
         // We never want this to appear
-        Destroy(newPrefab.FindChild("ColorToggle"));
+        DestroyImmediate(newPrefab.FindChild("ColorToggle"));
 
         // Need to modify the pingTab's script from uGUI_PingEntry to uGUI_PlayerEntry
         uGUI_PingEntry pingEntry = newPrefab.GetComponent<uGUI_PingEntry>();
@@ -178,7 +178,7 @@ public class uGUI_PlayerListTab : uGUI_PingTab
         playerEntry.id = pingEntry.id;
         playerEntry.spriteVisible = pingEntry.spriteVisible;
         playerEntry.spriteHidden = pingEntry.spriteHidden;
-        Destroy(pingEntry);
+        DestroyImmediate(pingEntry);
 
         // Make buttons for mute, kick, tp
         Transform container = newPrefab.transform;

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -56,7 +56,7 @@ public class PlayerModelManager
         GameObject go = signalHandle.GetResult();
         go.name = "RemotePlayerSignalPrototype";
         go.transform.localScale = new Vector3(.5f, .5f, .5f);
-        go.transform.localPosition += new Vector3(0, 0.8f, 0);
+        go.transform.localPosition = new Vector3(0, 0.8f, 0);
         go.SetActive(false);
 
         result.Set(go);

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -78,6 +78,10 @@ public class PlayerModelManager
         // ping will be moved to the player list tab
         ping.displayPingInManager = false;
 
+        // SignalPing is not required for player as we don't need to display text or anchor to a specific world position
+        // we also take a dependency on the lack of signalping later to differentiate remote player pings from others.
+        Object.DestroyImmediate(signalBase.GetComponent<SignalPing>());
+
         SetInGamePingColor(player, ping);
     }
 

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/PlayerWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/PlayerWorldEntitySpawner.cs
@@ -41,7 +41,7 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
 
             remotePlayer.Value.InitializeGameObject(remotePlayerBody);
             
-            if (!IsSwimming(entity.Transform.LocalPosition.ToUnity(), parent))
+            if (!IsSwimming(entity.Transform.Position.ToUnity(), parent))
             {
                 remotePlayer.Value.UpdateAnimationAndCollider(AnimChangeType.UNDERWATER, AnimChangeState.OFF);
             }
@@ -65,7 +65,7 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
 
     private GameObject CloneLocalPlayerBodyPrototype()
     {
-        GameObject clone = Object.Instantiate(localPlayer.BodyPrototype, Multiplayer.Main.transform, false);
+        GameObject clone = Object.Instantiate(localPlayer.BodyPrototype, null, false);
         clone.SetActive(true);
         return clone;
     }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
@@ -118,6 +118,8 @@ public class VehicleWorldEntitySpawner : IWorldEntitySpawner
 
         NitroxEntity.SetNewId(constructedObject, vehicleEntity.Id);
 
+        AddCinematicControllers(constructedObject);
+
         result.Set(constructedObject);
         yield break;
     }

--- a/NitroxClient/MonoBehaviours/Gui/InGame/Modal.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/Modal.cs
@@ -73,7 +73,7 @@ public abstract class Modal
     {
         if (FreezeGame)
         {
-            FreezeTime.Begin(FreezeTime.Id.IngameMenu);
+            FreezeTime.Begin(FreezeTime.Id.Quit);
         }
         CurrentModal?.Hide();
         CurrentModal = this;

--- a/NitroxClient/MonoBehaviours/Gui/InGame/Modal.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/Modal.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UWE;
@@ -22,7 +23,7 @@ public abstract class Modal
     public static Modal CurrentModal;
 
     private GameObject modalSubWindow;
-    private Text text;
+    private TextMeshProUGUI text;
 
     // All the properties that will be overriden by new instances that inherit this class
     public string SubWindowName { get; init; }
@@ -141,7 +142,7 @@ public abstract class Modal
     /// </summary>
     private void UpdateModal()
     {
-        text = modalSubWindow.FindChild("Header").GetComponent<Text>();
+        text = modalSubWindow.FindChild("Header").GetComponent<TextMeshProUGUI>();
         text.text = ModalText;
 
         GameObject buttonYesObject = modalSubWindow.FindChild("ButtonYes");
@@ -151,7 +152,7 @@ public abstract class Modal
         // We need to reinitialize onClick to avoid keeping Persisted Events (which are set manually inside Unity's Editor)
         yesButton.onClick = new Button.ButtonClickedEvent();
         yesButton.onClick.AddListener(() => { ClickYes(); });
-        buttonYesObject.GetComponentInChildren<Text>().text = YesButtonText;
+        buttonYesObject.GetComponentInChildren<TextMeshProUGUI>().text = YesButtonText;
 
         if (HideNoButton)
         {
@@ -165,7 +166,7 @@ public abstract class Modal
             Button noButton = buttonNoObject.GetComponent<Button>();
             noButton.onClick = new Button.ButtonClickedEvent();
             noButton.onClick.AddListener(() => { ClickNo(); });
-            buttonNoObject.GetComponentInChildren<Text>().text = NoButtonText;
+            buttonNoObject.GetComponentInChildren<TextMeshProUGUI>().text = NoButtonText;
         }
     }
 

--- a/NitroxPatcher/Patches/Dynamic/FreezeTime_Begin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FreezeTime_Begin_Patch.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+using System.Collections.Generic;
+using System.Reflection;
 using HarmonyLib;
 using NitroxModel.Helper;
 using UWE;
@@ -6,23 +7,22 @@ using UWE;
 /// <summary>
 /// Because we're in multiplayer mode, we generally don't want the game to freeze
 /// </summary>
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+public class FreezeTime_Begin_Patch : NitroxPatch, IDynamicPatch
 {
-    public class FreezeTime_Begin_Patch : NitroxPatch, IDynamicPatch
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => FreezeTime.Begin(default(FreezeTime.Id)));
+
+    private static HashSet<FreezeTime.Id> allowedFreezeIds = new() { FreezeTime.Id.Quit, FreezeTime.Id.WaitScreen };
+
+    // We don't want to prevent from freezing the game if the opened modal wants to freeze the game
+    public static bool Prefix(FreezeTime.Id id)
     {
-        private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => FreezeTime.Begin(default(FreezeTime.Id)));
+        return allowedFreezeIds.Contains(id);
+    }
 
-        // We don't want to prevent from freezing the game if the opened modal wants to freeze the game
-        public static bool Prefix(string userId)
-        {
-            // If we ask to freeze from a Nitrox modal, userId will be like this: NitroxServerStoppedModalFreeze
-            return userId.Contains("Nitrox") && userId.EndsWith("Freeze");
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            //TODO: Fix this patch to the new freezetime - it might not be needed anymore
-            //PatchPrefix(harmony, TARGET_METHOD);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerMovementProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerMovementProcessor.cs
@@ -1,20 +1,34 @@
-﻿using NitroxModel.Packets;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic.Entities;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Entities;
 
 namespace NitroxServer.Communication.Packets.Processors
 {
     class PlayerMovementProcessor : AuthenticatedPacketProcessor<PlayerMovement>
     {
         private readonly PlayerManager playerManager;
+        private readonly EntityRegistry entityRegistry;
 
-        public PlayerMovementProcessor(PlayerManager playerManager)
+        public PlayerMovementProcessor(PlayerManager playerManager, EntityRegistry entityRegistry)
         {
             this.playerManager = playerManager;
+            this.entityRegistry = entityRegistry;
         }
 
         public override void Process(PlayerMovement packet, Player player)
         {
+            Optional<PlayerWorldEntity> playerEntity = entityRegistry.GetEntityById<PlayerWorldEntity>(player.PlayerContext.PlayerNitroxId);
+
+            if (playerEntity.HasValue)
+            {
+                playerEntity.Value.Transform.Position = packet.Position;
+                playerEntity.Value.Transform.Rotation = packet.BodyRotation;
+            }
+
             player.Position = packet.Position;
             player.Rotation = packet.BodyRotation;
             playerManager.SendPacketToOtherPlayers(packet, player);


### PR DESCRIPTION
1) Players not being able to enter a newly constructed cyclops due to missing cinematic controllers.
2) Player pings were not showing up due to inappropriate parenting of the remote player game object in addition to unnecessary offset on ping position.
3) The player entity was never having its position updated on the server side.  This makes some calculations incorrect (such as isSwimming).  Currently these positions are in two places, there is a todo item to consolidate.  
4) Fixed a long-standing record keeping bug with simulation lock type not stored on the client properly.  To my knowledge this has no effect as singular lock requests go through a different code path.  However, it was a land mine that should be fixed.  
5) Fixed multiple bugs causing player ping manager to not register changes in ping status or show the action popups.
6) Fixed freeze time so it correctly functions with the big update's enum value.