### PR TITLE
Reducing jitter and stuttering as a cyclops passenger.

### DIFF
--- a/NitroxClient/MonoBehaviours/MultiplayerCyclops.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerCyclops.cs
@@ -8,7 +8,7 @@ namespace NitroxClient.MonoBehaviours
         private ISubThrottleHandler[] subThrottleHandlers;
         private float previousAbsYaw;
 
-        internal RemotePlayer CurrentPlayer { get; set; }
+        public RemotePlayer CurrentPlayer { get; set; }
 
         protected override void Awake()
         {

--- a/NitroxPatcher/Patches/Dynamic/Player_RequiresHighPrecisionPhysics_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_RequiresHighPrecisionPhysics_Patch.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Subnautica enables high precision physics any time a player is in a cyclops that is undergoing physics and is not actively anchored to the pilot seat. 
+/// This is usually rare in the base game (mostly a player disconnecting from the pilot seat); however, it is the normal case for a passanger in nitrox. We
+/// disable the switching as it causing oscillation of the interpolation.  Instead, any time someone is in the submarine we require high precision physics
+/// if there is a remote player actively piloting.
+/// </summary>
+public class Player_RequiresHighPrecisionPhysics_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Player t) => t.RequiresHighPrecisionPhysics());
+
+    public static bool Prefix(ref bool __result)
+    {
+        if (Player.main.currentSub)
+        {
+            MultiplayerCyclops cyclops = Player.main.currentSub.GetComponent<MultiplayerCyclops>();
+
+            if (cyclops)
+            {
+                __result = (cyclops.CurrentPlayer != null);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/VFXConstructing_WakeUpSubmarine_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/VFXConstructing_WakeUpSubmarine_Patch.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// In the base game, subnautica uses a script to freeze all rigid bodies when they get out of distance.  However, this script
+/// also messes with interpolation of objects - especially those being driven by other players.  We disable the functionality
+/// when the Cyclops is fully loaded because there are validations that fail if removing it earlier (i.e. exceptions in code).
+/// </summary>
+public class VFXConstructing_WakeUpSubmarine_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((VFXConstructing t) => t.WakeUpSubmarine());
+
+    public static void Postfix(VFXConstructing __instance)
+    {
+        FreezeRigidbodyWhenFar freezer = __instance.GetComponent<FreezeRigidbodyWhenFar>();
+
+        if (freezer)
+        {
+            freezer.enabled = false;
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
+    }
+}


### PR DESCRIPTION
This an experimental PR to see if we can reduce the poor cyclops experience.
 
I've included two potential fixes:

1) When riding as a passenger, the cyclops interpolation switches rapidly between none/Interpolate each frame.  The root cause is `Player.RequiresHighPrecisionPhysics()` going in and out of criteria every few frames.  The change here is to give a constant value of 'true' when another player is piloting the sub.

2) Even with the above fix the cyclops would stick on 'Interpolate'.  This results in poor visual performance over 'None' when surfacing or diving in the cyclops (and can also launch the player more often!). This was due to the `FreezeRigidbodyWhenFar` causing permanent interpolate when in range although `RequiresHighPrecisionPhysics` should have locked interpolate to 'None'.  This seems like a potential oversight from UWE.  The fix is to patch out `FreezeRigidbodyWhenFar` for the cyclops after construction time.