### PR TITLE
Sync spawning commands

### DIFF
--- a/Nitrox.Test/Patcher/Patches/Dynamic/SpawnConsoleCommand_OnConsoleCommand_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/SpawnConsoleCommand_OnConsoleCommand_PatchTest.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxTest.Patcher;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+[TestClass]
+public class SpawnConsoleCommand_OnConsoleCommand_PatchTest
+{
+    [TestMethod]
+    public void Sanity()
+    {
+        IEnumerable<CodeInstruction> originalIl = PatchTestHelper.GetInstructionsFromMethod(SpawnConsoleCommand_OnConsoleCommand_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> transformedIl = SpawnConsoleCommand_OnConsoleCommand_Patch.Transpiler(originalIl);
+        transformedIl.Count().Should().Be(originalIl.Count() + 2);
+    }
+}

--- a/Nitrox.Test/Patcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_PatchTest.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxTest.Patcher;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+[TestClass]
+public class SubConsoleCommand_OnConsoleCommand_sub_PatchTest
+{
+    [TestMethod]
+    public void Sanity()
+    {
+        IEnumerable<CodeInstruction> originalIl = PatchTestHelper.GetInstructionsFromMethod(SubConsoleCommand_OnConsoleCommand_sub_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> transformedIl = SubConsoleCommand_OnConsoleCommand_sub_Patch.Transpiler(originalIl);
+        transformedIl.Count().Should().Be(originalIl.Count());
+    }
+}

--- a/NitroxClient/GameLogic/MobileVehicleBay.cs
+++ b/NitroxClient/GameLogic/MobileVehicleBay.cs
@@ -40,7 +40,7 @@ public class MobileVehicleBay
 
         NitroxId constructedObjectId = NitroxEntity.GenerateNewId(constructedObject);
 
-        VehicleWorldEntity vehicleEntity = Vehicles.MakeVehicleEntity(constructedObject, constructedObjectId, techType, constructorId);
+        VehicleWorldEntity vehicleEntity = Vehicles.BuildVehicleWorldEntity(constructedObject, constructedObjectId, techType, constructorId);
 
         packetSender.Send(new EntitySpawnedByClient(vehicleEntity));
 

--- a/NitroxClient/GameLogic/MobileVehicleBay.cs
+++ b/NitroxClient/GameLogic/MobileVehicleBay.cs
@@ -1,10 +1,8 @@
 using NitroxClient.Communication.Abstract;
-using NitroxClient.GameLogic.Helper;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.Packets;
-using NitroxModel_Subnautica.DataStructures;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic;
@@ -42,8 +40,7 @@ public class MobileVehicleBay
 
         NitroxId constructedObjectId = NitroxEntity.GenerateNewId(constructedObject);
 
-        VehicleWorldEntity vehicleEntity = new(constructorId, DayNightCycle.main.timePassedAsFloat, constructedObject.transform.ToLocalDto(), string.Empty, false, constructedObjectId, techType.ToDto(), null);
-        VehicleChildEntityHelper.PopulateChildren(constructedObjectId, constructedObject.GetFullHierarchyPath(), vehicleEntity.ChildEntities, constructedObject);
+        VehicleWorldEntity vehicleEntity = Vehicles.MakeVehicleEntity(constructedObject, constructedObjectId, techType, constructorId);
 
         packetSender.Send(new EntitySpawnedByClient(vehicleEntity));
 

--- a/NitroxClient/GameLogic/NitroxConsole.cs
+++ b/NitroxClient/GameLogic/NitroxConsole.cs
@@ -14,12 +14,12 @@ namespace NitroxClient.GameLogic
         public static bool DisableConsole { get; set; } = true;
 
         private readonly IPacketSender packetSender;
-        private readonly Items item;
+        private readonly Items items;
 
-        public NitroxConsole(IPacketSender packetSender, Items item)
+        public NitroxConsole(IPacketSender packetSender, Items items)
         {
             this.packetSender = packetSender;
-            this.item = item;
+            this.items = items;
         }
 
         //List of things that can be spawned : https://subnauticacommands.com/items
@@ -35,8 +35,7 @@ namespace NitroxClient.GameLogic
                 }
                 else
                 {
-                    SpawnItem(gameObject);
-                    //TODO: Add support for no AI creature that need to be spawned as well
+                    DefaultSpawn(gameObject);
                 }
             }
             catch (Exception ex)
@@ -46,29 +45,22 @@ namespace NitroxClient.GameLogic
         }
 
         /// <summary>
-        /// Spawns Seamoth, Exosuit and Cyclops
+        /// Spawns Seamoth, Exosuit or Cyclops
         /// </summary>
         private void SpawnVehicle(GameObject gameObject, TechType techType)
         {
             NitroxId id = NitroxEntity.GetIdOrGenerateNew(gameObject);
 
-            VehicleWorldEntity vehicleEntity = Vehicles.MakeVehicleEntity(gameObject, id, techType);
+            VehicleWorldEntity vehicleEntity = Vehicles.BuildVehicleWorldEntity(gameObject, id, techType);
             
             packetSender.Send(new EntitySpawnedByClient(vehicleEntity));
 
             Log.Debug($"Spawning vehicle {techType} with id {id} at {gameObject.transform.position}");
         }
 
-        /// <summary>
-        /// Spawns a Pickupable item
-        /// </summary>
-        private void SpawnItem(GameObject gameObject)
+        private void DefaultSpawn(GameObject gameObject)
         {
-            if (gameObject.TryGetComponent(out Pickupable pickupable))
-            {
-                Log.Debug($"Spawning item {pickupable.GetTechName()} at {gameObject.transform.position}");
-                item.Dropped(gameObject, pickupable.GetTechType());
-            }
+            items.Dropped(gameObject);
         }
 
         private static TechType GetObjectTechType(GameObject gameObject)

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -235,7 +235,7 @@ public class Vehicles
         }
     }
 
-    public static VehicleWorldEntity MakeVehicleEntity(GameObject constructedObject, NitroxId constructedObjectId, TechType techType, NitroxId constructorId = null)
+    public static VehicleWorldEntity BuildVehicleWorldEntity(GameObject constructedObject, NitroxId constructedObjectId, TechType techType, NitroxId constructorId = null)
     {
         VehicleWorldEntity vehicleEntity = new(constructorId, DayNightCycle.main.timePassedAsFloat, constructedObject.transform.ToLocalDto(), string.Empty, false, constructedObjectId, techType.ToDto(), null);
         VehicleChildEntityHelper.PopulateChildren(constructedObjectId, constructedObject.GetFullHierarchyPath(), vehicleEntity.ChildEntities, constructedObject);

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -1,14 +1,16 @@
 using System.Collections;
 using NitroxClient.Communication;
 using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
-using NitroxModel_Subnautica.DataStructures;
-using NitroxModel_Subnautica.DataStructures.GameLogic;
 using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
+using NitroxModel_Subnautica.DataStructures;
+using NitroxModel_Subnautica.DataStructures.GameLogic;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic;
@@ -231,5 +233,12 @@ public class Vehicles
             nitroxEntity.Remove();
             UnityEngine.Object.DestroyImmediate(nitroxEntity);
         }
+    }
+
+    public static VehicleWorldEntity MakeVehicleEntity(GameObject constructedObject, NitroxId constructedObjectId, TechType techType, NitroxId constructorId = null)
+    {
+        VehicleWorldEntity vehicleEntity = new(constructorId, DayNightCycle.main.timePassedAsFloat, constructedObject.transform.ToLocalDto(), string.Empty, false, constructedObjectId, techType.ToDto(), null);
+        VehicleChildEntityHelper.PopulateChildren(constructedObjectId, constructedObject.GetFullHierarchyPath(), vehicleEntity.ChildEntities, constructedObject);
+        return vehicleEntity;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/SpawnConsoleCommand_OnConsoleCommand_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SpawnConsoleCommand_OnConsoleCommand_Patch.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -11,33 +10,26 @@ namespace NitroxPatcher.Patches.Dynamic;
 
 public sealed partial class SpawnConsoleCommand_OnConsoleCommand_Patch : NitroxPatch, IDynamicPatch
 {
-    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SpawnConsoleCommand t) => t.OnConsoleCommand_spawn(default(NotificationCenter.Notification)));
+    internal static readonly MethodInfo TARGET_METHOD = AccessTools.EnumeratorMoveNext(Reflect.Method((SpawnConsoleCommand t) => t.SpawnAsync(default)));
 
-    private static readonly OpCode INJECTION_CODE = OpCodes.Call;
-    private static readonly object INJECTION_OPERAND = Reflect.Method(() => Utils.CreatePrefab(default(GameObject), default(float), default(bool)));
-
-    public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+    /*
+     * GameObject gameObject = global::Utils.CreatePrefab(prefabForTechType, maxDist, i > 0);
+     * -> SpawnConsoleCommand_OnConsoleCommand_Patch.Callback(gameObject);
+     * LargeWorldEntity.Register(gameObject);
+     * CrafterLogic.NotifyCraftEnd(gameObject, techType);
+     * gameObject.SendMessage("StartConstruction", SendMessageOptions.DontRequireReceiver);
+     */
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        Validate.NotNull(INJECTION_OPERAND);
-
-        foreach (CodeInstruction instruction in instructions)
-        {
-            yield return instruction;
-
-            /*
-             * GameObject gameObject = global::Utils.CreatePrefab(prefabForTechType, maxDist, i > 0);
-             * -> SpawnConsoleCommand_OnConsoleCommand_Patch.Callback(gameObject);
-             * LargeWorldEntity.Register(gameObject);
-             * CrafterLogic.NotifyCraftEnd(gameObject, techType);
-             * gameObject.SendMessage("StartConstruction", SendMessageOptions.DontRequireReceiver);
-             */
-            if (instruction.opcode == INJECTION_CODE && instruction.operand.Equals(INJECTION_OPERAND))
-            {
-                yield return new CodeInstruction(OpCodes.Dup);
-                yield return new CodeInstruction(OpCodes.Call, ((Action<GameObject>)Callback).Method);
-            }
-
-        }
+        return new CodeMatcher(instructions).MatchStartForward([
+                                                new CodeMatch(OpCodes.Call, Reflect.Method(() => Utils.CreatePrefab(default, default, default)))
+                                            ])
+                                            .Advance(1)
+                                            .Insert([
+                                                new CodeInstruction(OpCodes.Dup),
+                                                new CodeInstruction(OpCodes.Call, Reflect.Method(() => Callback(default)))
+                                            ])
+                                            .InstructionEnumeration();
     }
 
     public static void Callback(GameObject gameObject)

--- a/NitroxPatcher/Patches/Dynamic/SpawnConsoleCommand_SpawnAsync_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SpawnConsoleCommand_SpawnAsync_Patch.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.Helper;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Syncs "spawn" command.
+/// </summary>
+public sealed partial class SpawnConsoleCommand_SpawnAsync_Patch : NitroxPatch, IDynamicPatch
+{
+    internal static readonly MethodInfo TARGET_METHOD = AccessTools.EnumeratorMoveNext(Reflect.Method((SpawnConsoleCommand t) => t.SpawnAsync(default)));
+
+    /*
+     * MODIFIED:
+     * GameObject gameObject = global::Utils.CreatePrefab(prefabForTechType, maxDist, i > 0);
+     * SpawnConsoleCommand_OnConsoleCommand_Patch.WrappedCallback(gameObject);      <---- INSERTED LINE
+     * LargeWorldEntity.Register(gameObject);
+     * CrafterLogic.NotifyCraftEnd(gameObject, techType);
+     * gameObject.SendMessage("StartConstruction", SendMessageOptions.DontRequireReceiver);
+     */
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions).MatchStartForward([
+                                                new CodeMatch(OpCodes.Call, Reflect.Method(() => Utils.CreatePrefab(default, default, default)))
+                                            ])
+                                            .Advance(1)
+                                            .Insert([
+                                                new CodeInstruction(OpCodes.Dup),
+                                                new CodeInstruction(OpCodes.Call, Reflect.Method(() => Callback(default)))
+                                            ])
+                                            .InstructionEnumeration();
+    }
+
+    public static void Callback(GameObject gameObject)
+    {
+        Resolve<NitroxConsole>().Spawn(gameObject);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
@@ -1,19 +1,41 @@
+using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NitroxClient.GameLogic;
 using NitroxModel.Helper;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
-/// <summary>
-/// Called whenever a Cyclops or Seamoth is spawned. Nitrox already has its own command to spawn vehicles.
-/// This patch is only meant to block the method from executing, causing two vehicles to be spawned instead of one
-/// </summary>
 public sealed partial class SubConsoleCommand_OnConsoleCommand_sub_Patch : NitroxPatch, IDynamicPatch
 {
-    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SubConsoleCommand t) => t.OnConsoleCommand_sub(default));
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((SubConsoleCommand t) => t.OnConsoleCommand_sub(default));
 
-    public static bool Prefix()
+    /*
+     * REPLACE:
+     * LightmappedPrefabs.main.RequestScenePrefab(text, new LightmappedPrefabs.OnPrefabLoaded(this.OnSubPrefabLoaded));
+     * BY:
+     * LightmappedPrefabs.main.RequestScenePrefab(text, new LightmappedPrefabs.OnPrefabLoaded(SubConsoleCommand_OnConsoleCommand_sub_Patch.WrappedCallback));
+     */
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        Log.InGame(Language.main.Get("Nitrox_CommandNotAvailable"));
-        return false;
+        return new CodeMatcher(instructions).MatchEndForward([
+                                                new CodeMatch(OpCodes.Stfld),
+                                                new CodeMatch(OpCodes.Ldsfld),
+                                                new CodeMatch(OpCodes.Ldloc_0),
+                                                new CodeMatch(OpCodes.Ldarg_0)
+                                            ])
+                                            .SetOpcodeAndAdvance(OpCodes.Ldnull)
+                                            .SetOperandAndAdvance(Reflect.Method(() => WrappedCallback(default)))
+                                            .InstructionEnumeration();
+    }
+
+    public static void WrappedCallback(GameObject prefab)
+    {
+        SubConsoleCommand instance = SubConsoleCommand.main;
+        // Call the original callback and then get the object it created to broadcast its creation
+        instance.OnSubPrefabLoaded(prefab);
+        Resolve<NitroxConsole>().Spawn(instance.lastCreatedSub);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubConsoleCommand_OnConsoleCommand_sub_Patch.cs
@@ -3,14 +3,36 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NitroxClient.GameLogic;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Helper;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
+/// <summary>
+/// Prevents local player from using "sub" command without at least the <see cref="Perms.MODERATOR"/> permissions.
+/// Once they have the permissions, sync this command.
+/// </summary>
 public sealed partial class SubConsoleCommand_OnConsoleCommand_sub_Patch : NitroxPatch, IDynamicPatch
 {
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((SubConsoleCommand t) => t.OnConsoleCommand_sub(default));
+
+    public static bool Prefix(NotificationCenter.Notification n)
+    {
+        if (Resolve<LocalPlayer>().Permissions < Perms.MODERATOR)
+        {
+            Log.InGame(Language.main.Get("Nitrox_MissingPermission").Replace("{PERMISSION}", Perms.MODERATOR.ToString()));
+            return false;
+        }
+
+        string text = (string)n.data[0];
+        if (!string.IsNullOrEmpty(text) && !text.ToLowerInvariant().Equals("cyclops"))
+        {
+            Log.InGame(Language.main.Get("Nitrox_CommandNotAvailable"));
+            return false;
+        }
+        return true;
+    }
 
     /*
      * REPLACE:


### PR DESCRIPTION
- [x] Fix "spawn" command (broken since Living Large)
- [x] [new] Sync "sub" command, we can now spawn cyclops with a command
~~- [ ] Maybe:  Move those to command callbacks ("/spawn [VEHICLE TYPE] [OPTIONAL COORDINATES]") with OP requirement~~
- [x] Require the moderator perms at least to use the those commands (only local check for now, but should be switched to the future command system once it's ready)

Adds the translation key: "Nitrox_MissingPermission" to be set like so
"You miss the permissions to execute this command [{PERMISSION}]"