### PR TITLE
Disable "Add Server" button when add server window overlay enabled

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
@@ -21,6 +21,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         private GameObject savedGamesRef;
         private GameObject deleteButtonRef;
         private GameObject multiplayerButton;
+        private GameObject addServerButtonInst;
         private Transform savedGameAreaContent;
         public JoinServer JoinServer { get; private set; }
 
@@ -31,6 +32,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         private bool shouldFocus;
         private bool showingAddServer;
         private bool isJoining;
+        private bool isAddServerEnabled;
 
         public void Setup(GameObject loadedMultiplayer, GameObject savedGames)
         {
@@ -48,14 +50,15 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
             deleteButtonRef = savedGamesRef.GetComponent<MainMenuLoadPanel>().saveInstance.GetComponent<MainMenuLoadButton>().deleteButton;
 
             CreateButton(translationKey: "Nitrox_AddServer", clickEvent: ShowAddServerWindow, disableTranslation: false);
+            isAddServerEnabled = true;
             LoadSavedServers();
             _ = FindLANServersAsync();
         }
 
         private void CreateButton(string translationKey, UnityAction clickEvent, bool disableTranslation)
         {
-            GameObject multiplayerButtonInst = Instantiate(multiplayerButton, savedGameAreaContent, false);
-            Transform txt = multiplayerButtonInst.RequireTransform("NewGameButton/Text");
+            addServerButtonInst = Instantiate(multiplayerButton, savedGameAreaContent, false);
+            Transform txt = addServerButtonInst.RequireTransform("NewGameButton/Text");
             txt.GetComponent<TextMeshProUGUI>().text = translationKey;
 
             if (disableTranslation)
@@ -63,7 +66,7 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
                 Destroy(txt.GetComponent<TranslationLiveUpdate>());
             }
 
-            Button multiplayerButtonButton = multiplayerButtonInst.RequireTransform("NewGameButton").GetComponent<Button>();
+            Button multiplayerButtonButton = addServerButtonInst.RequireTransform("NewGameButton").GetComponent<Button>();
             multiplayerButtonButton.onClick = new Button.ButtonClickedEvent();
             multiplayerButtonButton.onClick.AddListener(clickEvent);
         }
@@ -146,7 +149,19 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
         {
             if (showingAddServer)
             {
+                if (isAddServerEnabled)
+                {
+                    Button multiplayerButtonButton = addServerButtonInst.RequireTransform("NewGameButton").GetComponent<Button>();
+                    multiplayerButtonButton.enabled = false;
+                    isAddServerEnabled = false;
+                }
                 addServerWindowRect = GUILayout.Window(GUIUtility.GetControlID(FocusType.Keyboard), addServerWindowRect, DoAddServerWindow, Language.main.Get("Nitrox_AddServer"));
+            }
+            else if (!isAddServerEnabled)
+            {
+                Button multiplayerButtonButton = addServerButtonInst.RequireTransform("NewGameButton").GetComponent<Button>();
+                multiplayerButtonButton.enabled = true;
+                isAddServerEnabled = true;
             }
         }
 

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/MainMenuMultiplayerPanel.cs
@@ -130,17 +130,12 @@ namespace NitroxClient.MonoBehaviours.Gui.MainMenu
 
         private void ShowAddServerWindow()
         {
-            IEnumerator SetWindowComponents()
-            {
-                serverNameInput = "local";
-                serverHostInput = "127.0.0.1";
-                serverPortInput = ServerList.DEFAULT_PORT.ToString();
-                showingAddServer = true;
-                shouldFocus = true;
-                yield return null;
-                uGUI_MainMenu.main.canvasGroup.interactable = false;
-            }
-            CoroutineHost.StartCoroutine(SetWindowComponents());
+            serverNameInput = "local";
+            serverHostInput = "127.0.0.1";
+            serverPortInput = ServerList.DEFAULT_PORT.ToString();
+            showingAddServer = true;
+            shouldFocus = true;
+            uGUI_MainMenu.main.canvasGroup.interactable = false;
         }
 
         private void HideAddServerWindow()


### PR DESCRIPTION
Should close #1995 by disabling button when showingAddServer enabled

Main method for disabling button is handled in OnGUI but utilises a flag to prevent multiple expensive ops per frame. should mean it should run the expensive ops on 1 frame, and never again until the state changes

This fix required both modifying a variable name and moving this gameobject var to an outer scope. I have ran basic tests throughout the menu and have not observed any issues with this whatsoever. but if there is something deep-rooted that this would affect, I can try and approach it from a different angle.