### PR TITLE
Restore Launcher Window Animations

### DIFF
--- a/NitroxLauncher/MainWindow.xaml
+++ b/NitroxLauncher/MainWindow.xaml
@@ -11,7 +11,8 @@
         Title="Nitrox Launcher" Height="642" MinHeight="642" Width="1024" MinWidth="1024" 
         WindowStyle="None" WindowStartupLocation="CenterScreen"
         Closing="OnClosing"
-        Background="Black">
+        Background="Black"
+        Loaded="Window_Loaded">
 
     <Window.Resources>
         <BitmapImage x:Key="SidebarNitroxLogo" UriSource="pack://application:,,,/Assets/Images/nitroxLogo.png" />

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -1,12 +1,14 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Interop;
 using NitroxLauncher.Models.Events;
 using NitroxLauncher.Models.Properties;
 using NitroxLauncher.Pages;
@@ -215,6 +217,67 @@ namespace NitroxLauncher
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// Window Animation Code
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+        private static extern int SetWindowLong32(HandleRef hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+        private static extern IntPtr SetWindowLongPtr64(HandleRef hWnd, int nIndex, IntPtr dwNewLong);
+
+        public IntPtr myHWND;
+        public const int GWL_STYLE = -16;
+
+        public static class WS
+        {
+            public static readonly long
+            WS_BORDER = 0x00800000L,
+            WS_CAPTION = 0x00C00000L,
+            WS_CHILD = 0x40000000L,
+            WS_CHILDWINDOW = 0x40000000L,
+            WS_CLIPCHILDREN = 0x02000000L,
+            WS_CLIPSIBLINGS = 0x04000000L,
+            WS_DISABLED = 0x08000000L,
+            WS_DLGFRAME = 0x00400000L,
+            WS_GROUP = 0x00020000L,
+            WS_HSCROLL = 0x00100000L,
+            WS_ICONIC = 0x20000000L,
+            WS_MAXIMIZE = 0x01000000L,
+            WS_MAXIMIZEBOX = 0x00010000L,
+            WS_MINIMIZE = 0x20000000L,
+            WS_MINIMIZEBOX = 0x00020000L,
+            WS_OVERLAPPED = 0x00000000L,
+            WS_OVERLAPPEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+            WS_POPUP = 0x80000000L,
+            WS_POPUPWINDOW = WS_POPUP | WS_BORDER | WS_SYSMENU,
+            WS_SIZEBOX = 0x00040000L,
+            WS_SYSMENU = 0x00080000L,
+            WS_TABSTOP = 0x00010000L,
+            WS_THICKFRAME = 0x00040000L,
+            WS_TILED = 0x00000000L,
+            WS_TILEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+            WS_VISIBLE = 0x10000000L,
+            WS_VSCROLL = 0x00200000L;
+        }
+
+        public static IntPtr SetWindowLongPtr(HandleRef hWnd, int nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 8)
+            {
+                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+            }
+            else
+            {
+                return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+            }
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            myHWND = new WindowInteropHelper(this).Handle;
+            IntPtr myStyle = new IntPtr(WS.WS_CAPTION | WS.WS_CLIPCHILDREN | WS.WS_MINIMIZEBOX | WS.WS_MAXIMIZEBOX | WS.WS_SYSMENU | WS.WS_SIZEBOX);
+            SetWindowLongPtr(new HandleRef(null, myHWND), GWL_STYLE, myStyle);
         }
     }
 }

--- a/NitroxLauncher/MainWindow.xaml.cs
+++ b/NitroxLauncher/MainWindow.xaml.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -14,6 +13,7 @@ using NitroxLauncher.Models.Properties;
 using NitroxLauncher.Pages;
 using NitroxModel.Discovery;
 using NitroxModel.Helper;
+using NitroxModel.Platforms.OS.Windows;
 
 namespace NitroxLauncher
 {
@@ -43,7 +43,7 @@ namespace NitroxLauncher
         {
             Log.Setup();
             LauncherNotifier.Setup();
-            
+
             logic = new LauncherLogic();
 
             MaxHeight = SystemParameters.VirtualScreenHeight;
@@ -68,7 +68,7 @@ namespace NitroxLauncher
                                     MessageBoxImage.Error);
                     Environment.Exit(1);
                 }
-                
+
                 // This pirate detection subscriber is immediately invoked if pirate has been detected right now.
                 PirateDetection.PirateDetected += (o, eventArgs) =>
                 {
@@ -80,7 +80,7 @@ namespace NitroxLauncher
                         HorizontalAlignment = HorizontalAlignment.Stretch,
                         VerticalAlignment = VerticalAlignment.Stretch,
                         Margin = new Thickness(0),
-                        
+
                         Height = MinHeight * 0.7,
                         Width = MinWidth * 0.7
                     };
@@ -219,65 +219,9 @@ namespace NitroxLauncher
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        /// Window Animation Code
-        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-        private static extern int SetWindowLong32(HandleRef hWnd, int nIndex, int dwNewLong);
-
-        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-        private static extern IntPtr SetWindowLongPtr64(HandleRef hWnd, int nIndex, IntPtr dwNewLong);
-
-        public IntPtr myHWND;
-        public const int GWL_STYLE = -16;
-
-        public static class WS
-        {
-            public static readonly long
-            WS_BORDER = 0x00800000L,
-            WS_CAPTION = 0x00C00000L,
-            WS_CHILD = 0x40000000L,
-            WS_CHILDWINDOW = 0x40000000L,
-            WS_CLIPCHILDREN = 0x02000000L,
-            WS_CLIPSIBLINGS = 0x04000000L,
-            WS_DISABLED = 0x08000000L,
-            WS_DLGFRAME = 0x00400000L,
-            WS_GROUP = 0x00020000L,
-            WS_HSCROLL = 0x00100000L,
-            WS_ICONIC = 0x20000000L,
-            WS_MAXIMIZE = 0x01000000L,
-            WS_MAXIMIZEBOX = 0x00010000L,
-            WS_MINIMIZE = 0x20000000L,
-            WS_MINIMIZEBOX = 0x00020000L,
-            WS_OVERLAPPED = 0x00000000L,
-            WS_OVERLAPPEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
-            WS_POPUP = 0x80000000L,
-            WS_POPUPWINDOW = WS_POPUP | WS_BORDER | WS_SYSMENU,
-            WS_SIZEBOX = 0x00040000L,
-            WS_SYSMENU = 0x00080000L,
-            WS_TABSTOP = 0x00010000L,
-            WS_THICKFRAME = 0x00040000L,
-            WS_TILED = 0x00000000L,
-            WS_TILEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
-            WS_VISIBLE = 0x10000000L,
-            WS_VSCROLL = 0x00200000L;
-        }
-
-        public static IntPtr SetWindowLongPtr(HandleRef hWnd, int nIndex, IntPtr dwNewLong)
-        {
-            if (IntPtr.Size == 8)
-            {
-                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
-            }
-            else
-            {
-                return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
-            }
-        }
-
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            myHWND = new WindowInteropHelper(this).Handle;
-            IntPtr myStyle = new IntPtr(WS.WS_CAPTION | WS.WS_CLIPCHILDREN | WS.WS_MINIMIZEBOX | WS.WS_MAXIMIZEBOX | WS.WS_SYSMENU | WS.WS_SIZEBOX);
-            SetWindowLongPtr(new HandleRef(null, myHWND), GWL_STYLE, myStyle);
+            WindowsApi.EnableDefaultWindowAnimations(new WindowInteropHelper(this).Handle);
         }
     }
 }

--- a/NitroxModel/Platforms/OS/Windows/Internal/Win32Native.cs
+++ b/NitroxModel/Platforms/OS/Windows/Internal/Win32Native.cs
@@ -334,6 +334,44 @@ internal static class Win32Native
         Install
     }
 
+    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+    internal static extern int SetWindowLong32(HandleRef hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+    internal static extern IntPtr SetWindowLongPtr64(HandleRef hWnd, int nIndex, IntPtr dwNewLong);
+
+    [Flags]
+    public enum WS : long
+    {
+        WS_BORDER = 0x00800000L,
+        WS_CAPTION = 0x00C00000L,
+        WS_CHILD = 0x40000000L,
+        WS_CHILDWINDOW = 0x40000000L,
+        WS_CLIPCHILDREN = 0x02000000L,
+        WS_CLIPSIBLINGS = 0x04000000L,
+        WS_DISABLED = 0x08000000L,
+        WS_DLGFRAME = 0x00400000L,
+        WS_GROUP = 0x00020000L,
+        WS_HSCROLL = 0x00100000L,
+        WS_ICONIC = 0x20000000L,
+        WS_MAXIMIZE = 0x01000000L,
+        WS_MAXIMIZEBOX = 0x00010000L,
+        WS_MINIMIZE = 0x20000000L,
+        WS_MINIMIZEBOX = 0x00020000L,
+        WS_OVERLAPPED = 0x00000000L,
+        WS_OVERLAPPEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+        WS_POPUP = 0x80000000L,
+        WS_POPUPWINDOW = WS_POPUP | WS_BORDER | WS_SYSMENU,
+        WS_SIZEBOX = 0x00040000L,
+        WS_SYSMENU = 0x00080000L,
+        WS_TABSTOP = 0x00010000L,
+        WS_THICKFRAME = 0x00040000L,
+        WS_TILED = 0x00000000L,
+        WS_TILEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+        WS_VISIBLE = 0x10000000L,
+        WS_VSCROLL = 0x00200000L
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     private struct WINTRUST_DATA : IDisposable
     {

--- a/NitroxModel/Platforms/OS/Windows/WindowsApi.cs
+++ b/NitroxModel/Platforms/OS/Windows/WindowsApi.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+using NitroxModel.Platforms.OS.Windows.Internal;
+
+namespace NitroxModel.Platforms.OS.Windows;
+
+public class WindowsApi
+{
+    public static void EnableDefaultWindowAnimations(IntPtr hWnd, int nIndex = -16)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            IntPtr dwNewLong = new((long)(Win32Native.WS.WS_CAPTION | Win32Native.WS.WS_CLIPCHILDREN | Win32Native.WS.WS_MINIMIZEBOX | Win32Native.WS.WS_MAXIMIZEBOX | Win32Native.WS.WS_SYSMENU | Win32Native.WS.WS_SIZEBOX));
+            HandleRef handle = new(null, hWnd);
+            switch (IntPtr.Size)
+            {
+                case 8:
+                    Win32Native.SetWindowLongPtr64(handle, nIndex, dwNewLong);
+                    break;
+                default:
+                    Win32Native.SetWindowLong32(handle, nIndex, dwNewLong.ToInt32());
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
While working on a side WPF project, I was trying to find out how to restore the default window animations when creating a custom window (i.e. setting `WindowStyle="None"` for the base window), and I came across [this stack overflow question](https://stackoverflow.com/questions/56175722/how-to-restore-the-default-show-close-animations-for-a-window-when-setting-windo) that had code that somehow worked, for the most part. I tried putting it into the Nitrox launcher code and it worked there as well, so I decided that it might be a nice addition to the launcher.

It was also not supposed to restore the opening and closing animations of the window (it didn't for my project or for the user in that post), but it somehow did for the Nitrox launcher. There is just one small issue where the closing animation doesn't play if you close the app right away after opening it (as was supposed to be shown at the end of the video below, though OBS cut it off).

I know that work on the current launcher is not desired because of the Avalonia redesign that we are currently working on, however, I think this could be a nice addition to the current launcher while we are still working on that (and in case we don't get it finished before v1.8.0.0). I intend to also input this into the new launcher if that is possible (seeing as that this code is specific to Windows and may interfere with Linux compatibility).

Note; I am not sure if the place that I put the code is the best place to put it, but it was the only place that worked from what I've tried. I imagine that putting it in a separate file might be better.

https://user-images.githubusercontent.com/32976499/234925018-e5bd312d-50d5-4712-bc8c-86359a1991b8.mp4
