### PR TITLE
Added entity deletion accounting at several locations.

### DIFF
--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -42,6 +42,8 @@ namespace NitroxClient.GameLogic
 
             NitroxId id = NitroxEntity.GetId(gameObject);
 
+            EntityPositionBroadcaster.StopWatchingEntity(id);
+
             // Some picked up entities are not known by the server for several reasons.  First it can be picked up via a spawn item command.  Another
             // example is that some obects are not 'real' objects until they are clicked and end up spawning a prefab.  For example, the fire extinguisher
             // in the escape pod (mono: IntroFireExtinguisherHandTarget) or Creepvine seeds (mono: PickupPrefab).  When clicked, these spawn new prefabs

--- a/NitroxPatcher/Patches/Dynamic/IncubatorActivationTerminal_OnPlayerCinematicModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorActivationTerminal_OnPlayerCinematicModeEnd_Patch.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// When we place a power crystal into the incubator terminal it becomes consumed.  Inform the server the entity was destroyed.
+/// </summary>
+public class IncubatorActivationTerminal_OnPlayerCinematicModeEnd_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((IncubatorActivationTerminal t) => t.OnPlayerCinematicModeEnd(default(PlayerCinematicController)));
+
+    public static void Prefix(IncubatorActivationTerminal __instance)
+    {
+        if (__instance.crystalObject)
+        {
+            NitroxId id = NitroxEntity.GetId(__instance.crystalObject);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Incubator_OnHatched_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Incubator_OnHatched_Patch.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// The first step of OnHatched() is to check if the enzyme was attached, so that it can be destroyed.
+/// Before this destruction occurs, let's let the server know that the item is being deleted. 
+/// </summary>
+public class Incubator_OnHatched_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Incubator t) => t.OnHatched());
+
+    public static void Prefix(Incubator __instance)
+    {
+        if (__instance.enzymesObject)
+        {
+            NitroxId id = NitroxEntity.GetId(__instance.enzymesObject);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/PrecursorKeyTerminal_DestroyKey_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PrecursorKeyTerminal_DestroyKey_Patch.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// When we place a key into the precursor terminal it becomes consumed.  Inform the server the entity was destroyed.
+/// </summary>
+public class PrecursorKeyTerminal_DestroyKey_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((PrecursorKeyTerminal t) => t.DestroyKey());
+
+    public static void Prefix(PrecursorKeyTerminal __instance)
+    {
+        if (__instance.keyObject)
+        {
+            NitroxId id = NitroxEntity.GetId(__instance.keyObject);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/PrecursorTeleporterActivationTerminal_OnPlayerCinematicModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PrecursorTeleporterActivationTerminal_OnPlayerCinematicModeEnd_Patch.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// When we place a power crystal into the teleporter terminal it becomes consumed.  Inform the server the entity was destroyed.
+/// </summary>
+public class PrecursorTeleporterActivationTerminal_OnPlayerCinematicModeEnd_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((PrecursorTeleporterActivationTerminal t) => t.OnPlayerCinematicModeEnd(default(PlayerCinematicController)));
+
+    public static void Prefix(PrecursorTeleporterActivationTerminal __instance)
+    {
+        if (__instance.crystalObject)
+        {
+            NitroxId id = NitroxEntity.GetId(__instance.crystalObject);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Survival_Eat_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Survival_Eat_Patch.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Let the server know when the player successfully eats an item.
+/// </summary>
+public class Survival_Eat_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Survival t) => t.Eat(default(GameObject)));
+
+    public static void Postfix(bool __result, GameObject useObj)
+    {
+        if (__result && useObj)
+        {
+            NitroxId id = NitroxEntity.GetId(useObj);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Survival_Use_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Survival_Use_Patch.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Let the server know when the player successfully uses a consumable item (such as a first aid kit).
+/// </summary>
+public class Survival_Use_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Survival t) => t.Use(default(GameObject)));
+
+    public static void Postfix(bool __result, GameObject useObj)
+    {
+        if (__result && useObj)
+        {
+            NitroxId id = NitroxEntity.GetId(useObj);
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
@@ -10,16 +10,20 @@ namespace NitroxServer.Communication.Packets.Processors;
 public class EntityDestroyedPacketProcessor : AuthenticatedPacketProcessor<EntityDestroyed>
 {
     private readonly PlayerManager playerManager;
+    private readonly EntitySimulation entitySimulation;
     private readonly WorldEntityManager worldEntityManager;
 
-    public EntityDestroyedPacketProcessor(PlayerManager playerManager, WorldEntityManager worldEntityManager)
+    public EntityDestroyedPacketProcessor(PlayerManager playerManager, EntitySimulation entitySimulation, WorldEntityManager worldEntityManager)
     {
         this.playerManager = playerManager;
         this.worldEntityManager = worldEntityManager;
+        this.entitySimulation = entitySimulation;
     }
 
     public override void Process(EntityDestroyed packet, Player destroyingPlayer)
     {
+        entitySimulation.EntityDestroyed(packet.Id);
+
         if (worldEntityManager.TryDestroyEntity(packet.Id, out Optional<Entity> entity))
         {
             foreach (Player player in playerManager.GetConnectedPlayers())

--- a/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
@@ -14,7 +14,6 @@ namespace NitroxServer.GameLogic.Entities
     public class WorldEntityManager
     {
         private readonly EntityRegistry entityRegistry;
-        private readonly EntitySimulation entitySimulation;
 
         /// <summary>
         ///     Phasing entities can disappear if you go out of range.
@@ -248,8 +247,6 @@ namespace NitroxServer.GameLogic.Entities
 
         public bool TryDestroyEntity(NitroxId entityId, out Optional<Entity> entity)
         {
-            entitySimulation.EntityDestroyed(entityId);
-
             entity = entityRegistry.RemoveEntity(entityId);
 
             if (!entity.HasValue)


### PR DESCRIPTION
Nitrox currently has several codepaths that don't report a destroyed entity.  I went through and plugged some of the major gaps. 

This PR also includes a minor bug fix to remove broadcasting on picked up items and a circular dependency between server classes.