### PR TITLE
Code clean up initial sync processors

### DIFF
--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -165,8 +165,8 @@ namespace NitroxClient
         {
             containerBuilder
                 .RegisterAssemblyTypes(currentAssembly)
-                .AssignableTo<InitialSyncProcessor>()
-                .As<InitialSyncProcessor>()
+                .AssignableTo<IInitialSyncProcessor>()
+                .As<IInitialSyncProcessor>()
                 .InstancePerLifetimeScope();
         }
     }

--- a/NitroxClient/Communication/PacketSuppression.cs
+++ b/NitroxClient/Communication/PacketSuppression.cs
@@ -13,12 +13,12 @@ public readonly struct PacketSuppressor<T> : IDisposable
     private static bool isSuppressed;
     public static bool IsSuppressed => isSuppressed;
 
-    public static readonly PacketSuppressor<T> Instance = new();
+    private static readonly PacketSuppressor<T> instance = new();
 
     public static PacketSuppressor<T> Suppress()
     {
         isSuppressed = true;
-        return Instance;
+        return instance;
     }
 
     public void Dispose()

--- a/NitroxClient/Communication/Packets/Processors/InitialPlayerSyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/InitialPlayerSyncProcessor.cs
@@ -12,8 +12,8 @@ namespace NitroxClient.Communication.Packets.Processors
     public class InitialPlayerSyncProcessor : ClientPacketProcessor<InitialPlayerSync>
     {
         private readonly IPacketSender packetSender;
-        private readonly HashSet<InitialSyncProcessor> processors;
-        private readonly HashSet<Type> alreadyRan = new HashSet<Type>();
+        private readonly HashSet<IInitialSyncProcessor> processors;
+        private readonly HashSet<Type> alreadyRan = new();
         private InitialPlayerSync packet;
 
         private WaitScreen.ManualWaitItem loadingMultiplayerWaitItem;
@@ -22,7 +22,7 @@ namespace NitroxClient.Communication.Packets.Processors
         private int cumulativeProcessorsRan;
         private int processorsRanLastCycle;
 
-        public InitialPlayerSyncProcessor(IPacketSender packetSender, IEnumerable<InitialSyncProcessor> processors)
+        public InitialPlayerSyncProcessor(IPacketSender packetSender, IEnumerable<IInitialSyncProcessor> processors)
         {
             this.packetSender = packetSender;
             this.processors = processors.ToSet();
@@ -38,7 +38,7 @@ namespace NitroxClient.Communication.Packets.Processors
 
         private IEnumerator ProcessInitialSyncPacket(object sender, EventArgs eventArgs)
         {
-            // Some packets should not fire during game session join but only afterwards so that initialized/spawned game objects don't trigger packet sending again. 
+            // Some packets should not fire during game session join but only afterwards so that initialized/spawned game objects don't trigger packet sending again.
             using (PacketSuppressor<PingRenamed>.Suppress())
             {
                 bool moreProcessorsToRun;
@@ -68,17 +68,17 @@ namespace NitroxClient.Communication.Packets.Processors
         {
             processorsRanLastCycle = 0;
 
-            foreach (InitialSyncProcessor processor in processors)
+            foreach (IInitialSyncProcessor processor in processors)
             {
                 if (IsWaitingToRun(processor.GetType()) && HasDependenciesSatisfied(processor))
                 {
                     loadingMultiplayerWaitItem.SetProgress(cumulativeProcessorsRan, processors.Count);
 
-                    Log.Info($"Running {processor.GetType()}");
                     alreadyRan.Add(processor.GetType());
                     processorsRanLastCycle++;
                     cumulativeProcessorsRan++;
 
+                    Log.Info($"Running {processor.GetType()}");
                     subWaitScreenItem = WaitScreen.Add($"Running {processor.GetType().Name}");
                     yield return Multiplayer.Main.StartCoroutine(processor.Process(packet, subWaitScreenItem));
                     WaitScreen.Remove(subWaitScreenItem);
@@ -86,7 +86,7 @@ namespace NitroxClient.Communication.Packets.Processors
             }
         }
 
-        private bool HasDependenciesSatisfied(InitialSyncProcessor processor)
+        private bool HasDependenciesSatisfied(IInitialSyncProcessor processor)
         {
             foreach (Type dependentType in processor.DependentProcessors)
             {
@@ -108,7 +108,7 @@ namespace NitroxClient.Communication.Packets.Processors
         {
             string remaining = "";
 
-            foreach (InitialSyncProcessor processor in processors)
+            foreach (IInitialSyncProcessor processor in processors)
             {
                 if (IsWaitingToRun(processor.GetType()))
                 {

--- a/NitroxClient/GameLogic/InitialSync/Abstract/IInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/Abstract/IInitialSyncProcessor.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NitroxModel.Packets;
+
+namespace NitroxClient.GameLogic.InitialSync.Abstract;
+
+public interface IInitialSyncProcessor<in TPacket> where TPacket : Packet
+{
+    HashSet<Type> DependentProcessors { get; }
+
+    IEnumerator Process(TPacket packet, WaitScreen.ManualWaitItem waitScreenItem);
+}
+
+public interface IInitialSyncProcessor : IInitialSyncProcessor<InitialPlayerSync>
+{
+}

--- a/NitroxClient/GameLogic/InitialSync/Abstract/InitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/Abstract/InitialSyncProcessor.cs
@@ -1,29 +1,46 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using NitroxModel.Packets;
 
 namespace NitroxClient.GameLogic.InitialSync.Abstract;
 
-public abstract class InitialSyncProcessor
+public abstract class InitialSyncProcessor : IInitialSyncProcessor
 {
-    public virtual List<IEnumerator> GetSteps(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem) => new();
-
-    public virtual bool AutomaticProgress => false;
+    public virtual List<Func<InitialPlayerSync, IEnumerator>> Steps { get; } = new();
+    public virtual HashSet<Type> DependentProcessors { get; } = new();
 
     public virtual IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
     {
-        List<IEnumerator> steps = GetSteps(packet, waitScreenItem);
-        for (int i = 0; i < steps.Count; i++)
+        for (int i = 0; i < Steps.Count; i++)
         {
-            yield return steps[i];
-            if (AutomaticProgress)
-            {
-                waitScreenItem.SetProgress(i / steps.Count);
-            }
+            yield return Steps[i](packet);
+            waitScreenItem.SetProgress((float)i / Steps.Count);
             yield return null;
         }
     }
 
-    public List<Type> DependentProcessors { get; } = new();
+    public void AddDependency<TDependency>() where TDependency : IInitialSyncProcessor
+    {
+        DependentProcessors.Add(typeof(TDependency));
+    }
+
+    public void AddStep(Func<InitialPlayerSync, IEnumerator> step)
+    {
+        Steps.Add(step);
+    }
+
+    public void AddStep(Action<InitialPlayerSync> step)
+    {
+        Steps.Add(sync =>
+        {
+            step(sync);
+            return Array.Empty<object>().GetEnumerator();
+        });
+    }
+
+    public void AddStep(Func<IEnumerator> step)
+    {
+        Steps.Add(_ => step());
+    }
 }

--- a/NitroxClient/GameLogic/InitialSync/EquippedItemInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/EquippedItemInitialSyncProcessor.cs
@@ -11,73 +11,72 @@ using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
 using UnityEngine;
 
-namespace NitroxClient.GameLogic.InitialSync
+namespace NitroxClient.GameLogic.InitialSync;
+
+public class EquippedItemInitialSyncProcessor : InitialSyncProcessor
 {
-    public class EquippedItemInitialSyncProcessor : InitialSyncProcessor
+    private readonly IPacketSender packetSender;
+
+    public EquippedItemInitialSyncProcessor(IPacketSender packetSender)
     {
-        private readonly IPacketSender packetSender;
+        this.packetSender = packetSender;
 
-        public EquippedItemInitialSyncProcessor(IPacketSender packetSender)
+        AddDependency<PlayerInitialSyncProcessor>();
+        AddDependency<RemotePlayerInitialSyncProcessor>();
+        AddDependency<GlobalRootInitialSyncProcessor>();
+    }
+
+    public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    {
+        int totalEquippedItemsDone = 0;
+
+        using (PacketSuppressor<EntitySpawnedByClient>.Suppress())
         {
-            this.packetSender = packetSender;
-
-            DependentProcessors.Add(typeof(PlayerInitialSyncProcessor));  // the player needs to be configured before we can equip items
-            DependentProcessors.Add(typeof(RemotePlayerInitialSyncProcessor)); // remote players can also equip items
-            DependentProcessors.Add(typeof(GlobalRootInitialSyncProcessor)); // Equipment also includes vehicles modules in global root
-        }
-
-        public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
-        {
-            int totalEquippedItemsDone = 0;
-
-            using (PacketSuppressor<EntitySpawnedByClient>.Suppress())
+            foreach (EquippedItemData equippedItem in packet.EquippedItems)
             {
-                foreach (EquippedItemData equippedItem in packet.EquippedItems)
+                waitScreenItem.SetProgress(totalEquippedItemsDone, packet.EquippedItems.Count);
+
+                GameObject gameObject = SerializationHelper.GetGameObject(equippedItem.SerializedData);
+                NitroxEntity.SetNewId(gameObject, equippedItem.ItemId);
+
+                Pickupable pickupable = gameObject.RequireComponent<Pickupable>();
+                Optional<GameObject> opGameObject = NitroxEntity.GetObjectFrom(equippedItem.ContainerId);
+
+                if (opGameObject.HasValue)
                 {
-                    waitScreenItem.SetProgress(totalEquippedItemsDone, packet.EquippedItems.Count);
+                    GameObject owner = opGameObject.Value;
 
-                    GameObject gameObject = SerializationHelper.GetGameObject(equippedItem.SerializedData);
-                    NitroxEntity.SetNewId(gameObject, equippedItem.ItemId);
+                    Optional<Equipment> opEquipment = EquipmentHelper.FindEquipmentComponent(owner);
 
-                    Pickupable pickupable = gameObject.RequireComponent<Pickupable>();
-                    Optional<GameObject> opGameObject = NitroxEntity.GetObjectFrom(equippedItem.ContainerId);
-
-                    if (opGameObject.HasValue)
+                    if (opEquipment.HasValue)
                     {
-                        GameObject owner = opGameObject.Value;
+                        Equipment equipment = opEquipment.Value;
+                        InventoryItem inventoryItem = new(pickupable);
+                        inventoryItem.container = equipment;
+                        inventoryItem.item.Reparent(equipment.tr);
 
-                        Optional<Equipment> opEquipment = EquipmentHelper.FindEquipmentComponent(owner);
+                        Dictionary<string, InventoryItem> itemsBySlot = equipment.equipment;
+                        itemsBySlot[equippedItem.Slot] = inventoryItem;
 
-                        if (opEquipment.HasValue)
-                        {
-                            Equipment equipment = opEquipment.Value;
-                            InventoryItem inventoryItem = new(pickupable);
-                            inventoryItem.container = equipment;
-                            inventoryItem.item.Reparent(equipment.tr);
-
-                            Dictionary<string, InventoryItem> itemsBySlot = equipment.equipment;
-                            itemsBySlot[equippedItem.Slot] = inventoryItem;
-
-                            equipment.UpdateCount(pickupable.GetTechType(), true);
-                            Equipment.SendEquipmentEvent(pickupable, 0, owner, equippedItem.Slot);
-                            equipment.NotifyEquip(equippedItem.Slot, inventoryItem);
-                        }
-                        else
-                        {
-                            Log.Info($"Could not find equipment type for {gameObject.name}");
-                        }
+                        equipment.UpdateCount(pickupable.GetTechType(), true);
+                        Equipment.SendEquipmentEvent(pickupable, 0, owner, equippedItem.Slot);
+                        equipment.NotifyEquip(equippedItem.Slot, inventoryItem);
                     }
                     else
                     {
-                        Log.Info($"Could not find Container for {gameObject.name}");
+                        Log.Info($"Could not find equipment type for {gameObject.name}");
                     }
-
-                    totalEquippedItemsDone++;
-                    yield return null;
                 }
-            }
+                else
+                {
+                    Log.Info($"Could not find Container for {gameObject.name}");
+                }
 
-            Log.Info($"Recieved initial sync with {totalEquippedItemsDone} pieces of equipped items");
+                totalEquippedItemsDone++;
+                yield return null;
+            }
         }
+
+        Log.Info($"Recieved initial sync with {totalEquippedItemsDone} pieces of equipped items");
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/GlobalRootInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/GlobalRootInitialSyncProcessor.cs
@@ -4,35 +4,41 @@ using NitroxClient.GameLogic.InitialSync.Abstract;
 using NitroxModel.Packets;
 using UnityEngine;
 
-namespace NitroxClient.GameLogic.InitialSync
+namespace NitroxClient.GameLogic.InitialSync;
+
+/// <summary>
+///     Makes sure players can be spawned in entities in the global root (such as vehicles/escape pod).
+/// </summary>
+/// <remarks>
+///     This allows for:<br/>
+///      - vehicles to use equipment
+/// </remarks>
+public class GlobalRootInitialSyncProcessor : InitialSyncProcessor
 {
-    public class GlobalRootInitialSyncProcessor : InitialSyncProcessor
+    private readonly Entities entities;
+
+    public GlobalRootInitialSyncProcessor(Entities entities)
     {
-        private readonly Entities entities;
+        this.entities = entities;
 
-        public GlobalRootInitialSyncProcessor(Entities entities)
-        {
-            this.entities = entities;
+        // As we migrate systems over to entities, we want to ensure the required components are in place to spawn these entities.
+        // For example, migrating inventories to the entity system requires players are spawned in the world before we try to add
+        // inventory items to them.  Eventually, all of the below processors will become entities on their own
+        AddDependency<PlayerInitialSyncProcessor>();
+        AddDependency<RemotePlayerInitialSyncProcessor>();
+    }
 
-            // As we migrate systems over to entities, we want to ensure the required components are in place to spawn these entities.
-            // For example, migrating inventories to the entity system requires players are spawned in the world before we try to add
-            // inventory items to them.  Eventually, all of the below processors will become entities on their own 
-            DependentProcessors.Add(typeof(PlayerInitialSyncProcessor));
-            DependentProcessors.Add(typeof(RemotePlayerInitialSyncProcessor));
-        }
+    public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    {
+        yield return new WaitUntil(LargeWorldStreamer.main.IsWorldSettled);
+        // Make sure all building-related prefabs are fully loaded (happen to bug when launching multiple clients locally)
+        yield return Base.InitializeAsync();
+        yield return BaseGhost.InitializeAsync();
+        yield return BaseDeconstructable.InitializeAsync();
 
-        public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
-        {
-            yield return new WaitUntil(LargeWorldStreamer.main.IsWorldSettled);
-            // Make sure all building-related prefabs are fully loaded (happen to bug when launching multiple clients locally)
-            yield return Base.InitializeAsync();
-            yield return BaseGhost.InitializeAsync();
-            yield return BaseDeconstructable.InitializeAsync();
+        BuildingHandler.Main.InitializeOperations(packet.BuildOperationIds);
 
-            BuildingHandler.Main.InitializeOperations(packet.BuildOperationIds);
-
-            Log.Info($"Received initial sync packet with {packet.GlobalRootEntities.Count} global root entities");
-            yield return entities.SpawnBatchAsync(packet.GlobalRootEntities);
-        }
+        Log.Info($"Received initial sync packet with {packet.GlobalRootEntities.Count} global root entities");
+        yield return entities.SpawnBatchAsync(packet.GlobalRootEntities);
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,17 +21,15 @@ public class PdaInitialSyncProcessor : InitialSyncProcessor
     }
 
     // The steps are ordered like their call order in Player.OnProtoDeserialize
-    public override List<IEnumerator> GetSteps(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    public override List<Func<InitialPlayerSync, IEnumerator>> Steps { get; } = new()
     {
-        return new List<IEnumerator> {
-            RestoreKnownTech(packet),
-            RestorePDALog(packet),
-            RestoreEncyclopediaEntries(packet),
-            RestorePDAScanner(packet)
-        };
-    }
+        RestoreKnownTech,
+        RestorePDALog,
+        RestoreEncyclopediaEntries,
+        RestorePDAScanner
+    };
 
-    private IEnumerator RestoreKnownTech(InitialPlayerSync packet)
+    private static IEnumerator RestoreKnownTech(InitialPlayerSync packet)
     {
         List<TechType> knownTech = packet.PDAData.KnownTechTypes.Select(techType => techType.ToUnity()).ToList();
         HashSet<TechType> analyzedTech = packet.PDAData.AnalyzedTechTypes.Select(techType => techType.ToUnity()).ToHashSet();
@@ -43,7 +42,7 @@ public class PdaInitialSyncProcessor : InitialSyncProcessor
         yield break;
     }
 
-    private IEnumerator RestorePDALog(InitialPlayerSync packet)
+    private static IEnumerator RestorePDALog(InitialPlayerSync packet)
     {
         List<PDALogEntry> logEntries = packet.PDAData.PDALogEntries;
         Log.Info($"Received initial sync packet with {logEntries.Count} pda log entries");
@@ -56,7 +55,7 @@ public class PdaInitialSyncProcessor : InitialSyncProcessor
         yield break;
     }
 
-    private IEnumerator RestoreEncyclopediaEntries(InitialPlayerSync packet)
+    private static IEnumerator RestoreEncyclopediaEntries(InitialPlayerSync packet)
     {
         List<string> entries = packet.PDAData.EncyclopediaEntries;
         Log.Info($"Received initial sync packet with {entries.Count} encyclopedia entries");
@@ -72,7 +71,7 @@ public class PdaInitialSyncProcessor : InitialSyncProcessor
         yield break;
     }
 
-    private IEnumerator RestorePDAScanner(InitialPlayerSync packet)
+    private static IEnumerator RestorePDAScanner(InitialPlayerSync packet)
     {
         InitialPDAData pdaData = packet.PDAData;
 

--- a/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
@@ -1,113 +1,104 @@
 using System.Collections;
 using NitroxClient.GameLogic.InitialSync.Abstract;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
-using NitroxModel.Packets;
 using NitroxModel.Server;
 using UnityEngine;
 
-namespace NitroxClient.GameLogic.InitialSync
+namespace NitroxClient.GameLogic.InitialSync;
+
+/// <summary>
+///     Makes sure the player is configured.
+/// </summary>
+/// <remarks>
+///     This allows the player to:<br/>
+///      - use equipment
+/// </remarks>
+public class PlayerInitialSyncProcessor : InitialSyncProcessor
 {
-    public class PlayerInitialSyncProcessor : InitialSyncProcessor
+    private readonly Items item;
+    private readonly ItemContainers itemContainers;
+    private readonly LocalPlayer localPlayer;
+
+    public PlayerInitialSyncProcessor(Items item, ItemContainers itemContainers, LocalPlayer localPlayer)
     {
-        private readonly Items item;
-        private readonly ItemContainers itemContainers;
+        this.item = item;
+        this.itemContainers = itemContainers;
+        this.localPlayer = localPlayer;
 
-        public PlayerInitialSyncProcessor(Items item, ItemContainers itemContainers)
+        AddStep(sync => SetPlayerPermissions(sync.Permissions));
+        AddStep(sync => SetPlayerGameObjectId(sync.PlayerGameObjectId));
+        AddStep(sync => AddStartingItemsToPlayer(sync.FirstTimeConnecting));
+        AddStep(sync => SetPlayerStats(sync.PlayerStatsData));
+        AddStep(sync => SetPlayerGameMode(sync.GameMode));
+    }
+
+    private void SetPlayerPermissions(Perms permissions)
+    {
+        localPlayer.Permissions = permissions;
+    }
+
+    private void SetPlayerGameObjectId(NitroxId id)
+    {
+        NitroxEntity.SetNewId(Player.mainObject, id);
+        Log.Info($"Received initial sync player GameObject Id: {id}");
+    }
+
+    private IEnumerator AddStartingItemsToPlayer(bool firstTimeConnecting)
+    {
+        if (firstTimeConnecting)
         {
-            this.item = item;
-            this.itemContainers = itemContainers;
-        }
-
-        public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
-        {
-            SetPlayerPermissions(packet.Permissions);
-            waitScreenItem.SetProgress(0.16f);
-            yield return null;
-
-            SetPlayerGameObjectId(packet.PlayerGameObjectId);
-            waitScreenItem.SetProgress(0.33f);
-            yield return null;
-
-            yield return AddStartingItemsToPlayer(packet.FirstTimeConnecting);
-            waitScreenItem.SetProgress(0.50f);
-            yield return null;
-
-            SetPlayerStats(packet.PlayerStatsData);
-            waitScreenItem.SetProgress(0.66f);
-            yield return null;
-
-            SetPlayerGameMode(packet.GameMode);
-            waitScreenItem.SetProgress(0.83f);
-            yield return null;
-        }
-
-        private void SetPlayerPermissions(Perms permissions)
-        {
-            NitroxServiceLocator.LocateService<LocalPlayer>().Permissions = permissions;
-        }
-
-        private void SetPlayerGameObjectId(NitroxId id)
-        {
-            NitroxEntity.SetNewId(Player.mainObject, id);
-            Log.Info($"Received initial sync player GameObject Id: {id}");
-        }
-
-        private IEnumerator AddStartingItemsToPlayer(bool firstTimeConnecting)
-        {
-            if (firstTimeConnecting)
+            if (!Player.main.TryGetIdOrWarn(out NitroxId localPlayerId))
             {
-                if (!Player.main.TryGetIdOrWarn(out NitroxId localPlayerId))
-                {
-                    yield break;
-                }
+                yield break;
+            }
 
-                foreach (TechType techType in LootSpawner.main.GetEscapePodStorageTechTypes())
-                {
-                    TaskResult<GameObject> result = new TaskResult<GameObject>();
-                    yield return CraftData.InstantiateFromPrefabAsync(techType, result, false);
-                    GameObject gameObject = result.Get();
-                    Pickupable pickupable = gameObject.GetComponent<Pickupable>();
-                    pickupable.Initialize();
+            foreach (TechType techType in LootSpawner.main.GetEscapePodStorageTechTypes())
+            {
+                TaskResult<GameObject> result = new();
+                yield return CraftData.InstantiateFromPrefabAsync(techType, result);
+                GameObject gameObject = result.Get();
+                Pickupable pickupable = gameObject.GetComponent<Pickupable>();
+                pickupable.Initialize();
 
-                    item.Created(gameObject);
-                    itemContainers.AddItem(gameObject, localPlayerId);
-                }
+                item.Created(gameObject);
+                itemContainers.AddItem(gameObject, localPlayerId);
             }
         }
+    }
 
-        private void SetPlayerStats(PlayerStatsData statsData)
+    private void SetPlayerStats(PlayerStatsData statsData)
+    {
+        if (statsData != null)
         {
-            if (statsData != null)
+            Player.main.oxygenMgr.AddOxygen(statsData.Oxygen);
+            Player.main.liveMixin.health = statsData.Health;
+            Survival survivalComponent = Player.main.GetComponent<Survival>();
+            survivalComponent.food = statsData.Food;
+            survivalComponent.water = statsData.Water;
+            Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
+
+            //If InfectionAmount is at least 1f then the infection reveal should have happened already.
+            //If InfectionAmount is below 1f then the reveal has not.
+            if (statsData.InfectionAmount >= 1f)
             {
-                Player.main.oxygenMgr.AddOxygen(statsData.Oxygen);
-                Player.main.liveMixin.health = statsData.Health;
-                Player.main.GetComponent<Survival>().food = statsData.Food;
-                Player.main.GetComponent<Survival>().water = statsData.Water;
-                Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
-
-                //If InfectionAmount is at least 1f then the infection reveal should have happened already.
-                //If InfectionAmount is below 1f then the reveal has not.
-                if (statsData.InfectionAmount >= 1f)
-                {
-                    Player.main.infectionRevealed = true;
-                }
-
-                // We need to make the player invincible before he finishes loading because in some cases he will eventually die before loading
-                Player.main.liveMixin.invincible = true;
-                Player.main.FreezeStats();
+                Player.main.infectionRevealed = true;
             }
-            // We need to start it at least once for everything that's in the PDA to load
-            Player.main.GetPDA().Open(PDATab.Inventory);
-            Player.main.GetPDA().Close();
+
+            // We need to make the player invincible before he finishes loading because in some cases he will eventually die before loading
+            Player.main.liveMixin.invincible = true;
+            Player.main.FreezeStats();
         }
 
-        private void SetPlayerGameMode(NitroxGameMode gameMode)
-        {
-            Log.Info($"Received initial sync packet with gamemode {gameMode}");
-            GameModeUtils.SetGameMode((GameModeOption)(int)gameMode, GameModeOption.None);
-        }
+        // We need to start it at least once for everything that's in the PDA to load
+        Player.main.GetPDA().Open(PDATab.Inventory);
+        Player.main.GetPDA().Close();
+    }
+
+    private void SetPlayerGameMode(NitroxGameMode gameMode)
+    {
+        Log.Info($"Received initial sync packet with gamemode {gameMode}");
+        GameModeUtils.SetGameMode((GameModeOption)(int)gameMode, GameModeOption.None);
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -10,95 +10,94 @@ using NitroxModel_Subnautica.DataStructures;
 using UnityEngine;
 using Math = System.Math;
 
-namespace NitroxClient.GameLogic.InitialSync
+namespace NitroxClient.GameLogic.InitialSync;
+
+public class PlayerPositionInitialSyncProcessor : InitialSyncProcessor
 {
-    public class PlayerPositionInitialSyncProcessor : InitialSyncProcessor
+    private static readonly Vector3 spawnRelativeToEscapePod = new Vector3(0.9f, 2.1f, 0);
+
+    private readonly IPacketSender packetSender;
+
+    public PlayerPositionInitialSyncProcessor(IPacketSender packetSender)
     {
-        private static readonly Vector3 spawnRelativeToEscapePod = new Vector3(0.9f, 2.1f, 0);
+        this.packetSender = packetSender;
 
-        private readonly IPacketSender packetSender;
-
-        public PlayerPositionInitialSyncProcessor(IPacketSender packetSender)
-        {
-            this.packetSender = packetSender;
-
-            DependentProcessors.Add(typeof(PlayerInitialSyncProcessor)); // Make sure the player is configured
-            DependentProcessors.Add(typeof(GlobalRootInitialSyncProcessor)); // Players can be spawned in entities in the global root (such as vehicles/escape pod)
-        }
-
-        public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
-        {
-            // We freeze the player so that he doesn't fall before the cells around him have loaded
-            Player.main.cinematicModeActive = true;
-
-            AttachPlayerToEscapePod(packet.AssignedEscapePodId);
-
-            Vector3 position = packet.PlayerSpawnData.ToUnity();
-            Quaternion rotation = packet.PlayerSpawnRotation.ToUnity();
-            if (Math.Abs(position.x) < 0.0002 && Math.Abs(position.y) < 0.0002 && Math.Abs(position.z) < 0.0002)
-            {
-                position = Player.mainObject.transform.position;
-            }
-            Player.main.SetPosition(position, rotation);
-
-            // Player.Update is setting SubRootID to null after Player position is set
-            using (PacketSuppressor<EscapePodChanged>.Suppress())
-            {
-                Player.main.ValidateEscapePod();
-            }
-
-            // Player position is relative to a subroot if in a subroot
-            Optional<NitroxId> subRootId = packet.PlayerSubRootId;
-            if (!subRootId.HasValue)
-            {
-                yield return Terrain.WaitForWorldLoad();
-                yield break;
-            }
-
-            Optional<GameObject> sub = NitroxEntity.GetObjectFrom(subRootId.Value);
-            if (!sub.HasValue)
-            {
-                Log.Error($"Could not spawn player into subroot with id: {subRootId.Value}");
-                yield return Terrain.WaitForWorldLoad();
-                yield break;
-            }
-
-            if (!sub.Value.TryGetComponent(out SubRoot subRoot))
-            {
-                Log.Debug("SubRootId-GameObject has no SubRoot component, so it's assumed to be the EscapePod");
-                yield return Terrain.WaitForWorldLoad();
-                yield break;
-            }
-
-            Player.main.SetCurrentSub(subRoot, true);
-            if (subRoot.isBase)
-            {
-                // If the player's in a base, we don't need to wait for the world to load
-                Player.main.cinematicModeActive = false;
-                yield break;
-            }
-
-            Transform rootTransform = subRoot.transform;
-            Quaternion vehicleAngle = rootTransform.rotation;
-            // "position" is a relative position and "positionInVehicle" an absolute position
-            Vector3 positionInVehicle = vehicleAngle * position + rootTransform.position;
-            Player.main.SetPosition(positionInVehicle, rotation * vehicleAngle);
-            Player.main.cinematicModeActive = false;
-            Player.main.UpdateIsUnderwater();
-        }
-
-        private void AttachPlayerToEscapePod(NitroxId escapePodId)
-        {
-            GameObject escapePod = NitroxEntity.RequireObjectFrom(escapePodId);
-
-            EscapePod.main.transform.position = escapePod.transform.position;
-            EscapePod.main.playerSpawn.position = escapePod.transform.position + spawnRelativeToEscapePod;
-
-            Player.main.transform.position = EscapePod.main.playerSpawn.position;
-            Player.main.transform.rotation = EscapePod.main.playerSpawn.rotation;
-
-            Player.main.currentEscapePod = escapePod.GetComponent<EscapePod>();
-        }
-
+        AddDependency<PlayerInitialSyncProcessor>();
+        AddDependency<GlobalRootInitialSyncProcessor>();
     }
+
+    public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    {
+        // We freeze the player so that he doesn't fall before the cells around him have loaded
+        Player.main.cinematicModeActive = true;
+
+        AttachPlayerToEscapePod(packet.AssignedEscapePodId);
+
+        Vector3 position = packet.PlayerSpawnData.ToUnity();
+        Quaternion rotation = packet.PlayerSpawnRotation.ToUnity();
+        if (Math.Abs(position.x) < 0.0002 && Math.Abs(position.y) < 0.0002 && Math.Abs(position.z) < 0.0002)
+        {
+            position = Player.mainObject.transform.position;
+        }
+        Player.main.SetPosition(position, rotation);
+
+        // Player.Update is setting SubRootID to null after Player position is set
+        using (PacketSuppressor<EscapePodChanged>.Suppress())
+        {
+            Player.main.ValidateEscapePod();
+        }
+
+        // Player position is relative to a subroot if in a subroot
+        Optional<NitroxId> subRootId = packet.PlayerSubRootId;
+        if (!subRootId.HasValue)
+        {
+            yield return Terrain.WaitForWorldLoad();
+            yield break;
+        }
+
+        Optional<GameObject> sub = NitroxEntity.GetObjectFrom(subRootId.Value);
+        if (!sub.HasValue)
+        {
+            Log.Error($"Could not spawn player into subroot with id: {subRootId.Value}");
+            yield return Terrain.WaitForWorldLoad();
+            yield break;
+        }
+
+        if (!sub.Value.TryGetComponent(out SubRoot subRoot))
+        {
+            Log.Debug("SubRootId-GameObject has no SubRoot component, so it's assumed to be the EscapePod");
+            yield return Terrain.WaitForWorldLoad();
+            yield break;
+        }
+
+        Player.main.SetCurrentSub(subRoot, true);
+        if (subRoot.isBase)
+        {
+            // If the player's in a base, we don't need to wait for the world to load
+            Player.main.cinematicModeActive = false;
+            yield break;
+        }
+
+        Transform rootTransform = subRoot.transform;
+        Quaternion vehicleAngle = rootTransform.rotation;
+        // "position" is a relative position and "positionInVehicle" an absolute position
+        Vector3 positionInVehicle = vehicleAngle * position + rootTransform.position;
+        Player.main.SetPosition(positionInVehicle, rotation * vehicleAngle);
+        Player.main.cinematicModeActive = false;
+        Player.main.UpdateIsUnderwater();
+    }
+
+    private void AttachPlayerToEscapePod(NitroxId escapePodId)
+    {
+        GameObject escapePod = NitroxEntity.RequireObjectFrom(escapePodId);
+
+        EscapePod.main.transform.position = escapePod.transform.position;
+        EscapePod.main.playerSpawn.position = escapePod.transform.position + spawnRelativeToEscapePod;
+
+        Player.main.transform.position = EscapePod.main.playerSpawn.position;
+        Player.main.transform.rotation = EscapePod.main.playerSpawn.rotation;
+
+        Player.main.currentEscapePod = escapePod.GetComponent<EscapePod>();
+    }
+
 }

--- a/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/QuickSlotInitialSyncProcessor.cs
@@ -11,8 +11,8 @@ public class QuickSlotInitialSyncProcessor : InitialSyncProcessor
 {
     public QuickSlotInitialSyncProcessor()
     {
-        DependentProcessors.Add(typeof(PlayerInitialSyncProcessor));  // the player needs to be configured before we can set quick slots.
-        DependentProcessors.Add(typeof(EquippedItemInitialSyncProcessor)); // we need to have the items spawned into our inventory before we can quick slot them.
+        AddDependency<PlayerInitialSyncProcessor>();  // the player needs to be configured before we can set quick slots.
+        AddDependency<EquippedItemInitialSyncProcessor>(); // we need to have the items spawned into our inventory before we can quick slot them.
     }
 
     public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)

--- a/NitroxClient/GameLogic/InitialSync/RemotePlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/RemotePlayerInitialSyncProcessor.cs
@@ -3,30 +3,36 @@ using NitroxClient.GameLogic.InitialSync.Abstract;
 using NitroxModel.MultiplayerSession;
 using NitroxModel.Packets;
 
-namespace NitroxClient.GameLogic.InitialSync
+namespace NitroxClient.GameLogic.InitialSync;
+
+/// <summary>
+///     Makes sure the remote player object is loaded.
+/// </summary>
+/// <remarks>
+///     This allows for the remote player to:<br/>
+///      - use equipment
+/// </remarks>
+public class RemotePlayerInitialSyncProcessor : InitialSyncProcessor
 {
-    public class RemotePlayerInitialSyncProcessor : InitialSyncProcessor
+    private readonly PlayerManager remotePlayerManager;
+
+    public RemotePlayerInitialSyncProcessor(PlayerManager remotePlayerManager)
     {
-        private readonly PlayerManager remotePlayerManager;
+        this.remotePlayerManager = remotePlayerManager;
+    }
 
-        public RemotePlayerInitialSyncProcessor(PlayerManager remotePlayerManager)
+    public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
+    {
+        int remotePlayersSynced = 0;
+
+        foreach (PlayerContext otherPlayer in packet.OtherPlayers)
         {
-            this.remotePlayerManager = remotePlayerManager;
-        }
+            waitScreenItem.SetProgress(remotePlayersSynced, packet.OtherPlayers.Count);
 
-        public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)
-        {
-            int remotePlayersSynced = 0;
+            remotePlayerManager.Create(otherPlayer);
 
-            foreach (PlayerContext otherPlayer in packet.OtherPlayers)
-            {
-                waitScreenItem.SetProgress(remotePlayersSynced, packet.OtherPlayers.Count);
-
-                remotePlayerManager.Create(otherPlayer);
-
-                remotePlayersSynced++;
-                yield return null;
-            }
+            remotePlayersSynced++;
+            yield return null;
         }
     }
 }


### PR DESCRIPTION
 - Made dependencies in InitSyncProcessors type checked for being an InitSyncProcessor.
 - Removed two instances of bad DI usage (inline resolve instead of ctor parameter) for:
     - `LocalPlayer` in `PlayerInitialSyncProcessor`
     - `TimeManager` in `StoryGoalInitialSyncProcessor`
 - Fixed an equality check on `goal` which should be on its `goal.Key` in `StoryGoalInitialSyncProcessor`
 - Removed an usused local variable in `StoryGoalInitialSyncProcessor`:
     - `List<string> goalKeys = scheduledGoals.ConvertAll((goal) => goal.GoalKey);`
 - Minor edits to progress calculations in `SimulationOwnershipInitialSyncProcessor`
 - Used "file-scoped namespace" syntax in all `InitialSyncProcessor` related types.