### PR TITLE
Avoid generating .pdb files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
         <BuildGenDllDir>$(BuildGenDir)publicized_assemblies\</BuildGenDllDir>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Prefer32Bit>false</Prefer32Bit>
+        <DebugType>embedded</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ImplicitUsings>disable</ImplicitUsings>
         <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>


### PR DESCRIPTION
[https://learn.microsoft.com/fr-fr/dotnet/csharp/language-reference/compiler-options/code-generation](https://learn.microsoft.com/fr-fr/dotnet/csharp/language-reference/compiler-options/code-generation)

Debug symbols will be emitted directly in .dll/.exe instead of outside, resulting in bunch on .pdb files