### PR TITLE
Fix Player list and add AnchoredPosition to RectTransform's debug

### DIFF
--- a/NitroxClient/Debuggers/Drawer/UnityUI/RectTransformDrawer.cs
+++ b/NitroxClient/Debuggers/Drawer/UnityUI/RectTransformDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NitroxClient.Debuggers.Drawer.Unity;
 using UnityEngine;
 
@@ -21,11 +21,18 @@ public class RectTransformDrawer : IDrawer
         }
     }
 
-    private static void DrawRectTransform(RectTransform rectTransform)
+    private void DrawRectTransform(RectTransform rectTransform)
     {
         using (new GUILayout.VerticalScope())
         {
             //TODO: Implement position display like the Unity editor
+            using (new GUILayout.HorizontalScope())
+            {
+                GUILayout.Label("Anchored Position", NitroxGUILayout.DrawerLabel, GUILayout.Width(LABEL_WIDTH));
+                NitroxGUILayout.Separator();
+                rectTransform.anchoredPosition = VectorDrawer.DrawVector2(rectTransform.anchoredPosition, VECTOR_MAX_WIDTH);
+            }
+
             using (new GUILayout.HorizontalScope())
             {
                 GUILayout.Label("Local Position", NitroxGUILayout.DrawerLabel, GUILayout.Width(LABEL_WIDTH));

--- a/NitroxClient/GameLogic/HUD/PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PlayerListTab.cs
@@ -1,4 +1,4 @@
-﻿using NitroxClient.GameLogic.HUD.PdaTabs;
+using NitroxClient.GameLogic.HUD.PdaTabs;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.HUD;
@@ -32,6 +32,7 @@ public class PlayerListTab : NitroxPDATab
         tabCopy.SetActive(false);
         uGUI_PlayerListTab newTab = tabCopy.AddComponent<uGUI_PlayerListTab>();
         newTab.MakePrefab(pingTab.prefabEntry);
+        GameObject.DestroyImmediate(tabCopy.GetComponent<uGUI_PingTab>());
         tabCopy.SetActive(true);
 
         tab = newTab;


### PR DESCRIPTION
- Player list is back to normal with colors and everything, also made the buttons position moving it simpler.
![image](https://user-images.githubusercontent.com/24827220/226113819-7a08cf12-ceda-4ac1-8bf9-d3a75fb2bf5a.png)

Position moving issue was caused by the game not having enough time to startup UI elements properly and therefore misplacing the newly created buttons. Making the Start method of ``uGUI_PlayerPingEntry`` an IEnumerator and waiting for one frame before moving the buttons fixes it.

- Added the AnchoredPosition field for RectTransform which is more relevant that global/local position.
![image](https://user-images.githubusercontent.com/24827220/226113945-db7aacc4-f7a0-452c-9084-1f5f755367b2.png)
