### PR TITLE
Added ability to open explorer at Server World save file location on Launcher.

### DIFF
--- a/NitroxLauncher/Pages/ServerPage.xaml
+++ b/NitroxLauncher/Pages/ServerPage.xaml
@@ -20,6 +20,7 @@
         <BitmapImage x:Key="AddServerButton" UriSource="pack://application:,,,/Assets/Images/world-manager/plus-2x.png"/>
         <BitmapImage x:Key="RefreshButton" UriSource="pack://application:,,,/Assets/Images/world-manager/reload-2x.png"/>
         <BitmapImage x:Key="GoBackButton" UriSource="pack://application:,,,/Assets/Images/world-manager/back-2x.png"/>
+        <BitmapImage x:Key="SaveLocationButton" UriSource="pack://application:,,,/Assets/Images/world-manager/cog-2x.png" />
 
         <Storyboard x:Key="WorldSelectedAnimation">
             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="WorldSelectionPane" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[3].(TranslateTransform.X)">
@@ -292,7 +293,7 @@
                                         <!-- Template for World Listing Buttons -->
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <Border x:Name="WorldListingBorder" Height="83" Width="Auto" Background="#FF151516" CornerRadius="7" Margin="0 3">
+                                                <Border x:Name="WorldListingBorder" Height="125" Width="Auto" Background="#FF151516" CornerRadius="7" Margin="0 3">
                                                     <Grid Width="Auto" MaxWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Border}}">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="*"/>
@@ -332,6 +333,8 @@
                                                         <!-- World Options Pop-up -->
                                                         <Grid x:Name="WorldOptionsBox" Grid.Column="2" Height="{Binding Height, RelativeSource={RelativeSource AncestorType=Border}}" Width="0">
                                                             <Grid.RowDefinitions>
+                                                                <RowDefinition />
+                                                                <RowDefinition Height="2" />
                                                                 <RowDefinition/>
                                                                 <RowDefinition Height="2"/>
                                                                 <RowDefinition/>
@@ -345,10 +348,22 @@
                                                             <!-- Separator -->
                                                             <Border Grid.Row="1" Background="Black"/>
 
+                                                            <!--Save File Location Button -->
+                                                            <Button Grid.Row="2" ToolTip="Open Save File Location" Click="OpenSaveFileLocation_Click"
+                                                                    Height="{Binding Height, RelativeSource={RelativeSource AncestorType=Grid}}"
+                                                                    Width="{Binding Width, RelativeSource={RelativeSource AncestorType=Grid}}">
+                                                                <Image Source="{StaticResource SaveLocationButton}" Width="20" Height="20" />
+                                                            </Button>
+
+                                                            <Border Grid.Row="3" Background="Black" />
+                                                            
                                                             <!-- Delete World Button -->
-                                                            <Button Grid.Row="2" ToolTip="Delete this world" Click="DeleteWorld_Click" Height="{Binding Height, RelativeSource={RelativeSource AncestorType=Grid}}" Width="{Binding Width, RelativeSource={RelativeSource AncestorType=Grid}}">
+                                                            <Button Grid.Row="4" ToolTip="Delete this world" Click="DeleteWorld_Click"
+                                                                    Height="{Binding Height, RelativeSource={RelativeSource AncestorType=Grid}}"
+                                                                    Width="{Binding Width, RelativeSource={RelativeSource AncestorType=Grid}}">
                                                                 <Image Source="{StaticResource TrashcanButton}" Width="20" Height="20"/>
                                                             </Button>
+
                                                         </Grid>
                                                     </Grid>
                                                 </Border>
@@ -766,7 +781,7 @@
 
         </Grid>
 
-        <Grid x:Name="ConfirmationBox" Opacity="0" IsHitTestVisible="False" Grid.RowSpan="2">
+        <Grid x:Name="ConfirmationBox" Opacity="0" IsHitTestVisible="False" Grid.RowSpan="4">
 
             <!-- Have all of the background act like the "No" button when clicked -->
             <Button Click="NoConfirmBtn_Click" Background="Black" Opacity=".5" Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Grid}}" Height="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=Grid}}" Cursor="Arrow"/>

--- a/NitroxLauncher/Pages/ServerPage.xaml.cs
+++ b/NitroxLauncher/Pages/ServerPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -7,13 +8,13 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
+using Microsoft.VisualBasic.FileIO;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using NitroxLauncher.Models;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Server;
 using NitroxServer.Serialization;
 using NitroxServer.Serialization.World;
-using Microsoft.VisualBasic.FileIO;
 
 namespace NitroxLauncher.Pages
 {
@@ -253,6 +254,25 @@ namespace NitroxLauncher.Pages
             throw new NotImplementedException();
         }
 
+        private void OpenSaveFileLocation_Click(object sender, RoutedEventArgs e)
+        {
+            WorldManager.Listing selectedWorld = GetWorldListingFromSenderControl(sender);
+            if (Directory.Exists(selectedWorld.WorldSaveDir))
+            {
+                ProcessStartInfo startExplorerProcessInfo = new()
+                {
+                    Arguments = selectedWorld.WorldSaveDir,
+                    FileName = "explorer.exe"
+                };
+
+                Process.Start(startExplorerProcessInfo);
+            }
+            else
+            {
+                LauncherNotifier.Error($"No save file available at location: {SelectedWorldDirectory}...");
+            }
+        }
+
         private void DeleteWorld_Click(object sender, RoutedEventArgs e)
         {
             WorldManager.Listing selectedWorld = GetWorldListingFromSenderControl(sender);
@@ -405,7 +425,7 @@ namespace NitroxLauncher.Pages
             Config.Seed = TBWorldSeed.Text;
         }
 
-        private void TBMaxPlayerCap_Input(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        private void TBMaxPlayerCap_Input(object sender, KeyboardFocusChangedEventArgs e)
         {
             string originalMaxPlayerCap = Convert.ToString(Config.MaxConnections);
 
@@ -459,7 +479,7 @@ namespace NitroxLauncher.Pages
             }
         }
         
-        private void TBSaveInterval_Input(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        private void TBSaveInterval_Input(object sender, KeyboardFocusChangedEventArgs e)
         {
             string originalSaveInterval = Convert.ToString(Config.SaveInterval/1000);
 
@@ -496,7 +516,7 @@ namespace NitroxLauncher.Pages
             Config.SaveInterval = saveIntervalNum;
         }
 
-        private void TBJoinPassword_Input(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        private void TBJoinPassword_Input(object sender, KeyboardFocusChangedEventArgs e)
         {
             TBJoinPassword.Text = TBJoinPassword.Text.TrimStart();
             TBJoinPassword.Text = TBJoinPassword.Text.TrimEnd();
@@ -509,7 +529,7 @@ namespace NitroxLauncher.Pages
             }
         }
 
-        private void TBWorldServerPort_Input(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e)
+        private void TBWorldServerPort_Input(object sender, KeyboardFocusChangedEventArgs e)
         {
             string originalServerPort = Convert.ToString(Config.ServerPort);
 
@@ -629,7 +649,7 @@ namespace NitroxLauncher.Pages
             using (CommonOpenFileDialog dialog = new()
             {
                 Multiselect = false,
-                InitialDirectory = System.IO.Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
+                InitialDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
                 EnsurePathExists = true,
                 IsFolderPicker = true,
                 Title = "Select the save file to import"

--- a/NitroxLauncher/Pages/ServerPage.xaml.cs
+++ b/NitroxLauncher/Pages/ServerPage.xaml.cs
@@ -259,13 +259,21 @@ namespace NitroxLauncher.Pages
             WorldManager.Listing selectedWorld = GetWorldListingFromSenderControl(sender);
             if (Directory.Exists(selectedWorld.WorldSaveDir))
             {
-                ProcessStartInfo startExplorerProcessInfo = new()
+                try
                 {
-                    Arguments = selectedWorld.WorldSaveDir,
-                    FileName = "explorer.exe"
-                };
+                    ProcessStartInfo startExplorerProcessInfo = new()
+                    {
+                        Arguments = selectedWorld.WorldSaveDir,
+                        FileName = "explorer.exe"
+                    };
 
-                Process.Start(startExplorerProcessInfo);
+                    Process.Start(startExplorerProcessInfo);
+                }
+                catch (Exception ex)
+                {
+                    LauncherNotifier.Error("Unable to start explorer process at save location. This has been logged.");
+                    Log.Error($"Exception on trying to start explorer process at save file location. : {ex.GetType()} {ex.Message}");
+                }
             }
             else
             {

--- a/NitroxLauncher/Pages/ServerPage.xaml.cs
+++ b/NitroxLauncher/Pages/ServerPage.xaml.cs
@@ -261,13 +261,7 @@ namespace NitroxLauncher.Pages
             {
                 try
                 {
-                    ProcessStartInfo startExplorerProcessInfo = new()
-                    {
-                        Arguments = selectedWorld.WorldSaveDir,
-                        FileName = "explorer.exe"
-                    };
-
-                    Process.Start(startExplorerProcessInfo);
+                    Process.Start($"file://{selectedWorld.WorldSaveDir}");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Addresses #2020 by adding a button to the server worlds menu to open the save file location of that world.
Used existing settings and icons wherever I could to make this addition as seamless as possible. 

I also propose replacing the ellipsis icon for the world settings with the cog icon, allowing me to then use the ellipsis icon for opening the save file location which think would make more sense. 

Increased the size of each list element to accommodate the new button whilst keeping the old button sizes the same. 83 -> 125 px in height.