### PR TITLE
Added InternalsVisibleTo for all Nitrox projects in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
         <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^Nitrox.*$'))">
         <NitroxProject>true</NitroxProject>
     </PropertyGroup>
@@ -45,7 +45,7 @@
             </ItemGroup>
         </When>
     </Choose>
-    
+
     <!-- Include our analyzer and code gen library to all Nitrox projects -->
     <Choose>
         <When Condition="'$(NitroxLibrary)' == 'true'">
@@ -54,7 +54,7 @@
             </ItemGroup>
         </When>
     </Choose>
-    
+
     <!-- Include default project references to all other "Nitrox*" projects -->
     <Choose>
         <When Condition="'$(UnityModLibrary)' == 'true'">
@@ -70,8 +70,19 @@
             </ItemGroup>
         </When>
     </Choose>
-    
-    <!-- Tell developer that it needs to build the Nitrox.BuildTool to fetch the game assemblies. 
+
+    <!-- Set internals visible for all projects for Nitrox.Test (excluding Nitrox.Test itself) -->
+    <Choose>
+        <When Condition="'$(NitroxLibrary)' == 'true' and '$(TestLibrary)' != 'true'">
+            <ItemGroup>
+                <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+                    <_Parameter1>Nitrox.Test</_Parameter1>
+                </AssemblyAttribute>
+            </ItemGroup>
+        </When>
+    </Choose>
+
+    <!-- Tell developer that it needs to build the Nitrox.BuildTool to fetch the game assemblies.
     "dotnet restore" should still be allowed to run to fetch NuGet packages -->
     <Target Name="PrepareForModding" AfterTargets="Restore;BeforeResolveReferences" Condition="'$(UnityModLibrary)' == 'true' and !Exists('$(BuildGenDir)publicized_assemblies')">
         <Error Text="Run the Nitrox.BuildTool project to fetch the assemblies, before building other Nitrox projects." />

--- a/Nitrox.Test/Model/ExtensionsTests.cs
+++ b/Nitrox.Test/Model/ExtensionsTests.cs
@@ -11,17 +11,18 @@ public class ExtensionsTest
     [TestMethod]
     public void RemoveAllFast_ShouldDoNothingWhenEmptyList()
     {
-        List<string> list = new() { "one", "two", "three", "four" };
-        list.RemoveAllFast((object)null, static (_, _) => false);
-        list.Should().BeEquivalentTo("one", "two", "three", "four");
+        object[] list = Array.Empty<object>();
+        list.Should().BeEmpty();
+        list.RemoveAllFast((object)null, static (_, _) => true);
+        list.Should().BeEmpty();
     }
 
     [TestMethod]
     public void RemoveAllFast_ShouldDoNothingWhenAlwaysFalsePredicate()
     {
-        object[] list = new object[0];
-        list.RemoveAllFast((object)null, static (_, _) => true);
-        list.Should().BeEmpty();
+        List<string> list = new() { "one", "two", "three", "four" };
+        list.RemoveAllFast((object)null, static (_, _) => false);
+        list.Should().BeEquivalentTo("one", "two", "three", "four");
     }
 
     [TestMethod]

--- a/Nitrox.Test/Patcher/Patches/Dynamic/DevConsole_Update_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/DevConsole_Update_PatchTest.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using FluentAssertions;
 using HarmonyLib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NitroxPatcher.Patches.Dynamic;
 using NitroxTest.Patcher;
+using static NitroxPatcher.Patches.Dynamic.DevConsole_Update_Patch;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -14,7 +15,8 @@ public class DevConsole_Update_PatchTest
     [TestMethod]
     public void Sanity()
     {
-        PatchTestHelper.TestPattern(DevConsole_Update_Patch.TargetMethod, DevConsole_Update_Patch.DevConsoleSetStateTruePattern, out IEnumerable<CodeInstruction> originalIl, out IEnumerable<CodeInstruction> transformedIl);
-        originalIl.Count().Should().Be(transformedIl.Count());
+        ReadOnlyCollection<CodeInstruction> originalIl = PatchTestHelper.GetInstructionsFromMethod(TARGET_METHOD);
+        IEnumerable<CodeInstruction> transformedIl = Transpiler(TARGET_METHOD, originalIl);
+        originalIl.Count.Should().Be(transformedIl.Count());
     }
 }

--- a/Nitrox.Test/Patcher/Patches/Dynamic/ItemsContainer_DestroyItem_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/ItemsContainer_DestroyItem_PatchTest.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxTest.Patcher;
 using static NitroxPatcher.Patches.Dynamic.ItemsContainer_DestroyItem_Patch;
 
-namespace Nitrox.Test.Patcher.Patches.Dynamic;
+namespace NitroxPatcher.Patches.Dynamic;
 
 [TestClass]
 public class ItemsContainer_DestroyItem_PatchTest

--- a/NitroxClient/Properties/AssemblyInfo.cs
+++ b/NitroxClient/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
@@ -32,5 +31,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 // COMMON: [assembly: AssemblyVersion("X.X.X.X")]
 // COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
-
-[assembly: InternalsVisibleTo("Nitrox.Test")]

--- a/NitroxModel/Properties/AssemblyInfo.cs
+++ b/NitroxModel/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
@@ -32,5 +31,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 // COMMON: [assembly: AssemblyVersion("X.X.X.X")]
 // COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
-
-[assembly: InternalsVisibleTo("Nitrox.Test")]

--- a/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
@@ -6,41 +6,44 @@ using NitroxPatcher.PatternMatching;
 using UnityEngine;
 using static System.Reflection.Emit.OpCodes;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+///     Keeps DevConsole disabled when enter is pressed.
+/// </summary>
+internal class DevConsole_Update_Patch : NitroxPatch, IDynamicPatch
 {
-    internal class DevConsole_Update_Patch : NitroxPatch, IDynamicPatch
+    private static readonly InstructionsPattern devConsoleSetStateTruePattern = new()
     {
-        /// <summary>
-        ///     Pattern to keep DevConsole disabled when enter is pressed.
-        /// </summary>
-        public static readonly InstructionsPattern DevConsoleSetStateTruePattern = new()
+        Reflect.Method(() => Input.GetKeyDown(default(KeyCode))),
+        Brfalse,
+        Ldarg_0,
+        Ldfld,
+        Brtrue,
+        Ldarg_0,
+        { Ldc_I4_1, "ConsoleEnableFlag" },
+        Reflect.Method((DevConsole t) => t.SetState(default(bool)))
+    };
+
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((DevConsole t) => t.Update());
+
+    public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+    {
+        static void PreventDevConsoleTrue(string label, CodeInstruction instruction)
         {
-            Reflect.Method(() => Input.GetKeyDown(default(string))),
-            Brfalse,
-            Ldarg_0,
-            Ldfld,
-            Brtrue,
-            Ldarg_0,
-            { Ldc_I4_1, "TrueArgument" },
-            Reflect.Method((DevConsole t) => t.SetState(default(bool)))
-        };
-
-        public static readonly MethodInfo TargetMethod = Reflect.Method((DevConsole t) => t.Update());
-
-        public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions) => instructions
-            .Transform(DevConsoleSetStateTruePattern, (label, instruction) =>
+            switch (label)
             {
-                switch (label)
-                {
-                    case "TrueArgument":
-                        instruction.opcode = Ldc_I4_0;
-                        break;
-                }
-            });
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchTranspiler(harmony, TargetMethod);
+                case "ConsoleEnableFlag":
+                    instruction.opcode = Ldc_I4_0;
+                    break;
+            }
         }
+
+        return instructions.Transform(devConsoleSetStateTruePattern, PreventDevConsoleTrue);
+    }
+
+    public override void Patch(Harmony harmony)
+    {
+        PatchTranspiler(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/ItemsContainer_DestroyItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ItemsContainer_DestroyItem_Patch.cs
@@ -24,15 +24,15 @@ public class ItemsContainer_DestroyItem_Patch : NitroxPatch, IDynamicPatch
     {
         Ldarg_0,
         Ldarg_1,
-        { Reflect.Method((ItemsContainer container) => container.RemoveItem(default(TechType))), "NotifyServer" },
-        Stloc_0
+        Reflect.Method((ItemsContainer container) => container.RemoveItem(default(TechType))),
+        { Stloc_0, "NotifyServer" }
     };
 
     public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
     {
         static IEnumerable<CodeInstruction> InsertNotifyServerCall(string label, CodeInstruction instruction)
         {
-            // After the call to RemoveItem we want to call our callback method
+            // After the call to RemoveItem (and storing the return value) we want to call our callback method
             if (label.Equals("NotifyServer"))
             {
                 yield return new(Ldloc_0);

--- a/NitroxPatcher/PatternMatching/InstructionPattern.cs
+++ b/NitroxPatcher/PatternMatching/InstructionPattern.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -38,7 +39,7 @@ public readonly struct InstructionPattern
         Type methodDeclaringType = method.DeclaringType;
         Validate.NotNull(methodDeclaringType);
 
-        return new() { OpCode = OpCodes.Call, Operand = new(methodDeclaringType.Name, method.Name) };
+        return new() { OpCode = OpCodes.Call, Operand = new(methodDeclaringType.FullName, method.Name, method.GetParameters().Select(p => p.ParameterType).ToArray()) };
     }
 
     public static bool operator ==(InstructionPattern pattern, CodeInstruction instruction)

--- a/NitroxPatcher/Properties/AssemblyInfo.cs
+++ b/NitroxPatcher/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
@@ -28,5 +27,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 // COMMON: [assembly: AssemblyVersion("X.X.X.X")]
 // COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
-
-[assembly: InternalsVisibleTo("Nitrox.Test")]

--- a/NitroxServer/Properties/AssemblyInfo.cs
+++ b/NitroxServer/Properties/AssemblyInfo.cs
@@ -28,5 +28,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 // COMMON: [assembly: AssemblyVersion("X.X.X.X")]
 // COMMON: [assembly: AssemblyFileVersion("X.X.X.X")]
-
-[assembly: InternalsVisibleTo("Nitrox.Test")]


### PR DESCRIPTION
Removed manual definitions of InternalsVisibleTo in each project.

We've been using the same namespace in Nitrox.Test as the code it tests but with [this attribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute?view=net-8.0) that's not needed.