### PR TITLE
Improved grant local admin to allow all IPs that will loop back

### DIFF
--- a/Nitrox.Test/Model/Helper/NetHelperTest.cs
+++ b/Nitrox.Test/Model/Helper/NetHelperTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,11 +13,11 @@ public class NetHelperTest
     public void ShouldMatchPrivateIps()
     {
         // Tested subnet ranges that are reserved for private networks:
-        // 10.0.0.0/8 
-        // 127.0.0.0/8 
-        // 172.16.0.0/12 
-        // 192.0.0.0/24 
-        // 192.168.0.0/16 
+        // 10.0.0.0/8
+        // 127.0.0.0/8
+        // 172.16.0.0/12
+        // 192.0.0.0/24
+        // 192.168.0.0/16
         // 198.18.0.0/15
 
         IPAddress.Parse("10.0.0.0").IsPrivate().Should().BeTrue();
@@ -35,5 +37,35 @@ public class NetHelperTest
         IPAddress.Parse("192.0.1.0").IsPrivate().Should().BeFalse();
         IPAddress.Parse("198.17.255.255").IsPrivate().Should().BeFalse();
         IPAddress.Parse("198.20.0.0").IsPrivate().Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ShouldMatchLocalhostIps()
+    {
+        IPAddress GetSlightlyDifferentIp(IPAddress address)
+        {
+            if (address.AddressFamily != AddressFamily.InterNetwork)
+            {
+                throw new Exception("Only supports IPv4");
+            }
+            byte[] bytes = address.GetAddressBytes();
+            unchecked
+            {
+                while (bytes[3] is < 1 or > 253)
+                {
+                    bytes[3]++;
+                }
+                bytes[3]++;
+            }
+            return new IPAddress(bytes);
+        }
+
+        IPAddress.Parse("127.0.0.1").IsLocalhost().Should().BeTrue();
+        IPAddress.Parse("127.0.0.2").IsLocalhost().Should().BeTrue();
+        IPAddress.Parse("192.168.0.255").IsLocalhost().Should().BeFalse();
+        NetHelper.GetLanIp().IsLocalhost().Should().BeTrue();
+        IPAddress differentIp = GetSlightlyDifferentIp(NetHelper.GetLanIp());
+        differentIp.Should().NotBeEquivalentTo(NetHelper.GetLanIp());
+        differentIp.IsLocalhost().Should().BeFalse();
     }
 }

--- a/NitroxModel/Helper/NetHelper.cs
+++ b/NitroxModel/Helper/NetHelper.cs
@@ -161,5 +161,31 @@ namespace NitroxModel.Helper
             }
             return false;
         }
+
+        /// <summary>
+        ///     Returns true if the IP address points to the executing machine.
+        /// </summary>
+        public static bool IsLocalhost(this IPAddress address)
+        {
+            if (address == null)
+            {
+                return false;
+            }
+            if (IPAddress.IsLoopback(address))
+            {
+                return true;
+            }
+            foreach (NetworkInterface ni in GetInternetInterfaces())
+            {
+                foreach (UnicastIPAddressInformation ip in ni.GetIPProperties().UnicastAddresses)
+                {
+                    if (address.Equals(ip.Address))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Numerics;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.DataStructures.Unity;
 using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
 using NitroxModel.MultiplayerSession;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
@@ -51,8 +50,9 @@ namespace NitroxServer.Communication.Packets.Processors
             playerManager.SendPacketToOtherPlayers(playerJoinedPacket, player);
 
             // Make players on localhost admin by default.
-            if (IPAddress.IsLoopback(connection.Endpoint.Address))
+            if (connection.Endpoint.Address.IsLocalhost())
             {
+                Log.Info($"Granted admin to '{player.Name}' because they're playing on the host machine");
                 player.Permissions = Perms.ADMIN;
             }
 


### PR DESCRIPTION
Previously this only worked for 127.x.x.x range IPs but now also works for LAN ipv4 and ipv6 IPs.