### PR TITLE
Prevent keybind resetting on startup

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
+using NitroxClient.Serialization;
 
 namespace NitroxClient.MonoBehaviours.Gui.Input
 {
@@ -11,11 +12,13 @@ namespace NitroxClient.MonoBehaviours.Gui.Input
 
         public KeyBindingManager()
         {
+            ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
             KeyboardKeyBindings = new List<KeyBinding>
             {
                 // new bindings should not be set to a value equivalent to a pre-existing GameInput.Button enum or another custom binding
-                new(45, "Chat", GameInput.Device.Keyboard, new DefaultKeyBinding("Y", GameInput.BindingSet.Primary), new ChatKeyBindingAction()),
-                new(46, "Focus Discord (Alt +)", GameInput.Device.Keyboard, new DefaultKeyBinding("F", GameInput.BindingSet.Primary), new DiscordFocusBindingAction())
+                new((int)KeyBindingValues.CHAT, "Chat", GameInput.Device.Keyboard, new DefaultKeyBinding(cfg.OpenChatKeybindPrimary, GameInput.BindingSet.Primary), new ChatKeyBindingAction(), !string.IsNullOrEmpty(cfg.OpenChatKeybindSecondary)),
+                new((int)KeyBindingValues.FOCUS_DISCORD, "Focus Discord (Alt +)", GameInput.Device.Keyboard, new DefaultKeyBinding(cfg.FocusDiscordKeybindPrimary, GameInput.BindingSet.Primary), new DiscordFocusBindingAction(),
+                    !string.IsNullOrEmpty(cfg.FocusDiscordKeybindSecondary)),
             };
         }
 
@@ -24,5 +27,14 @@ namespace NitroxClient.MonoBehaviours.Gui.Input
         {
             return KeyboardKeyBindings.Select(keyBinding => (int)keyBinding.Button).DefaultIfEmpty(0).Max();
         }
+    }
+
+    /// <summary>
+    ///     Refers the keybinding values used for button creation in the options menu, to a more clear form
+    /// </summary>
+    public enum KeyBindingValues
+    {
+        CHAT = 45,
+        FOCUS_DISCORD = 46
     }
 }

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 using NitroxClient.Serialization;
+using NitroxModel.Helper;
 
 namespace NitroxClient.MonoBehaviours.Gui.Input
 {
@@ -12,13 +13,12 @@ namespace NitroxClient.MonoBehaviours.Gui.Input
 
         public KeyBindingManager()
         {
-            ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
+            ClientConfig cfg = ClientConfig.Load(NitroxUser.AppDataPath);
             KeyboardKeyBindings = new List<KeyBinding>
             {
                 // new bindings should not be set to a value equivalent to a pre-existing GameInput.Button enum or another custom binding
-                new((int)KeyBindingValues.CHAT, "Chat", GameInput.Device.Keyboard, new DefaultKeyBinding(cfg.OpenChatKeybindPrimary, GameInput.BindingSet.Primary), new ChatKeyBindingAction(), !string.IsNullOrEmpty(cfg.OpenChatKeybindSecondary)),
-                new((int)KeyBindingValues.FOCUS_DISCORD, "Focus Discord (Alt +)", GameInput.Device.Keyboard, new DefaultKeyBinding(cfg.FocusDiscordKeybindPrimary, GameInput.BindingSet.Primary), new DiscordFocusBindingAction(),
-                    !string.IsNullOrEmpty(cfg.FocusDiscordKeybindSecondary)),
+                new((int)KeyBindingValues.CHAT, "Chat", GameInput.Device.Keyboard, new ChatKeyBindingAction(), cfg.OpenChatKeybindPrimary, cfg.OpenChatKeybindSecondary),
+                new((int)KeyBindingValues.FOCUS_DISCORD, "Focus Discord (Alt +)", GameInput.Device.Keyboard, new DiscordFocusBindingAction(), cfg.FocusDiscordKeybindPrimary, cfg.FocusDiscordKeybindSecondary),
             };
         }
 

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
@@ -6,17 +6,19 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings
     {
         public GameInput.Button Button { get; }
         public GameInput.Device Device { get; }
+        public bool HasSecondary { get; }
         public string Label { get; }
         public DefaultKeyBinding DefaultKeyBinding { get; }
         public KeyBindingAction Action { get; }
 
-        public KeyBinding(int keyBindingValue, string buttonLabel, GameInput.Device buttonDevice, DefaultKeyBinding buttonDefaults, KeyBindingAction buttonAction)
+        public KeyBinding(int keyBindingValue, string buttonLabel, GameInput.Device buttonDevice, DefaultKeyBinding buttonDefaults, KeyBindingAction buttonAction, bool hasSecondary = false)
         {
             Button = (GameInput.Button)keyBindingValue;
             Device = buttonDevice;
             Label = buttonLabel;
             Action = buttonAction;
             DefaultKeyBinding = buttonDefaults;
+            HasSecondary = hasSecondary;
         }
     }
 }

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
@@ -1,24 +1,26 @@
 ﻿using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
+using NitroxModel.Helper;
 
-namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings
+namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
+
+public class KeyBinding
 {
-    public class KeyBinding
-    {
-        public GameInput.Button Button { get; }
-        public GameInput.Device Device { get; }
-        public bool HasSecondary { get; }
-        public string Label { get; }
-        public DefaultKeyBinding DefaultKeyBinding { get; }
-        public KeyBindingAction Action { get; }
+    public GameInput.Button Button { get; }
+    public GameInput.Device Device { get; }
+    public string Label { get; }
+    public string PrimaryKey { get; }
+    public string SecondaryKey { get; }
+    public KeyBindingAction Action { get; }
 
-        public KeyBinding(int keyBindingValue, string buttonLabel, GameInput.Device buttonDevice, DefaultKeyBinding buttonDefaults, KeyBindingAction buttonAction, bool hasSecondary = false)
-        {
-            Button = (GameInput.Button)keyBindingValue;
-            Device = buttonDevice;
-            Label = buttonLabel;
-            Action = buttonAction;
-            DefaultKeyBinding = buttonDefaults;
-            HasSecondary = hasSecondary;
-        }
+    public KeyBinding(int keyBindingValue, string buttonLabel, GameInput.Device buttonDevice, KeyBindingAction buttonAction, string primaryKey, string secondaryKey = null)
+    {
+        Validate.NotNull(primaryKey);
+
+        Button = (GameInput.Button)keyBindingValue;
+        Device = buttonDevice;
+        Label = buttonLabel;
+        Action = buttonAction;
+        PrimaryKey = primaryKey;
+        SecondaryKey = secondaryKey;
     }
 }

--- a/NitroxClient/Serialization/ClientConfig.cs
+++ b/NitroxClient/Serialization/ClientConfig.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.IO;
+using NitroxModel.Helper;
 using NitroxModel.Serialization;
 
 namespace NitroxClient.Serialization;
-
-public class ClientConfigSettings
-{
-    public static readonly string NitroxRoamingDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
-}
 
 /// <summary>
 ///     This is the client config for Nitrox
@@ -34,32 +30,28 @@ public class ClientConfig : NitroxConfig<ClientConfig>
     ///     This is ran once on game startup. Use <see cref="ClientConfig.Load" /> to retrieve instance
     /// </summary>
     /// <returns>Instance of ClientConfig</returns>
-    public static ClientConfig InitClientConfig()
+    public static ClientConfig Init()
     {
-        if (!Directory.Exists(ClientConfigSettings.NitroxRoamingDir))
-        {
-            Directory.CreateDirectory(ClientConfigSettings.NitroxRoamingDir);
-        }
+        string appDataPath = NitroxUser.AppDataPath;
+        Directory.CreateDirectory(appDataPath);
 
         ClientConfig cfg = null;
         try
         {
-            if (File.Exists(Path.Combine(ClientConfigSettings.NitroxRoamingDir, "client.cfg")))
+            if (File.Exists(Path.Combine(appDataPath, "client.cfg")))
             {
-                cfg = Load(ClientConfigSettings.NitroxRoamingDir);
+                cfg = Load(appDataPath);
             }
             else
             {
                 cfg = new ClientConfig();
-                cfg.Serialize(ClientConfigSettings.NitroxRoamingDir);
+                cfg.Serialize(appDataPath);
             }
         }
         catch (Exception ex)
         {
             Log.Error($"Unable to load client config: {ex.Message}");
         }
-
-        Log.Info("Client Config Registered.");
 
         return cfg;
     }

--- a/NitroxClient/Serialization/ClientConfig.cs
+++ b/NitroxClient/Serialization/ClientConfig.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using NitroxModel.Serialization;
+
+namespace NitroxClient.Serialization;
+
+public class ClientConfigSettings
+{
+    public static readonly string NitroxRoamingDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
+}
+
+/// <summary>
+///     This is the client config for Nitrox
+///     The file should be stored under %appdata%\Roaming\Nitrox\client.cfg
+/// </summary>
+[PropertyDescription("These are the settings for the Nitrox Client.")]
+public class ClientConfig : NitroxConfig<ClientConfig>
+{
+    public override string FileName => "client.cfg";
+
+    [PropertyDescription("Keybinds to open chat [Default primary is Y]")]
+    public string OpenChatKeybindPrimary { get; set; } = "Y";
+
+    public string OpenChatKeybindSecondary { get; set; } = "";
+
+    [PropertyDescription("Keybinds to focus discord, ALT + [Default primary is F]")]
+    public string FocusDiscordKeybindPrimary { get; set; } = "F";
+
+    public string FocusDiscordKeybindSecondary { get; set; } = "";
+
+    /// <summary>
+    ///     This method initialises the client config
+    ///     It checks for an existing file and returns back either a fresh instance, or an existing instance
+    ///     This is ran once on game startup. Use <see cref="ClientConfig.Load" /> to retrieve instance
+    /// </summary>
+    /// <returns>Instance of ClientConfig</returns>
+    public static ClientConfig InitClientConfig()
+    {
+        if (!Directory.Exists(ClientConfigSettings.NitroxRoamingDir))
+        {
+            Directory.CreateDirectory(ClientConfigSettings.NitroxRoamingDir);
+        }
+
+        ClientConfig cfg = null;
+        try
+        {
+            if (File.Exists(Path.Combine(ClientConfigSettings.NitroxRoamingDir, "client.cfg")))
+            {
+                cfg = Load(ClientConfigSettings.NitroxRoamingDir);
+            }
+            else
+            {
+                cfg = new ClientConfig();
+                cfg.Serialize(ClientConfigSettings.NitroxRoamingDir);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Unable to load client config: {ex.Message}");
+        }
+
+        Log.Info("Client Config Registered.");
+
+        return cfg;
+    }
+}

--- a/NitroxModel/Helper/NitroxUser.cs
+++ b/NitroxModel/Helper/NitroxUser.cs
@@ -11,6 +11,8 @@ namespace NitroxModel.Helper
 {
     public static class NitroxUser
     {
+        private static string appDataPath;
+        public static string AppDataPath { get; } = appDataPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
         public const string LAUNCHER_PATH_ENV_KEY = "NITROX_LAUNCHER_PATH";
         private const string PREFERRED_GAMEPATH_REGKEY = @"SOFTWARE\Nitrox\PreferredGamePath";
         private static string launcherPath;

--- a/NitroxModel/Helper/NitroxUser.cs
+++ b/NitroxModel/Helper/NitroxUser.cs
@@ -11,10 +11,9 @@ namespace NitroxModel.Helper
 {
     public static class NitroxUser
     {
-        private static string appDataPath;
-        public static string AppDataPath { get; } = appDataPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
         public const string LAUNCHER_PATH_ENV_KEY = "NITROX_LAUNCHER_PATH";
         private const string PREFERRED_GAMEPATH_REGKEY = @"SOFTWARE\Nitrox\PreferredGamePath";
+        private static string appDataPath;
         private static string launcherPath;
         private static string gamePath;
 
@@ -31,6 +30,8 @@ namespace NitroxModel.Helper
                 return null;
             }
         };
+
+        public static string AppDataPath { get; } = appDataPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox");
 
         /// <summary>
         ///     Tries to get the launcher path that was previously saved by other Nitrox code.

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -14,7 +14,6 @@ public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersis
     public static void Postfix()
     {
         ClientConfig cfg = ClientConfig.InitClientConfig();
-        //ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
         KeyBindingManager keyBindingManager = new();
         foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
         {

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -5,35 +5,34 @@ using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
 using NitroxClient.Serialization;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Persistent
-{
-    public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersistentPatch
-    {
-        private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => GameInput.SetupDefaultKeyboardBindings());
+namespace NitroxPatcher.Patches.Persistent;
 
-        public static void Postfix()
+public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersistentPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => GameInput.SetupDefaultKeyboardBindings());
+
+    public static void Postfix()
+    {
+        ClientConfig cfg = ClientConfig.InitClientConfig();
+        //ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
+        KeyBindingManager keyBindingManager = new();
+        foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
         {
-            ClientConfig cfg = ClientConfig.InitClientConfig();
-            //ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
-            KeyBindingManager keyBindingManager = new();
-            foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
+            GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, keyBinding.DefaultKeyBinding.BindingSet, keyBinding.DefaultKeyBinding.Binding);
+            switch (keyBinding.HasSecondary) // if for some reason the options.bin gets deleted, such when loading sp, and the client.cfg has secondary keybinds, we need to repopulate them, this handles that.
             {
-                GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, keyBinding.DefaultKeyBinding.BindingSet, keyBinding.DefaultKeyBinding.Binding);
-                switch (keyBinding.HasSecondary) // if for some reason the options.bin gets deleted, such when loading sp, and the client.cfg has secondary keybinds, we need to repopulate them, this handles that.
-                {
-                    case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.CHAT:
-                        GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.OpenChatKeybindSecondary);
-                        break;
-                    case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.FOCUS_DISCORD:
-                        GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.FocusDiscordKeybindSecondary);
-                        break;
-                }
+                case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.CHAT:
+                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.OpenChatKeybindSecondary);
+                    break;
+                case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.FOCUS_DISCORD:
+                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.FocusDiscordKeybindSecondary);
+                    break;
             }
         }
+    }
 
-        public override void Patch(Harmony harmony)
-        {
-            PatchPostfix(harmony, TARGET_METHOD);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPostfix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using NitroxClient.MonoBehaviours.Gui.Input;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
-using NitroxClient.Serialization;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Persistent;
@@ -13,21 +12,15 @@ public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersis
 
     public static void Postfix()
     {
-        ClientConfig cfg = ClientConfig.Init();
         KeyBindingManager keyBindingManager = new();
         foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
         {
             GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Primary, keyBinding.PrimaryKey);
 
             // if the options.bin gets deleted (when loading SP) and the client.cfg has secondary keybinds, repopulate them.
-            switch ((KeyBindingValues)keyBinding.Button) 
+            if (!string.IsNullOrEmpty(keyBinding.SecondaryKey))
             {
-                case KeyBindingValues.CHAT:
-                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.OpenChatKeybindSecondary);
-                    break;
-                case KeyBindingValues.FOCUS_DISCORD:
-                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.FocusDiscordKeybindSecondary);
-                    break;
+                GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, keyBinding.SecondaryKey);
             }
         }
     }

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -13,17 +13,19 @@ public class GameInput_SetupDefaultKeyboardBindings_Patch : NitroxPatch, IPersis
 
     public static void Postfix()
     {
-        ClientConfig cfg = ClientConfig.InitClientConfig();
+        ClientConfig cfg = ClientConfig.Init();
         KeyBindingManager keyBindingManager = new();
         foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
         {
-            GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, keyBinding.DefaultKeyBinding.BindingSet, keyBinding.DefaultKeyBinding.Binding);
-            switch (keyBinding.HasSecondary) // if for some reason the options.bin gets deleted, such when loading sp, and the client.cfg has secondary keybinds, we need to repopulate them, this handles that.
+            GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Primary, keyBinding.PrimaryKey);
+
+            // if the options.bin gets deleted (when loading SP) and the client.cfg has secondary keybinds, repopulate them.
+            switch ((KeyBindingValues)keyBinding.Button) 
             {
-                case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.CHAT:
+                case KeyBindingValues.CHAT:
                     GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.OpenChatKeybindSecondary);
                     break;
-                case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.FOCUS_DISCORD:
+                case KeyBindingValues.FOCUS_DISCORD:
                     GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.FocusDiscordKeybindSecondary);
                     break;
             }

--- a/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInput_SetupDefaultKeyboardBindings_Patch.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using NitroxClient.MonoBehaviours.Gui.Input;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
+using NitroxClient.Serialization;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Persistent
@@ -12,10 +13,21 @@ namespace NitroxPatcher.Patches.Persistent
 
         public static void Postfix()
         {
+            ClientConfig cfg = ClientConfig.InitClientConfig();
+            //ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
             KeyBindingManager keyBindingManager = new();
             foreach (KeyBinding keyBinding in keyBindingManager.KeyboardKeyBindings)
             {
                 GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, keyBinding.DefaultKeyBinding.BindingSet, keyBinding.DefaultKeyBinding.Binding);
+                switch (keyBinding.HasSecondary) // if for some reason the options.bin gets deleted, such when loading sp, and the client.cfg has secondary keybinds, we need to repopulate them, this handles that.
+                {
+                    case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.CHAT:
+                        GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.OpenChatKeybindSecondary);
+                        break;
+                    case true when keyBinding.Button == (GameInput.Button)KeyBindingValues.FOCUS_DISCORD:
+                        GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, GameInput.BindingSet.Secondary, cfg.FocusDiscordKeybindSecondary);
+                        break;
+                }
             }
         }
 

--- a/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
@@ -14,7 +14,7 @@ namespace NitroxPatcher.Patches.Persistent
 
         public static void Postfix(GameSettings.ISerializer serializer)
         {
-            ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
+            ClientConfig cfg = ClientConfig.Load(NitroxUser.AppDataPath);
             KeyBindingManager keyBindingManager = new();
             string serializerFormat = "Input/Binding/{0}/{1}/{2}";
 
@@ -26,18 +26,18 @@ namespace NitroxPatcher.Patches.Persistent
                     string binding = GameInput.GetBinding(keyBinding.Device, keyBinding.Button, bindingSet);
 
                     // We need to assign the correct binding for primary and secondary binding sets to the relevant area of the config.
-                    switch (keyBinding.Button)
+                    switch ((KeyBindingValues)keyBinding.Button)
                     {
-                        case (GameInput.Button)KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Primary:
+                        case KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Primary:
                             cfg.OpenChatKeybindPrimary = binding;
                             break;
-                        case (GameInput.Button)KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Primary:
+                        case KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Primary:
                             cfg.FocusDiscordKeybindPrimary = binding;
                             break;
-                        case (GameInput.Button)KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Secondary:
+                        case KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Secondary:
                             cfg.OpenChatKeybindSecondary = binding;
                             break;
-                        case (GameInput.Button)KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Secondary:
+                        case KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Secondary:
                             cfg.FocusDiscordKeybindSecondary = binding;
                             break;
                     }
@@ -46,7 +46,7 @@ namespace NitroxPatcher.Patches.Persistent
                 }
             }
 
-            cfg.Serialize(ClientConfigSettings.NitroxRoamingDir);
+            cfg.Serialize(NitroxUser.AppDataPath);
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
@@ -41,8 +41,6 @@ namespace NitroxPatcher.Patches.Persistent
                             cfg.FocusDiscordKeybindSecondary = binding;
                             break;
                     }
-
-                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, bindingSet, binding);
                 }
             }
 

--- a/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
@@ -5,9 +5,9 @@ using NitroxClient.MonoBehaviours.Gui.Input;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Persistent
 {
-    public class GameSettings_SerializeInputSettings_Patch : NitroxPatch, IDynamicPatch
+    public class GameSettings_SerializeInputSettings_Patch : NitroxPatch, IPersistentPatch
     {
         private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => GameSettings.SerializeInputSettings(default(GameSettings.ISerializer)));
 

--- a/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameSettings_SerializeInputSettings_Patch.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using HarmonyLib;
 using NitroxClient.MonoBehaviours.Gui.Input;
 using NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
+using NitroxClient.Serialization;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Persistent
@@ -13,6 +14,7 @@ namespace NitroxPatcher.Patches.Persistent
 
         public static void Postfix(GameSettings.ISerializer serializer)
         {
+            ClientConfig cfg = ClientConfig.Load(ClientConfigSettings.NitroxRoamingDir);
             KeyBindingManager keyBindingManager = new();
             string serializerFormat = "Input/Binding/{0}/{1}/{2}";
 
@@ -22,11 +24,29 @@ namespace NitroxPatcher.Patches.Persistent
                 {
                     Log.Debug($"Getting keybinding: {keyBinding.Device}, {keyBinding.Label} ({keyBinding.Button}), {bindingSet}");
                     string binding = GameInput.GetBinding(keyBinding.Device, keyBinding.Button, bindingSet);
-                    string name = string.Format(serializerFormat, keyBinding.Device, keyBinding.Button, bindingSet);
 
-                    GameInput.SetBinding(keyBinding.Device, keyBinding.Button, bindingSet, serializer.Serialize(name, binding));
+                    // We need to assign the correct binding for primary and secondary binding sets to the relevant area of the config.
+                    switch (keyBinding.Button)
+                    {
+                        case (GameInput.Button)KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Primary:
+                            cfg.OpenChatKeybindPrimary = binding;
+                            break;
+                        case (GameInput.Button)KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Primary:
+                            cfg.FocusDiscordKeybindPrimary = binding;
+                            break;
+                        case (GameInput.Button)KeyBindingValues.CHAT when bindingSet == GameInput.BindingSet.Secondary:
+                            cfg.OpenChatKeybindSecondary = binding;
+                            break;
+                        case (GameInput.Button)KeyBindingValues.FOCUS_DISCORD when bindingSet == GameInput.BindingSet.Secondary:
+                            cfg.FocusDiscordKeybindSecondary = binding;
+                            break;
+                    }
+
+                    GameInput.SetBindingInternal(keyBinding.Device, keyBinding.Button, bindingSet, binding);
                 }
             }
+
+            cfg.Serialize(ClientConfigSettings.NitroxRoamingDir);
         }
 
         public override void Patch(Harmony harmony)


### PR DESCRIPTION
Fixes #1897 by making the GameSettings_SerializeInputSettings_Patch persistent not dynamic, such that it is ran on startup, not on world load.

Testing:
I have tested with no options file, an options file that doesn't contain our keybinds, and one that contains keybinds assigned to different keys, each one is replaced correctly in and out of game. 