### PR TITLE
AssetParsing improvements

### DIFF
--- a/Nitrox.BuildTool/Nitrox.BuildTool.csproj
+++ b/Nitrox.BuildTool/Nitrox.BuildTool.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mono.Cecil" Version="0.11.4"/>
+        <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\NitroxModel\NitroxModel.csproj"/>
+        <ProjectReference Include="..\NitroxModel\NitroxModel.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Nitrox.Test/Nitrox.Test.csproj
+++ b/Nitrox.Test/Nitrox.Test.csproj
@@ -7,12 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2" />
-        <PackageReference Include="CompareNETObjects" Version="4.78.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+        <PackageReference Include="Bogus" Version="35.5.0" />
+        <PackageReference Include="CompareNETObjects" Version="4.83.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="MSTest" Version="3.2.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="MSTest" Version="3.2.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/Abstract/EntityMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/Abstract/EntityMetadataProcessor.cs
@@ -4,13 +4,13 @@ using UnityEngine;
 
 namespace NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
 
-public abstract class EntityMetadataProcessor<T> : IEntityMetadataProcessor where T : EntityMetadata
+public abstract class EntityMetadataProcessor<TMetadata> : IEntityMetadataProcessor where TMetadata : EntityMetadata
 {
-    public abstract void ProcessMetadata(GameObject gameObject, T metadata);
+    public abstract void ProcessMetadata(GameObject gameObject, TMetadata metadata);
 
     public void ProcessMetadata(GameObject gameObject, EntityMetadata metadata)
     {
-        ProcessMetadata(gameObject, (T)metadata);
+        ProcessMetadata(gameObject, (TMetadata)metadata);
     }
 
     protected T Resolve<T>() where T : class

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="DiscordGameSDKWrapper" Version="3.2.1" />
+      <PackageReference Include="DiscordGameSDKWrapper" Version="3.2.1.1" />
     </ItemGroup>
 
 </Project>

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
       <PackageReference Include="dnlib" Version="3.4.0" />
-      <PackageReference Include="LitJson" Version="0.17.0" />
+      <PackageReference Include="LitJson" Version="0.19.0" />
       <PackageReference Include="ToastNotifications" Version="2.5.1" />
       <PackageReference Include="ToastNotifications.Messages" Version="2.5.1" />
       <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -15,12 +15,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dnlib" Version="3.4.0" />
+      <PackageReference Include="dnlib" Version="4.4.0" />
       <PackageReference Include="LitJson" Version="0.19.0" />
       <PackageReference Include="ToastNotifications" Version="2.5.1" />
       <PackageReference Include="ToastNotifications.Messages" Version="2.5.1" />
       <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
-      <PackageReference Include="WindowsFirewallHelper" Version="2.1.4.81" />
+      <PackageReference Include="WindowsFirewallHelper" Version="2.2.0.86" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
+++ b/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LitJson" Version="0.16.0" />
+    <PackageReference Include="LitJson" Version="0.19.0" />
   </ItemGroup>
 
 </Project>

--- a/NitroxModel/DataStructures/GameLogic/RandomStartGenerator.cs
+++ b/NitroxModel/DataStructures/GameLogic/RandomStartGenerator.cs
@@ -1,67 +1,58 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Drawing;
 using NitroxModel.DataStructures.Unity;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
-namespace NitroxModel.DataStructures.GameLogic
+namespace NitroxModel.DataStructures.GameLogic;
+
+public class RandomStartGenerator(Image<Bgra32> texture)
 {
-    public class RandomStartGenerator
+    public NitroxVector3 GenerateRandomStartPosition(Random rnd)
     {
-        private readonly Bitmap randomStartTexture;
-
-        public RandomStartGenerator(Bitmap randomStartTexture)
+        for (int i = 0; i < 1000; i++)
         {
-            this.randomStartTexture = randomStartTexture;
-        }
+            float normalizedX = (float)rnd.NextDouble();
+            float normalizedZ = (float)rnd.NextDouble();
 
-        public NitroxVector3 GenerateRandomStartPosition(Random rnd)
-        {
-            for (int i = 0; i < 1000; i++)
+            if (IsStartPointValid(normalizedX, normalizedZ))
             {
-                float normalizedX = (float)rnd.NextDouble();
-                float normalizedZ = (float)rnd.NextDouble();
-
-                if (IsStartPointValid(normalizedX, normalizedZ))
-                {
-                    float x = 4096f * normalizedX - 2048f; // normalizedX = (x + 2048) / 4096
-                    float z = 4096f * normalizedZ - 2048f;
-                    return new NitroxVector3(x, 0, z);
-                }
+                float x = 4096f * normalizedX - 2048f; // normalizedX = (x + 2048) / 4096
+                float z = 4096f * normalizedZ - 2048f;
+                return new NitroxVector3(x, 0, z);
             }
-
-            return NitroxVector3.Zero;
         }
 
-        public List<NitroxVector3> GenerateRandomStartPositions(string seed)
+        return NitroxVector3.Zero;
+    }
+
+    public List<NitroxVector3> GenerateRandomStartPositions(string seed)
+    {
+        Random rnd = new(seed.GetHashCode());
+        List<NitroxVector3> list = [];
+
+        for (int i = 0; i < 1000; i++)
         {
+            float normalizedX = (float)rnd.NextDouble();
+            float normalizedZ = (float)rnd.NextDouble();
 
-            Random rnd = new Random(seed.GetHashCode());
-            List<NitroxVector3> list = new List<NitroxVector3>();
-
-            for (int i = 0; i < 1000; i++)
+            if (IsStartPointValid(normalizedX, normalizedZ))
             {
-                float normalizedX = (float)rnd.NextDouble();
-                float normalizedZ = (float)rnd.NextDouble();
-
-                if (IsStartPointValid(normalizedX, normalizedZ))
-                {
-                    float x = 4096f * normalizedX - 2048f; // normalizedX = (x + 2048) / 4096
-                    float z = 4096f * normalizedZ - 2048f;
-                    list.Add(new NitroxVector3(x, 0, z));
-                }
+                float x = 4096f * normalizedX - 2048f; // normalizedX = (x + 2048) / 4096
+                float z = 4096f * normalizedZ - 2048f;
+                list.Add(new NitroxVector3(x, 0, z));
             }
-
-            return list;
         }
 
-        private bool IsStartPointValid(float normalizedX, float normalizedZ)
-        {
-            int textureX = (int)(normalizedX * (float)512);
-            int textureZ = (int)(normalizedZ * (float)512);
+        return list;
+    }
 
-            Color pixelColor = randomStartTexture.GetPixel(textureX, textureZ);
+    private bool IsStartPointValid(float normalizedX, float normalizedZ)
+    {
+        int textureX = (int)(normalizedX * (float)512);
+        int textureZ = (int)(normalizedZ * (float)512);
+        Bgra32 pixel = texture[textureX, textureZ];
 
-            return pixelColor.G > 127;
-        }
+        return pixel.G > 127;
     }
 }

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -15,8 +15,8 @@
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
-        <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -9,13 +9,13 @@
         <PackageReference Include="Autofac" Version="4.9.4" />
         <PackageReference Include="LiteNetLib" Version="1.2.0" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-        <PackageReference Include="Mono.Nat" Version="3.0.2" />
+        <PackageReference Include="Mono.Nat" Version="3.0.4" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="Nitrox.BinaryPack" Version="2.0.1" />
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="AssetsTools.NET" Version="3.0.0" />
         <PackageReference Include="AssetsTools.NET.MonoCecil" Version="1.0.0" />
         <PackageReference Include="AssetsTools.NET.Texture" Version="1.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
         <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     </ItemGroup>
 

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
@@ -14,7 +14,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AssetsTools.NET" Version="3.0.0-preview1" />
+        <PackageReference Include="AssetsTools.NET" Version="3.0.0" />
+        <PackageReference Include="AssetsTools.NET.MonoCecil" Version="1.0.0" />
+        <PackageReference Include="AssetsTools.NET.Texture" Version="1.0.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -1,4 +1,4 @@
-﻿global using NitroxModel.Logger;
+global using NitroxModel.Logger;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/NitroxServer-Subnautica/Resources/Parsers/Abstract/BundleFileParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Abstract/BundleFileParser.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 
@@ -6,17 +6,25 @@ namespace NitroxServer_Subnautica.Resources.Parsers.Abstract;
 
 public abstract class BundleFileParser<T> : AssetParser
 {
-    protected static AssetsFileInstance assetFileInst;
-    protected static AssetsFile bundleFile;
+    protected BundleFileInstance bundleFileInstance;
+    protected AssetsFileInstance assetFileInst;
+    protected AssetsFile bundleFile;
 
-    protected BundleFileParser(string bundleName, int index)
+    protected BundleFileParser(string bundleName, int index) : base()
     {
-        string bundlePath = Path.Combine(ResourceAssetsParser.FindDirectoryContainingResourceAssets(), "StreamingAssets", "aa", "StandaloneWindows64", bundleName);
+        string bundlePath = Path.Combine(rootPath, "StreamingAssets", "aa", "StandaloneWindows64", bundleName);
         BundleFileInstance bundleFileInst = assetsManager.LoadBundleFile(bundlePath);
-        assetFileInst = assetsManager.LoadAssetsFileFromBundle(bundleFileInst, index, true);
+        assetFileInst = assetsManager.LoadAssetsFileFromBundle(bundleFileInst, index, loadDeps: true);
         bundleFile = assetFileInst.file;
     }
 
-    public abstract T ParseFile();
+    protected override void Clear()
+    {
+        assetsManager.UnloadBundleFile(bundleFileInstance);
+        bundleFileInstance = null;
+        assetFileInst = null;
+        bundleFile = null;
+    }
 
+    public abstract T ParseFile();
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/Abstract/ResourceFileParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Abstract/ResourceFileParser.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 
@@ -6,13 +6,21 @@ namespace NitroxServer_Subnautica.Resources.Parsers.Abstract;
 
 public abstract class ResourceFileParser<T> : AssetParser
 {
-    protected static readonly AssetsFileInstance resourceInst;
-    protected static readonly AssetsFile resourceFile;
+    protected AssetsFileInstance resourceInst;
+    protected AssetsFile resourceFile;
 
-    static ResourceFileParser()
+    protected ResourceFileParser()
     {
         resourceInst = assetsManager.LoadAssetsFile(Path.Combine(rootPath, "resources.assets"), true);
         resourceFile = resourceInst.file;
     }
+    
+    protected override void Clear()
+    {
+        assetsManager.UnloadAssetsFile(resourceInst);
+        resourceInst = null;
+        resourceFile = null;
+    }
+
     public abstract T ParseFile();
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/EntityDistributionsParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/EntityDistributionsParser.cs
@@ -1,4 +1,4 @@
-﻿using AssetsTools.NET;
+using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using NitroxServer_Subnautica.Resources.Parsers.Abstract;
 using NitroxServer_Subnautica.Resources.Parsers.Helper;
@@ -12,8 +12,7 @@ public class EntityDistributionsParser : ResourceFileParser<string>
         AssetFileInfo assetFileInfo = resourceFile.GetAssetInfo(assetsManager, "EntityDistributions", AssetClassID.TextAsset);
         AssetTypeValueField assetValue = assetsManager.GetBaseField(resourceInst, assetFileInfo);
         string json = assetValue["m_Script"].AsString;
-        
-        assetsManager.UnloadAll();
+
         return json;
     }
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsFileMetadataExtension.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsFileMetadataExtension.cs
@@ -9,7 +9,7 @@ public static class AssetsFileMetadataExtension
     {
         foreach (AssetFileInfo assetInfo in assetsFile.GetAssetsOfType(classID))
         {
-            if (AssetHelper.GetAssetNameFast(assetsFile, assetsManager.classDatabase, assetInfo).Equals(assetName))
+            if (AssetHelper.GetAssetNameFast(assetsFile, assetsManager.ClassDatabase, assetInfo).Equals(assetName))
             {
                 return assetInfo;
             }

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/ThreadSafeMonoCecilTempGenerator.cs
@@ -1,27 +1,21 @@
 using System;
-using System.Collections.Generic;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
-using Mono.Cecil;
 
 namespace NitroxServer_Subnautica.Resources.Parsers.Helper;
 
-public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator, IDisposable
+public class ThreadSafeMonoCecilTempGenerator(string managedPath) : IMonoBehaviourTemplateGenerator, IDisposable
 {
-    private readonly MonoCecilTempGenerator generator;
+    private readonly MonoCecilTempGenerator generator = new(managedPath);
     private readonly object locker = new();
-
-    public ThreadSafeMonoCecilTempGenerator(string managedPath)
-    {
-        generator = new MonoCecilTempGenerator(managedPath);
-    }
 
     public AssetTypeTemplateField GetTemplateField(
         AssetTypeTemplateField baseField,
         string assemblyName,
         string nameSpace,
         string className,
-        UnityVersion unityVersion)
+        UnityVersion unityVersion
+    )
     {
         lock (locker)
         {
@@ -29,12 +23,5 @@ public class ThreadSafeMonoCecilTempGenerator : IMonoBehaviourTemplateGenerator,
         }
     }
 
-    public void Dispose()
-    {
-        foreach (KeyValuePair<string, AssemblyDefinition> pair in generator.loadedAssemblies)
-        {
-            pair.Value.Dispose();
-        }
-        generator.loadedAssemblies.Clear();
-    }
+    public void Dispose() => generator?.Dispose();
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/RandomStartParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/RandomStartParser.cs
@@ -1,11 +1,12 @@
-﻿using System.Drawing;
-using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
+using AssetsTools.NET.Texture;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer_Subnautica.Resources.Parsers.Abstract;
 using NitroxServer_Subnautica.Resources.Parsers.Helper;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 namespace NitroxServer_Subnautica.Resources.Parsers;
 
@@ -17,20 +18,18 @@ public class RandomStartParser : BundleFileParser<RandomStartGenerator>
     {
         AssetFileInfo assetFile = bundleFile.GetAssetInfo(assetsManager, "RandomStart", AssetClassID.Texture2D);
         AssetTypeValueField textureValueField = assetsManager.GetBaseField(assetFileInst, assetFile);
+
         TextureFile textureFile = TextureFile.ReadTextureFile(textureValueField);
         byte[] texDat = textureFile.GetTextureData(assetFileInst);
-        assetsManager.UnloadAll();
 
-        if (texDat == null || texDat.Length <= 0)
+        if (texDat is not { Length: > 0 })
         {
             return null;
         }
-        
-        Bitmap texture = new(textureFile.m_Width, textureFile.m_Height, textureFile.m_Width * 4, PixelFormat.Format32bppArgb,
-                             Marshal.UnsafeAddrOfPinnedArrayElement(texDat, 0));
-        texture.RotateFlip(RotateFlipType.RotateNoneFlipY);
 
-        return new RandomStartGenerator(texture);
+        Image<Bgra32> image = Image.LoadPixelData<Bgra32>(texDat, textureFile.m_Width, textureFile.m_Height);
+        image.Mutate(x => x.Flip(FlipMode.Vertical));
 
+        return new RandomStartGenerator(image);
     }
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/WorldEntityInfoParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/WorldEntityInfoParser.cs
@@ -11,12 +11,14 @@ public class WorldEntityInfoParser : ResourceFileParser<Dictionary<string, World
 {
     public override Dictionary<string, WorldEntityInfo> ParseFile()
     {
-        Dictionary<string, WorldEntityInfo> worldEntitiesByClassId = new();
+        Dictionary<string, WorldEntityInfo> worldEntitiesByClassId = [];
 
         AssetFileInfo assetFileInfo = resourceFile.GetAssetInfo(assetsManager, "WorldEntityData", AssetClassID.MonoBehaviour);
         AssetTypeValueField assetValue = assetsManager.GetBaseField(resourceInst, assetFileInfo);
 
-        foreach (AssetTypeValueField info in assetValue["infos"])
+        AssetTypeValueField worldEntityArray = assetValue["infos"]["Array"];
+
+        foreach (AssetTypeValueField info in worldEntityArray)
         {
             WorldEntityInfo entityData = new()
             {
@@ -31,7 +33,6 @@ public class WorldEntityInfoParser : ResourceFileParser<Dictionary<string, World
             worldEntitiesByClassId.Add(entityData.classId, entityData);
         }
 
-        assetsManager.UnloadAll();
         return worldEntitiesByClassId;
     }
 }

--- a/NitroxServer-Subnautica/Resources/ResourceAssets.cs
+++ b/NitroxServer-Subnautica/Resources/ResourceAssets.cs
@@ -4,22 +4,24 @@ using NitroxModel.Helper;
 using NitroxServer.Resources;
 using UWE;
 
-namespace NitroxServer_Subnautica.Resources
-{
-    public class ResourceAssets
-    {
-        public Dictionary<string, WorldEntityInfo> WorldEntitiesByClassId { get; init; } = new();
-        public string LootDistributionsJson { get; init; } = "";
-        public Dictionary<string, PrefabPlaceholdersGroupAsset> PrefabPlaceholdersGroupsByGroupClassId { get; init; } = new();
-        public RandomStartGenerator NitroxRandom { get; init; }
+namespace NitroxServer_Subnautica.Resources;
 
-        public static void ValidateMembers(ResourceAssets resourceAssets)
-        {
-            Validate.NotNull(resourceAssets);
-            Validate.IsTrue(resourceAssets.WorldEntitiesByClassId.Count > 0);
-            Validate.IsTrue(resourceAssets.LootDistributionsJson != "");
-            Validate.IsTrue(resourceAssets.PrefabPlaceholdersGroupsByGroupClassId.Count > 0);
-            Validate.NotNull(resourceAssets.NitroxRandom);
-        }
+public sealed class ResourceAssets
+{
+    public Dictionary<string, WorldEntityInfo> WorldEntitiesByClassId { get; init; } = [];
+
+    public string LootDistributionsJson { get; init; } = "";
+
+    public Dictionary<string, PrefabPlaceholdersGroupAsset> PrefabPlaceholdersGroupsByGroupClassId { get; init; } = [];
+
+    public RandomStartGenerator NitroxRandom { get; init; }
+
+    public static void ValidateMembers(ResourceAssets resourceAssets)
+    {
+        Validate.NotNull(resourceAssets);
+        Validate.IsTrue(resourceAssets.WorldEntitiesByClassId.Count > 1);
+        Validate.IsTrue(resourceAssets.LootDistributionsJson != string.Empty);
+        Validate.IsTrue(resourceAssets.PrefabPlaceholdersGroupsByGroupClassId.Count > 1);
+        Validate.NotNull(resourceAssets.NitroxRandom);
     }
 }

--- a/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
+++ b/NitroxServer-Subnautica/SubnauticaServerAutoFacRegistrar.cs
@@ -1,11 +1,8 @@
-using System.Collections.Generic;
 using Autofac;
 using NitroxModel;
-using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Helper;
-using NitroxModel_Subnautica.DataStructures;
 using NitroxModel_Subnautica.DataStructures.GameLogic.Entities;
 using NitroxModel_Subnautica.Helper;
 using NitroxServer;
@@ -16,7 +13,6 @@ using NitroxServer.Serialization;
 using NitroxServer_Subnautica.GameLogic;
 using NitroxServer_Subnautica.GameLogic.Entities;
 using NitroxServer_Subnautica.GameLogic.Entities.Spawning;
-using NitroxServer_Subnautica.GameLogic.Entities.Spawning.EntityBootstrappers;
 using NitroxServer_Subnautica.Resources;
 using NitroxServer_Subnautica.Serialization;
 
@@ -52,7 +48,7 @@ namespace NitroxServer_Subnautica
             containerBuilder.Register(c => resourceAssets.NitroxRandom).SingleInstance();
             containerBuilder.RegisterType<SubnauticaUweWorldEntityFactory>().As<IUweWorldEntityFactory>().SingleInstance();
 
-            SubnauticaUwePrefabFactory prefabFactory = new SubnauticaUwePrefabFactory(resourceAssets.LootDistributionsJson);
+            SubnauticaUwePrefabFactory prefabFactory = new(resourceAssets.LootDistributionsJson);
             containerBuilder.Register(c => prefabFactory).As<IUwePrefabFactory>().SingleInstance();
             containerBuilder.RegisterType<SubnauticaEntityBootstrapperManager>()
                             .As<IEntityBootstrapperManager>()

--- a/NitroxServer/ConsoleCommands/DebugStartMapCommand.cs
+++ b/NitroxServer/ConsoleCommands/DebugStartMapCommand.cs
@@ -1,4 +1,4 @@
-﻿#if DEBUG
+#if DEBUG
 using System.Collections.Generic;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Unity;
@@ -7,31 +7,28 @@ using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.GameLogic;
 using NitroxServer.Serialization.World;
 
-namespace NitroxServer.ConsoleCommands
+namespace NitroxServer.ConsoleCommands;
+
+internal sealed class DebugStartMapCommand : Command
 {
+    private readonly RandomStartGenerator nitroxRandomStart;
+    private readonly PlayerManager playerManager;
+    private readonly World world;
 
-    internal class DebugStartMapCommand : Command
+    public DebugStartMapCommand(PlayerManager playerManager, RandomStartGenerator nitroxRandomStart, World world) :
+        base("debugstartmap", Perms.ADMIN, "Spawns blocks at spawn positions")
     {
-        private readonly RandomStartGenerator nitroxRandomStart;
-        private readonly PlayerManager playerManager;
-        private readonly World world;
-
-        public DebugStartMapCommand(PlayerManager playerManager, RandomStartGenerator nitroxRandomStart, World world) :
-            base("debugstartmap", Perms.ADMIN, "Spawns blocks at spawn positions")
-        {
-            this.playerManager = playerManager;
-            this.nitroxRandomStart = nitroxRandomStart;
-            this.world = world;
-        }
-
-        protected override void Execute(CallArgs args)
-        {
-            List<NitroxVector3> randomStartPositions = nitroxRandomStart.GenerateRandomStartPositions(world.Seed);
-
-            playerManager.SendPacketToAllPlayers(new DebugStartMapPacket(randomStartPositions));
-            SendMessage(args.Sender, $"Rendered {randomStartPositions.Count} spawn positions");
-        }
+        this.playerManager = playerManager;
+        this.nitroxRandomStart = nitroxRandomStart;
+        this.world = world;
     }
 
+    protected override void Execute(CallArgs args)
+    {
+        List<NitroxVector3> randomStartPositions = nitroxRandomStart.GenerateRandomStartPositions(world.Seed);
+
+        playerManager.SendPacketToAllPlayers(new DebugStartMapPacket(randomStartPositions));
+        SendMessage(args.Sender, $"Rendered {randomStartPositions.Count} spawn positions");
+    }
 }
 #endif


### PR DESCRIPTION
The original idea was to understand why the server loading could seem infinite when I try to start a server, I had assumed the possibility of race condition since we're using parallelism at some point but in this current state it was quite complicated to determine given the current implementation which has a rather confusing control flow. 
So I took the opportunity to try to clean this up while trying both investigate issues & upgrade to the latest version of AssetTools

Progress : 
* [x] Bump to latest version of AssetTools
* [x] Refactor asset parsers to avoid using static constructors in favor to Disposable parsers, since Nitrox is using them for a one shot load 
* [x] Drop `System.Drawing` reference in favor of `ImageSharp` which is cross-platform for RandomSpawnTexture reading
* [ ] Improve UX by adding more informations about what's going behind the scene (especially when game is on a slow external disk, it can takes several minutes to load)
* [ ] Fix loading errors happening with the refactor
