### PR TITLE
Added file locks to prevent race condition errors during parsing

### DIFF
--- a/NitroxModel/Extensions.cs
+++ b/NitroxModel/Extensions.cs
@@ -38,5 +38,6 @@ public static class Extensions
         }
     }
 
+    /// <inheritdoc cref="Array.IndexOf{T}(T[],T)"/>
     public static int GetIndex<T>(this T[] list, T itemToFind) => Array.IndexOf(list, itemToFind);
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
@@ -31,10 +31,13 @@ public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator,
 
     public void Dispose()
     {
-        foreach (KeyValuePair<string, AssemblyDefinition> pair in generator.loadedAssemblies)
+        lock (locker)
         {
-            pair.Value.Dispose();
+            foreach (KeyValuePair<string, AssemblyDefinition> pair in generator.loadedAssemblies)
+            {
+                pair.Value.Dispose();
+            }
+            generator.loadedAssemblies.Clear();
         }
-        generator.loadedAssemblies.Clear();
     }
 }


### PR DESCRIPTION
- [ ] `FileStream`, used by AssetParser on-demand, is not thread safe. Implement a safe wrapping of API.
- [ ] Optimize to get similar performance (server startup time) as before.
