### PR TITLE
Sync radiation leaks

### DIFF
--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -5,19 +5,18 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nitrox.Test;
-using Nitrox.Test.Helper;
 using Nitrox.Test.Helper.Faker;
 using NitroxModel.Core;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
-using NitroxServer_Subnautica;
-using NitroxServer.GameLogic;
-using NitroxServer.GameLogic.Unlockables;
-using NitroxServer.Serialization.World;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.DataStructures.GameLogic.Entities.Bases;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata.Bases;
-using NitroxModel.DataStructures;
+using NitroxServer.GameLogic;
+using NitroxServer.GameLogic.Unlockables;
+using NitroxServer.Serialization.World;
+using NitroxServer_Subnautica;
 
 namespace NitroxServer.Serialization;
 
@@ -321,6 +320,10 @@ public class WorldPersistenceTest
             case BeaconMetadata metadata when entityAfter.Metadata is BeaconMetadata metadataAfter:
                 Assert.AreEqual(metadata.Label, metadataAfter.Label);
                 break;
+            case RadiationMetadata metadata when entityAfter.Metadata is RadiationMetadata metadataAfter:
+                Assert.AreEqual(metadata.Health, metadataAfter.Health);
+                Assert.AreEqual(metadata.FixRealTime, metadataAfter.FixRealTime);
+                break;
             default:
                 Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.Metadata?.GetType().Name} - {entityAfter.Metadata?.GetType().Name}");
                 break;
@@ -413,8 +416,11 @@ public class WorldPersistenceTest
                                         Assert.AreEqual(vehicleWorldEntity.SpawnerId, vehicleWorldEntityAfter.SpawnerId);
                                         Assert.AreEqual(vehicleWorldEntity.ConstructionTime, vehicleWorldEntityAfter.ConstructionTime);
                                         break;
+                                    case RadiationLeakEntity radiationLeakEntity when globalRootEntityAfter is RadiationLeakEntity radiationLeakEntityAfter:
+                                        Assert.AreEqual(radiationLeakEntity.ObjectIndex, radiationLeakEntityAfter.ObjectIndex);
+                                        break;
                                     default:
-                                        Assert.Fail($"Runtime type of {nameof(WorldEntity)} is not equal even after the check: {worldEntity.GetType().Name} - {globalRootEntityAfter.GetType().Name}");
+                                        Assert.Fail($"Runtime type of {nameof(GlobalRootEntity)} is not equal even after the check: {worldEntity.GetType().Name} - {globalRootEntityAfter.GetType().Name}");
                                         break;
                                 }
                             }

--- a/NitroxClient/Communication/Packets/Processors/AuroraAndTimeUpdateProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraAndTimeUpdateProcessor.cs
@@ -17,6 +17,7 @@ public class AuroraAndTimeUpdateProcessor : ClientPacketProcessor<AuroraAndTimeU
     {
         timeManager.ProcessUpdate(packet.TimeData.TimePacket);
         StoryManager.UpdateAuroraData(packet.TimeData.AuroraEventData);
+        timeManager.AuroraRealExplosionTime = packet.TimeData.AuroraEventData.AuroraRealExplosionTime;
         if (packet.Restore)
         {
             StoryManager.RestoreAurora();

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -39,7 +39,7 @@ namespace NitroxClient.GameLogic
         public List<Entity> EntitiesToSpawn { get; private init; }
         private bool spawningEntities;
 
-        public Entities(IPacketSender packetSender, ThrottledPacketSender throttledPacketSender, EntityMetadataManager entityMetadataManager, PlayerManager playerManager, ILocalNitroxPlayer localPlayer)
+        public Entities(IPacketSender packetSender, ThrottledPacketSender throttledPacketSender, EntityMetadataManager entityMetadataManager, PlayerManager playerManager, ILocalNitroxPlayer localPlayer, TimeManager timeManager)
         {
             this.packetSender = packetSender;
             this.throttledPacketSender = throttledPacketSender;
@@ -60,6 +60,7 @@ namespace NitroxClient.GameLogic
             entitySpawnersByType[typeof(VehicleWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(SerializedWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(GlobalRootEntity)] = new GlobalRootEntitySpawner();
+            entitySpawnersByType[typeof(RadiationLeakEntity)] = new RadiationLeakEntitySpawner(timeManager);
             entitySpawnersByType[typeof(BuildEntity)] = new BuildEntitySpawner(this);
             entitySpawnersByType[typeof(ModuleEntity)] = new ModuleEntitySpawner(this);
             entitySpawnersByType[typeof(GhostEntity)] = new GhostEntitySpawner();

--- a/NitroxClient/GameLogic/InitialSync/GlobalRootInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/GlobalRootInitialSyncProcessor.cs
@@ -26,6 +26,7 @@ public class GlobalRootInitialSyncProcessor : InitialSyncProcessor
         // inventory items to them.  Eventually, all of the below processors will become entities on their own
         AddDependency<PlayerInitialSyncProcessor>();
         AddDependency<RemotePlayerInitialSyncProcessor>();
+        AddDependency<StoryGoalInitialSyncProcessor>();
     }
 
     public override IEnumerator Process(InitialPlayerSync packet, WaitScreen.ManualWaitItem waitScreenItem)

--- a/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
@@ -163,5 +163,7 @@ public class StoryGoalInitialSyncProcessor : InitialSyncProcessor
     private void SetTimeData(InitialPlayerSync packet)
     {
         timeManager.ProcessUpdate(packet.TimeData.TimePacket);
+        timeManager.InitRealTimeElapsed(packet.TimeData.RealTimeElapsed, packet.TimeData.TimePacket.UpdateTime);
+        timeManager.AuroraRealExplosionTime = packet.TimeData.AuroraEventData.AuroraRealExplosionTime;
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
@@ -163,7 +163,7 @@ public class StoryGoalInitialSyncProcessor : InitialSyncProcessor
     private void SetTimeData(InitialPlayerSync packet)
     {
         timeManager.ProcessUpdate(packet.TimeData.TimePacket);
-        timeManager.InitRealTimeElapsed(packet.TimeData.RealTimeElapsed, packet.TimeData.TimePacket.UpdateTime);
+        timeManager.InitRealTimeElapsed(packet.TimeData.TimePacket.RealTimeElapsed, packet.TimeData.TimePacket.UpdateTime, packet.IsFirstPlayer);
         timeManager.AuroraRealExplosionTime = packet.TimeData.AuroraEventData.AuroraRealExplosionTime;
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/Abstract/EntityMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/Abstract/EntityMetadataExtractor.cs
@@ -1,3 +1,4 @@
+using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 using NitroxModel.DataStructures.Util;
 
@@ -12,5 +13,10 @@ public abstract class EntityMetadataExtractor<I, O> : IEntityMetadataExtractor w
         EntityMetadata result = Extract((I)o);
 
         return Optional.OfNullable(result);
+    }
+
+    protected T Resolve<T>() where T : class
+    {
+        return NitroxServiceLocator.Cache<T>.Value;
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/RadiationMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/RadiationMetadataExtractor.cs
@@ -1,0 +1,16 @@
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+using NitroxModel.Core;
+using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+public class RadiationMetadataExtractor : EntityMetadataExtractor<RadiationLeak, RadiationMetadata>
+{
+    public override RadiationMetadata Extract(RadiationLeak leak)
+    {
+        // Note: this extractor should only be used when this radiation leak is being repaired
+        TimeManager timeManager = NitroxServiceLocator.LocateService<TimeManager>();
+        float realTimeFix = leak.liveMixin.IsFullHealth() ? (float)timeManager.RealTimeElapsed : -1;
+        return new(leak.liveMixin.health, realTimeFix);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/RadiationMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/RadiationMetadataExtractor.cs
@@ -1,5 +1,4 @@
 using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
-using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 
 namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
@@ -9,8 +8,7 @@ public class RadiationMetadataExtractor : EntityMetadataExtractor<RadiationLeak,
     public override RadiationMetadata Extract(RadiationLeak leak)
     {
         // Note: this extractor should only be used when this radiation leak is being repaired
-        TimeManager timeManager = NitroxServiceLocator.LocateService<TimeManager>();
-        float realTimeFix = leak.liveMixin.IsFullHealth() ? (float)timeManager.RealTimeElapsed : -1;
+        float realTimeFix = leak.liveMixin.IsFullHealth() ? (float)Resolve<TimeManager>().RealTimeElapsed : -1;
         return new(leak.liveMixin.health, realTimeFix);
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/Abstract/EntityMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/Abstract/EntityMetadataProcessor.cs
@@ -1,3 +1,4 @@
+using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 using UnityEngine;
 
@@ -10,5 +11,10 @@ public abstract class EntityMetadataProcessor<T> : IEntityMetadataProcessor wher
     public void ProcessMetadata(GameObject gameObject, EntityMetadata metadata)
     {
         ProcessMetadata(gameObject, (T)metadata);
+    }
+
+    protected T Resolve<T>() where T : class
+    {
+        return NitroxServiceLocator.Cache<T>.Value;
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/RadiationMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/RadiationMetadataProcessor.cs
@@ -1,6 +1,5 @@
 using NitroxClient.Communication;
 using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
-using NitroxModel.Core;
 using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 using NitroxModel.Packets;
 using UnityEngine;
@@ -16,10 +15,9 @@ public class RadiationMetadataProcessor : EntityMetadataProcessor<RadiationMetad
             Log.Error($"[{nameof(RadiationMetadataProcessor)}] Couldn't find LiveMixin on {gameObject}");
             return;
         }
-        LiveMixinManager liveMixinManager = NitroxServiceLocator.LocateService<LiveMixinManager>();
         using (PacketSuppressor<EntityMetadataUpdate>.Suppress())
         {
-            liveMixinManager.SyncRemoteHealth(liveMixin, metadata.Health);
+            Resolve<LiveMixinManager>().SyncRemoteHealth(liveMixin, metadata.Health);
         }
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/RadiationMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/RadiationMetadataProcessor.cs
@@ -1,0 +1,25 @@
+using NitroxClient.Communication;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using NitroxModel.Core;
+using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class RadiationMetadataProcessor : EntityMetadataProcessor<RadiationMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, RadiationMetadata metadata)
+    {
+        if (!gameObject.TryGetComponent(out LiveMixin liveMixin))
+        {
+            Log.Error($"[{nameof(RadiationMetadataProcessor)}] Couldn't find LiveMixin on {gameObject}");
+            return;
+        }
+        LiveMixinManager liveMixinManager = NitroxServiceLocator.LocateService<LiveMixinManager>();
+        using (PacketSuppressor<EntityMetadataUpdate>.Suppress())
+        {
+            liveMixinManager.SyncRemoteHealth(liveMixin, metadata.Health);
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
@@ -1,0 +1,101 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NitroxClient.GameLogic.Spawning.Abstract;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.DataStructures.GameLogic.Entities;
+using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
+using NitroxModel.DataStructures.Util;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.WorldEntities;
+
+public class RadiationLeakEntitySpawner : SyncEntitySpawner<RadiationLeakEntity>
+{
+    private const int TOTAL_LEAKS = 11;
+    private readonly TimeManager timeManager;
+    private readonly List<float> registeredLeaksFixTime = new();
+
+    public RadiationLeakEntitySpawner(TimeManager timeManager)
+    {
+        this.timeManager = timeManager;
+    }
+
+    protected override IEnumerator SpawnAsync(RadiationLeakEntity entity, TaskResult<Optional<GameObject>> result)
+    {
+        SpawnSync(entity, result);
+        yield break;
+    }
+
+    protected override bool SpawnSync(RadiationLeakEntity entity, TaskResult<Optional<GameObject>> result)
+    {
+        // This script is located under (Aurora Scene) //Aurora-Main/Aurora so it's a good starting point to search through the GameObjects
+        CrashedShipExploder crashedShipExploder = CrashedShipExploder.main;
+        LeakingRadiation leakingRadiation = LeakingRadiation.main;
+        if (!crashedShipExploder || !leakingRadiation || entity.Metadata is not RadiationMetadata metadata)
+        {
+            return true;
+        }
+        Transform radiationLeaksHolder = crashedShipExploder.transform.Find("radiationleaks").GetChild(0);
+        RadiationLeak radiationLeak = radiationLeaksHolder.GetChild(entity.ObjectIndex).GetComponent<RadiationLeak>();
+        NitroxEntity.SetNewId(radiationLeak.gameObject, entity.Id);
+        radiationLeak.liveMixin.health = metadata.Health;
+        registeredLeaksFixTime.Add(metadata.FixRealTime);
+
+        // We can only calculate the radiation increment and dissipation once we got all radiation leaks info
+        if (crashedShipExploder.IsExploded() && registeredLeaksFixTime.Count == TOTAL_LEAKS)
+        {
+            RecalculateRadiationRadius(leakingRadiation);
+        }
+
+        return true;
+    }
+
+    public void RecalculateRadiationRadius(LeakingRadiation leakingRadiation)
+    {
+        float realElapsedTime = (float)timeManager.RealTimeElapsed;
+        // We substract the explosion time from the real time because before that, the radius doesn't increment
+        float realExplosionTime = timeManager.AuroraRealExplosionTime;
+        float maxRegisteredLeakFixTime = registeredLeaksFixTime.Max();
+
+        // Note: Only increment radius if leaks were fixed AFTER explosion (before, game code doesn't increase radius)
+        
+        // If leaks aren't all fixed yet we calculate from current real elapsed time
+        float deltaTimeAfterExplosion = realElapsedTime - realExplosionTime;
+        if (maxRegisteredLeakFixTime == -1)
+        {
+            if (deltaTimeAfterExplosion > 0)
+            {
+                float radiusIncrement = deltaTimeAfterExplosion * leakingRadiation.kGrowRate;
+                // Calculation lines from LeakingRadiation.Update
+                leakingRadiation.currentRadius = Mathf.Clamp(leakingRadiation.kStartRadius + radiusIncrement, 0f, leakingRadiation.kMaxRadius);
+                leakingRadiation.damagePlayerInRadius.damageRadius = leakingRadiation.currentRadius;
+                leakingRadiation.radiatePlayerInRange.radiateRadius = leakingRadiation.currentRadius;
+            }
+            // If leaks aren't fixed, we won't need to calculate a radius decrement
+            return;
+        }
+        leakingRadiation.radiationFixed = true;
+
+        // If all leaks are fixed we calculate from the time they were fixed
+        float deltaAliveTime = maxRegisteredLeakFixTime - realExplosionTime;
+        if (deltaAliveTime > 0)
+        {
+            float radiusIncrement = deltaAliveTime * leakingRadiation.kGrowRate;
+            leakingRadiation.currentRadius = Mathf.Clamp(leakingRadiation.kStartRadius + radiusIncrement, 0f, leakingRadiation.kMaxRadius);
+        }
+
+        // Now calculate the natural dissipation decrement from the time leaks are fixed
+        // If they were fixed before real explosion time, we calculate from real explosion time
+        float deltaFixedTimeAfterExplosion = realElapsedTime - Mathf.Max(maxRegisteredLeakFixTime, realExplosionTime);
+        if (deltaFixedTimeAfterExplosion > 0)
+        {
+            float radiusDecrement = deltaFixedTimeAfterExplosion * leakingRadiation.kNaturalDissipation;
+            leakingRadiation.currentRadius = Mathf.Clamp(leakingRadiation.currentRadius + radiusDecrement, 0f, leakingRadiation.kMaxRadius);
+        }
+        leakingRadiation.damagePlayerInRadius.damageRadius = leakingRadiation.currentRadius;
+        leakingRadiation.radiatePlayerInRange.radiateRadius = leakingRadiation.currentRadius;
+    }
+
+    protected override bool SpawnsOwnChildren(RadiationLeakEntity entity) => false;
+}

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
@@ -12,6 +12,7 @@ namespace NitroxClient.GameLogic.Spawning.WorldEntities;
 
 public class RadiationLeakEntitySpawner : SyncEntitySpawner<RadiationLeakEntity>
 {
+    // This constant is defined by Subnautica and should never be modified (same as for SubnauticaWorldModifier)
     private const int TOTAL_LEAKS = 11;
     private readonly TimeManager timeManager;
     private readonly List<float> registeredLeaksFixTime = new();

--- a/NitroxClient/GameLogic/TimeManager.cs
+++ b/NitroxClient/GameLogic/TimeManager.cs
@@ -7,13 +7,33 @@ namespace NitroxClient.GameLogic;
 public class TimeManager
 {
     /// <summary>
-    /// Latest moment at which we updated the time
+    ///     Latest moment at which we updated the time
     /// </summary>
     private DateTimeOffset latestRegistrationTime;
     /// <summary>
-    /// Latest registered value of the time
+    ///     Latest registered value of the time
     /// </summary>
     private double latestRegisteredTime;
+
+    /// <summary>
+    ///     Moment at which real time elapsed was determined
+    /// </summary>
+    private DateTimeOffset realTimeElapsedRegistrationTime;
+    /// <summary>
+    ///     Only registered value of real time elapsed given when connecting. Associated to <see cref="realTimeElapsedRegistrationTime"/>
+    /// </summary>
+    private double realTimeElapsed;
+
+    public float AuroraRealExplosionTime { get; set; }
+
+    /// <summary>
+    ///     Calculates the exact real time elapsed from an offset (<see cref="realTimeElapsedRegistrationTime"/>) and the delta time between
+    ///     <see cref="DateTimeOffset.UtcNow"/> and the offset's exact <see cref="DateTimeOffset"/> (<see cref="latestRegistrationTime"/>).
+    /// </summary>
+    public double RealTimeElapsed
+    {
+        get => (DateTimeOffset.UtcNow - realTimeElapsedRegistrationTime).TotalMilliseconds * 0.001 + realTimeElapsed;
+    }
 
     private const double DEFAULT_TIME = 480;
 
@@ -75,5 +95,11 @@ public class TimeManager
         double currentTime = CurrentTime;
         DeltaTime = (float)(currentTime - DayNightCycle.main.timePassedAsDouble);
         return currentTime;
+    }
+
+    public void InitRealTimeElapsed(double realTimeElapsed, long registrationTime)
+    {
+        this.realTimeElapsed = realTimeElapsed;
+        realTimeElapsedRegistrationTime = DateTimeOffset.FromUnixTimeMilliseconds(registrationTime);
     }
 }

--- a/NitroxClient/GameLogic/TimeManager.cs
+++ b/NitroxClient/GameLogic/TimeManager.cs
@@ -1,4 +1,5 @@
 using System;
+using NitroxClient.MonoBehaviours;
 using NitroxModel.Packets;
 using UnityEngine;
 
@@ -6,6 +7,12 @@ namespace NitroxClient.GameLogic;
 
 public class TimeManager
 {
+    /// <summary>
+    ///     When first player connects to the server, time will resume when time will be resumed on server-side.
+    ///     According to this, we need to freeze time on first player connecting before it has fully loaded.
+    /// </summary>
+    private bool freezeTime = true;
+
     /// <summary>
     ///     Latest moment at which we updated the time
     /// </summary>
@@ -26,16 +33,31 @@ public class TimeManager
 
     public float AuroraRealExplosionTime { get; set; }
 
+    private const double DEFAULT_REAL_TIME = 0;
+
     /// <summary>
     ///     Calculates the exact real time elapsed from an offset (<see cref="realTimeElapsedRegistrationTime"/>) and the delta time between
     ///     <see cref="DateTimeOffset.UtcNow"/> and the offset's exact <see cref="DateTimeOffset"/> (<see cref="latestRegistrationTime"/>).
     /// </summary>
     public double RealTimeElapsed
     {
-        get => (DateTimeOffset.UtcNow - realTimeElapsedRegistrationTime).TotalMilliseconds * 0.001 + realTimeElapsed;
+        get
+        {
+            // Unitialized state
+            if (realTimeElapsedRegistrationTime == default)
+            {
+                return DEFAULT_REAL_TIME;
+            }
+            if (freezeTime)
+            {
+                return realTimeElapsed;
+            }
+
+            return (DateTimeOffset.UtcNow - realTimeElapsedRegistrationTime).TotalMilliseconds * 0.001 + realTimeElapsed;
+        }
     }
 
-    private const double DEFAULT_TIME = 480;
+    private const double DEFAULT_SUBNAUTICA_TIME = 480;
 
     /// <summary>
     ///     Calculates the current exact time from an offset (<see cref="latestRegisteredTime"/>) and the delta time between
@@ -52,7 +74,11 @@ public class TimeManager
             // Unitialized state
             if (latestRegisteredTime == 0)
             {
-                return DEFAULT_TIME;
+                return DEFAULT_SUBNAUTICA_TIME;
+            }
+            if (freezeTime)
+            {
+                return latestRegisteredTime;
             }
             return (DateTimeOffset.UtcNow - latestRegistrationTime).TotalMilliseconds * 0.001 + latestRegisteredTime;
         }
@@ -76,6 +102,13 @@ public class TimeManager
 
     public void ProcessUpdate(TimeChange packet)
     {
+        if (freezeTime && Multiplayer.Main && Multiplayer.Main.InitialSyncCompleted)
+        {
+            freezeTime = false;
+        }
+        realTimeElapsedRegistrationTime = DateTimeOffset.FromUnixTimeMilliseconds(packet.UpdateTime);
+        realTimeElapsed = packet.RealTimeElapsed;
+
         latestRegistrationTime = DateTimeOffset.FromUnixTimeMilliseconds(packet.UpdateTime);
         latestRegisteredTime = packet.CurrentTime;
         
@@ -97,9 +130,10 @@ public class TimeManager
         return currentTime;
     }
 
-    public void InitRealTimeElapsed(double realTimeElapsed, long registrationTime)
+    public void InitRealTimeElapsed(double realTimeElapsed, long registrationTime, bool isFirstPlayer)
     {
         this.realTimeElapsed = realTimeElapsed;
         realTimeElapsedRegistrationTime = DateTimeOffset.FromUnixTimeMilliseconds(registrationTime);
+        freezeTime = isFirstPlayer;
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/AuroraEventData.cs
+++ b/NitroxModel/DataStructures/GameLogic/AuroraEventData.cs
@@ -23,16 +23,23 @@ public class AuroraEventData
     [DataMember(Order = 2)]
     public float TimeToStartWarning;
 
+    /// <summary>
+    /// Real time in seconds at which Aurora's considered exploded
+    /// </summary>
+    [DataMember(Order = 3)]
+    public float AuroraRealExplosionTime;
+
     [IgnoreConstructor]
     protected AuroraEventData()
     {
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public AuroraEventData(float timeToStartCountdown, float timeToStartWarning)
+    public AuroraEventData(float timeToStartCountdown, float timeToStartWarning, float auroraRealExplosionTime)
     {
         TimeToStartCountdown = timeToStartCountdown;
         TimeToStartWarning = timeToStartWarning;
+        AuroraRealExplosionTime = auroraRealExplosionTime;
     }
 
     [NonSerialized]

--- a/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -19,6 +19,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 [ProtoInclude(56, typeof(PlanterEntity))]
 [ProtoInclude(57, typeof(PlayerWorldEntity))]
 [ProtoInclude(58, typeof(VehicleWorldEntity))]
+[ProtoInclude(59, typeof(RadiationLeakEntity))]
 public class GlobalRootEntity : WorldEntity
 {
     [IgnoreConstructor]

--- a/NitroxModel/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -33,6 +33,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities.Metadata
     [ProtoInclude(73, typeof(NamedColoredMetadata))]
     [ProtoInclude(74, typeof(BeaconMetadata))]
     [ProtoInclude(75, typeof(FlareMetadata))]
+    [ProtoInclude(76, typeof(RadiationMetadata))]
     public abstract class EntityMetadata
     {
     }

--- a/NitroxModel/DataStructures/GameLogic/Entities/Metadata/RadiationMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/Metadata/RadiationMetadata.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using BinaryPack.Attributes;
 
 namespace NitroxModel.DataStructures.GameLogic.Entities.Metadata;
 
@@ -12,9 +13,20 @@ public class RadiationMetadata : EntityMetadata
     [DataMember(Order = 2)]
     public float FixRealTime { get; set; }
 
+    [IgnoreConstructor]
+    protected RadiationMetadata()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
     public RadiationMetadata(float health, float fixRealTime = -1)
     {
         Health = health;
         FixRealTime = fixRealTime;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(RadiationMetadata)} Health: {Health}, FixRealTime: {FixRealTime}]";
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/Entities/Metadata/RadiationMetadata.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/Metadata/RadiationMetadata.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace NitroxModel.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable, DataContract]
+public class RadiationMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public float Health { get; set; }
+
+    [DataMember(Order = 2)]
+    public float FixRealTime { get; set; }
+
+    public RadiationMetadata(float health, float fixRealTime = -1)
+    {
+        Health = health;
+        FixRealTime = fixRealTime;
+    }
+}

--- a/NitroxModel/DataStructures/GameLogic/Entities/RadiationLeakEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/RadiationLeakEntity.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+using NitroxModel.DataStructures.GameLogic.Entities.Metadata;
+using NitroxModel.DataStructures.Unity;
+
+namespace NitroxModel.DataStructures.GameLogic.Entities;
+
+[Serializable, DataContract]
+public class RadiationLeakEntity : GlobalRootEntity
+{
+    [DataMember(Order = 1)]
+    public int ObjectIndex { get; set; }
+
+    [IgnoreConstructor]
+    protected RadiationLeakEntity()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
+    public RadiationLeakEntity(NitroxId id, int objectIndex, RadiationMetadata metadata)
+    {
+        Id = id;
+        ObjectIndex = objectIndex;
+        Metadata = metadata;
+    }
+
+    /// <remarks>Used for deserialization</remarks>
+    public RadiationLeakEntity(int objectIndex, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+        base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
+    {
+        ObjectIndex = objectIndex;
+    }
+}

--- a/NitroxModel/DataStructures/GameLogic/TimeData.cs
+++ b/NitroxModel/DataStructures/GameLogic/TimeData.cs
@@ -8,12 +8,10 @@ public class TimeData
 {
     public TimeChange TimePacket;
     public AuroraEventData AuroraEventData;
-    public double RealTimeElapsed;
 
-    public TimeData(TimeChange timePacket, AuroraEventData auroraEventData, double realTimeElapsed)
+    public TimeData(TimeChange timePacket, AuroraEventData auroraEventData)
     {
         TimePacket = timePacket;
         AuroraEventData = auroraEventData;
-        RealTimeElapsed = realTimeElapsed;
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/TimeData.cs
+++ b/NitroxModel/DataStructures/GameLogic/TimeData.cs
@@ -8,10 +8,12 @@ public class TimeData
 {
     public TimeChange TimePacket;
     public AuroraEventData AuroraEventData;
+    public double RealTimeElapsed;
 
-    public TimeData(TimeChange timePacket, AuroraEventData auroraEventData)
+    public TimeData(TimeChange timePacket, AuroraEventData auroraEventData, double realTimeElapsed)
     {
         TimePacket = timePacket;
         AuroraEventData = auroraEventData;
+        RealTimeElapsed = realTimeElapsed;
     }
 }

--- a/NitroxModel/Packets/InitialPlayerSync.cs
+++ b/NitroxModel/Packets/InitialPlayerSync.cs
@@ -32,6 +32,7 @@ namespace NitroxModel.Packets
         public Perms Permissions { get; }
         public SubnauticaPlayerPreferences Preferences { get; }
         public TimeData TimeData { get; }
+        public bool IsFirstPlayer { get; }
         public Dictionary<NitroxId, int> BuildOperationIds { get; }
 
         public InitialPlayerSync(NitroxId playerGameObjectId,
@@ -53,6 +54,7 @@ namespace NitroxModel.Packets
             Perms perms,
             SubnauticaPlayerPreferences preferences,
             TimeData timeData,
+            bool isFirstPlayer,
             Dictionary<NitroxId, int> buildOperationIds)
         {
             AssignedEscapePodId = assignedEscapePodId;
@@ -74,6 +76,7 @@ namespace NitroxModel.Packets
             Permissions = perms;
             Preferences = preferences;
             TimeData = timeData;
+            IsFirstPlayer = isFirstPlayer;
             BuildOperationIds = buildOperationIds;
         }
 
@@ -98,6 +101,7 @@ namespace NitroxModel.Packets
             Perms permissions,
             SubnauticaPlayerPreferences preferences,
             TimeData timeData,
+            bool isFirstPlayer,
             Dictionary<NitroxId, int> buildOperationIds)
         {
             AssignedEscapePodId = assignedEscapePodId;
@@ -119,6 +123,7 @@ namespace NitroxModel.Packets
             Permissions = permissions;
             Preferences = preferences;
             TimeData = timeData;
+            IsFirstPlayer = isFirstPlayer;
             BuildOperationIds = buildOperationIds;
         }
     }

--- a/NitroxModel/Packets/TimeChange.cs
+++ b/NitroxModel/Packets/TimeChange.cs
@@ -13,10 +13,15 @@ public class TimeChange : Packet
     /// Real time at which the CurrentTime was observed
     /// </summary>
     public long UpdateTime { get; }
+    /// <summary>
+    /// Real time elapsed in seconds
+    /// </summary>
+    public double RealTimeElapsed;
 
-    public TimeChange(double currentTime, long updateTime)
+    public TimeChange(double currentTime, long updateTime, double realTimeElapsed)
     {
         CurrentTime = currentTime;
         UpdateTime = updateTime;
+        RealTimeElapsed = realTimeElapsed;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FPSCounter_UpdateDisplay_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FPSCounter_UpdateDisplay_Patch.cs
@@ -12,11 +12,12 @@ public sealed partial class FPSCounter_UpdateDisplay_Patch : NitroxPatch, IDynam
 
     public static void Postfix(FPSCounter __instance)
     {
-        if (!Multiplayer.Main.InitialSyncCompleted)
+        if (!Multiplayer.Active)
         {
             return;
         }
         __instance.strBuffer.Append("Loading entities: ").AppendLine(Resolve<Entities>().EntitiesToSpawn.Count.ToString());
+        __instance.strBuffer.Append("Real time elapsed: ").AppendLine(Resolve<TimeManager>().RealTimeElapsed.ToString());
         __instance.text.SetText(__instance.strBuffer);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/LeakingRadiation_OnConsoleCommand_decontaminate_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LeakingRadiation_OnConsoleCommand_decontaminate_Patch.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Disables the "decontaminate" command
+/// </summary>
+public sealed partial class LeakingRadiation_OnConsoleCommand_decontaminate_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((LeakingRadiation t) => t.OnConsoleCommand_decontaminate());
+
+    public static bool Prefix()
+    {
+        // This command can't be synced because it would break how radiation leak is currently synced
+        // Currently all radiation radius calculations depend on the fixed leaks
+        // But this command would work even if leaks aren't fixed (modifying the radius but only on local client)
+        Log.InGame(Language.main.Get("Nitrox_CommandNotAvailable"));
+        return false;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/LeakingRadiation_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LeakingRadiation_Update_Patch.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Replaces local use of <see cref="Time.deltaTime"/> by <see cref="TimeManager.DeltaTime"/>
+/// </summary>
+public sealed partial class LeakingRadiation_Update_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((LeakingRadiation t) => t.Update());
+    private static readonly MethodInfo INSERTED_METHOD = Reflect.Method(() => GetDeltaTime());
+    private static readonly MethodInfo MATCHING_FIELD = Reflect.Property(() => Time.deltaTime).GetGetMethod();
+
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions).MatchStartForward(new CodeMatch(OpCodes.Call, MATCHING_FIELD))
+                                            .SetOperandAndAdvance(INSERTED_METHOD)
+                                            .InstructionEnumeration();
+    }
+
+    /// <summary>
+    /// Wrapper for dependency resolving and variable querying
+    /// </summary>
+    public static float GetDeltaTime()
+    {
+        return Resolve<TimeManager>().DeltaTime;
+    }
+}

--- a/NitroxServer-Subnautica/GameLogic/SubnauticaWorldModifier.cs
+++ b/NitroxServer-Subnautica/GameLogic/SubnauticaWorldModifier.cs
@@ -1,0 +1,18 @@
+using NitroxModel.DataStructures.GameLogic.Entities;
+using NitroxServer.GameLogic;
+using NitroxServer.Serialization.World;
+
+namespace NitroxServer_Subnautica.GameLogic;
+
+public class SubnauticaWorldModifier : IWorldModifier
+{
+    public void ModifyWorld(World world)
+    {
+        // Creating entities for the 11 RadiationLeakPoint located at (Aurora Scene) //Aurora-MainPrefab/Aurora/radiationleaks/RadiationLeaks(Clone)
+        for (int i = 0; i < 11; i++)
+        {
+            RadiationLeakEntity leakEntity = new(new(), i, new(0));
+            world.WorldEntityManager.AddGlobalRootEntity(leakEntity);
+        }
+    }
+}

--- a/NitroxServer-Subnautica/GameLogic/SubnauticaWorldModifier.cs
+++ b/NitroxServer-Subnautica/GameLogic/SubnauticaWorldModifier.cs
@@ -6,10 +6,13 @@ namespace NitroxServer_Subnautica.GameLogic;
 
 public class SubnauticaWorldModifier : IWorldModifier
 {
+    // This constant is defined by Subnautica and should never be modified
+    private const int TOTAL_LEAKS = 11;
+
     public void ModifyWorld(World world)
     {
         // Creating entities for the 11 RadiationLeakPoint located at (Aurora Scene) //Aurora-MainPrefab/Aurora/radiationleaks/RadiationLeaks(Clone)
-        for (int i = 0; i < 11; i++)
+        for (int i = 0; i < TOTAL_LEAKS; i++)
         {
             RadiationLeakEntity leakEntity = new(new(), i, new(0));
             world.WorldEntityManager.AddGlobalRootEntity(leakEntity);

--- a/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
+++ b/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
@@ -7,9 +7,11 @@ using NitroxModel_Subnautica.DataStructures;
 using NitroxModel_Subnautica.DataStructures.GameLogic.Entities;
 using NitroxModel_Subnautica.Helper;
 using NitroxServer;
+using NitroxServer.GameLogic;
 using NitroxServer.GameLogic.Entities;
 using NitroxServer.GameLogic.Entities.Spawning;
 using NitroxServer.Serialization;
+using NitroxServer_Subnautica.GameLogic;
 using NitroxServer_Subnautica.GameLogic.Entities;
 using NitroxServer_Subnautica.GameLogic.Entities.Spawning;
 using NitroxServer_Subnautica.GameLogic.Entities.Spawning.EntityBootstrappers;
@@ -56,6 +58,7 @@ namespace NitroxServer_Subnautica
 
             containerBuilder.RegisterType<SubnauticaMap>().As<IMap>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<EntityRegistry>().AsSelf().InstancePerLifetimeScope();
+            containerBuilder.RegisterType<SubnauticaWorldModifier>().As<IWorldModifier>().InstancePerLifetimeScope();
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -70,6 +70,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 RespawnExistingEntity(player);
             }
             List<GlobalRootEntity> globalRootEntities = world.WorldEntityManager.GetGlobalRootEntities(true);
+            bool isFirstPlayer = playerManager.GetConnectedPlayers().Count == 1;
 
             InitialPlayerSync initialPlayerSync = new(player.GameObjectId,
                 wasBrandNewPlayer,
@@ -90,6 +91,7 @@ namespace NitroxServer.Communication.Packets.Processors
                 player.Permissions,
                 new(new(player.PingInstancePreferences), player.PinnedRecipePreferences.ToList()),
                 storyManager.GetTimeData(),
+                isFirstPlayer,
                 BuildingManager.GetEntitiesOperations(globalRootEntities)
             );
 

--- a/NitroxServer/GameLogic/IWorldModifier.cs
+++ b/NitroxServer/GameLogic/IWorldModifier.cs
@@ -1,0 +1,11 @@
+using NitroxServer.Serialization.World;
+
+namespace NitroxServer.GameLogic;
+
+/// <summary>
+/// Holds a set of instructions to be ran when a world is created. There should be one Subnautica and one for BZ.
+/// </summary>
+public interface IWorldModifier
+{
+    public void ModifyWorld(World world);
+}

--- a/NitroxServer/GameLogic/StoryManager.cs
+++ b/NitroxServer/GameLogic/StoryManager.cs
@@ -192,7 +192,7 @@ public class StoryManager
 
     public TimeData GetTimeData()
     {
-        return new(timeKeeper.MakeTimePacket(), MakeAuroraData(), timeKeeper.RealTimeElapsed);
+        return new(timeKeeper.MakeTimePacket(), MakeAuroraData());
     }
 
     public enum TimeModification

--- a/NitroxServer/GameLogic/StoryTimingData.cs
+++ b/NitroxServer/GameLogic/StoryTimingData.cs
@@ -16,13 +16,21 @@ namespace NitroxServer.GameLogic
         [DataMember(Order = 3)]
         public double? AuroraWarningTime { get; set; }
 
+        [DataMember(Order = 4)]
+        public double RealTimeElapsed { get; set; }
+
+        [DataMember(Order = 5)]
+        public double? AuroraRealExplosionTime { get; set; }
+
         public static StoryTimingData From(StoryManager storyManager, TimeKeeper timeKeeper)
         {
             return new StoryTimingData
             {
                 ElapsedSeconds = timeKeeper.ElapsedSeconds,
                 AuroraCountdownTime = storyManager.AuroraCountdownTimeMs,
-                AuroraWarningTime = storyManager.AuroraWarningTimeMs
+                AuroraWarningTime = storyManager.AuroraWarningTimeMs,
+                RealTimeElapsed = timeKeeper.RealTimeElapsed,
+                AuroraRealExplosionTime = storyManager.AuroraRealExplosionTime
             };
         }
     }

--- a/NitroxServer/GameLogic/TimeKeeper.cs
+++ b/NitroxServer/GameLogic/TimeKeeper.cs
@@ -13,6 +13,11 @@ public class TimeKeeper
     private readonly Stopwatch stopWatch = new();
 
     /// <summary>
+    ///     Default time in Base SN is 480s
+    /// </summary>
+    public const int DEFAULT_TIME = 480;
+
+    /// <summary>
     /// Latest registered time without taking the current stopwatch time in account.
     /// </summary>
     private double elapsedTimeOutsideStopWatchMs;
@@ -65,14 +70,13 @@ public class TimeKeeper
     /// </remarks>
     private const int RESYNC_INTERVAL = 60;
 
-    public TimeSkipped OnTimeSkipped;
+    public TimeSkippedEventHandler TimeSkipped;
 
     public TimeKeeper(PlayerManager playerManager, double elapsedSeconds, double realTimeElapsed)
     {
         this.playerManager = playerManager;
 
-        // Default time in Base SN is 480s
-        elapsedTimeOutsideStopWatchMs = elapsedSeconds == 0 ? TimeSpan.FromSeconds(480).TotalMilliseconds : elapsedSeconds * 1000;
+        elapsedTimeOutsideStopWatchMs = elapsedSeconds == 0 ? TimeSpan.FromSeconds(DEFAULT_TIME).TotalMilliseconds : elapsedSeconds * 1000;
         this.realTimeElapsed = realTimeElapsed;
         ResyncTimer = MakeResyncTimer();
     }
@@ -134,7 +138,7 @@ public class TimeKeeper
         if (skipAmount > 0)
         {
             ElapsedSeconds += skipAmount;
-            OnTimeSkipped?.Invoke(skipAmount);
+            TimeSkipped?.Invoke(skipAmount);
 
             playerManager.SendPacketToAllPlayers(MakeTimePacket());
         }
@@ -145,5 +149,5 @@ public class TimeKeeper
         return new(ElapsedSeconds, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), RealTimeElapsed);
     }
 
-    public delegate void TimeSkipped(double skipAmount);
+    public delegate void TimeSkippedEventHandler(double skipAmount);
 }

--- a/NitroxServer/GameLogic/TimeKeeper.cs
+++ b/NitroxServer/GameLogic/TimeKeeper.cs
@@ -142,7 +142,7 @@ public class TimeKeeper
 
     public TimeChange MakeTimePacket()
     {
-        return new(ElapsedSeconds, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        return new(ElapsedSeconds, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), RealTimeElapsed);
     }
 
     public delegate void TimeSkipped(double skipAmount);

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -31,14 +31,16 @@ namespace NitroxServer.Serialization.World
         private readonly ServerJsonSerializer jsonSerializer;
         private readonly ServerConfig config;
         private readonly RandomStartGenerator randomStart;
+        private readonly IWorldModifier worldModifier;
         private readonly SaveDataUpgrade[] upgrades;
 
-        public WorldPersistence(ServerProtoBufSerializer protoBufSerializer, ServerJsonSerializer jsonSerializer, ServerConfig config, RandomStartGenerator randomStart, SaveDataUpgrade[] upgrades)
+        public WorldPersistence(ServerProtoBufSerializer protoBufSerializer, ServerJsonSerializer jsonSerializer, ServerConfig config, RandomStartGenerator randomStart, IWorldModifier worldModifier, SaveDataUpgrade[] upgrades)
         {
             this.protoBufSerializer = protoBufSerializer;
             this.jsonSerializer = jsonSerializer;
             this.config = config;
             this.randomStart = randomStart;
+            this.worldModifier = worldModifier;
             this.upgrades = upgrades;
 
             UpdateSerializer(config.SerializerMode);
@@ -177,7 +179,6 @@ namespace NitroxServer.Serialization.World
             };
 
             World newWorld = CreateWorld(pWorldData, config.GameMode);
-            IWorldModifier worldModifier = NitroxServiceLocator.LocateService<IWorldModifier>();
             worldModifier.ModifyWorld(newWorld);
 
             return newWorld;

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -176,7 +176,11 @@ namespace NitroxServer.Serialization.World
                 GlobalRootData = new()
             };
 
-            return CreateWorld(pWorldData, config.GameMode);
+            World newWorld = CreateWorld(pWorldData, config.GameMode);
+            IWorldModifier worldModifier = NitroxServiceLocator.LocateService<IWorldModifier>();
+            worldModifier.ModifyWorld(newWorld);
+
+            return newWorld;
         }
 
         public World CreateWorld(PersistedWorldData pWorldData, NitroxGameMode gameMode)
@@ -213,8 +217,8 @@ namespace NitroxServer.Serialization.World
                 Seed = seed
             };
 
-            world.TimeKeeper = new(world.PlayerManager, pWorldData.WorldData.GameData.StoryTiming.ElapsedSeconds);
-            world.StoryManager = new(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, seed, pWorldData.WorldData.GameData.StoryTiming.AuroraCountdownTime, pWorldData.WorldData.GameData.StoryTiming.AuroraWarningTime);
+            world.TimeKeeper = new(world.PlayerManager, pWorldData.WorldData.GameData.StoryTiming.ElapsedSeconds, pWorldData.WorldData.GameData.StoryTiming.RealTimeElapsed);
+            world.StoryManager = new(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, seed, pWorldData.WorldData.GameData.StoryTiming.AuroraCountdownTime, pWorldData.WorldData.GameData.StoryTiming.AuroraWarningTime, pWorldData.WorldData.GameData.StoryTiming.AuroraRealExplosionTime);
             world.ScheduleKeeper = new ScheduleKeeper(pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, world.PlayerManager);
 
             world.BatchEntitySpawner = new BatchEntitySpawner(


### PR DESCRIPTION
- [x] Sync radiation leak fixing (can be fixed by two people at a time)
- [x] Recalculates the radiation radius based on the time at which the last unfixed leak was fixed
- [x] Add a subsystem to modify worlds when they're created, in this case it's used to create the radiation leak entities but it could be used as well for BZ
- [x] Desync-proof local radiation updates because I replaced Time.deltaTime by our own loss-less deltaTime.
- [x] Add a "real elapsed time" on server-side which is propagated to the client so both of them can work with "Time.deltaTime" behaviours on clients.