### PR TITLE
Automatic entity resync

### DIFF
--- a/Nitrox.Test/Patcher/Patches/Dynamic/Inventory_LoseItems_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/Inventory_LoseItems_PatchTest.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 using HarmonyLib;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NitroxPatcher.PatternMatching;
 using NitroxTest.Patcher;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -12,19 +10,9 @@ public class Inventory_LoseItems_PatchTest
     [TestMethod]
     public void Sanity()
     {
-        List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
-        instructions.Add(new CodeInstruction(Inventory_LoseItems_Patch.INJECTION_OPCODE, Inventory_LoseItems_Patch.INJECTION_OPERAND));
-
-        IEnumerable<CodeInstruction> result = Inventory_LoseItems_Patch.Transpiler(null, instructions);
-        Assert.AreEqual(instructions.Count, result.Count());
-    }
-
-    [TestMethod]
-    public void InjectionSanity()
-    {
-        IEnumerable<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(Inventory_LoseItems_Patch.TARGET_METHOD);
-        IEnumerable<CodeInstruction> result = Inventory_LoseItems_Patch.Transpiler(Inventory_LoseItems_Patch.TARGET_METHOD, beforeInstructions);
-
-        Assert.IsTrue(beforeInstructions.Count() > result.Count());
+        IEnumerable<CodeInstruction> originalIl = PatchTestHelper.GetInstructionsFromMethod(Inventory_LoseItems_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> transformedIl = Inventory_LoseItems_Patch.Transpiler(originalIl);
+        Console.WriteLine(transformedIl.ToPrettyString());
+        transformedIl.Count().Should().Be(originalIl.Count() + 5);
     }
 }

--- a/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
@@ -34,10 +34,17 @@ public class LiteNetLibClient : IClient
         client = new NetManager(listener)
         {
             UpdateTime = 15,
+            EnableStatistics = true,
+            DisconnectOnUnreachable = true,
 #if DEBUG
             DisconnectTimeout = 300000 //Disables Timeout (for 5 min) for debug purpose (like if you jump though the server code)
 #endif
         };
+    }
+
+    public NetStatistics GetStatistics()
+    {
+        return client.Statistics;
     }
 
     public async Task StartAsync(string ipAddress, int serverPort)

--- a/NitroxClient/Communication/Packets/Processors/EntityReparentedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/EntityReparentedProcessor.cs
@@ -29,6 +29,7 @@ public class EntityReparentedProcessor : ClientPacketProcessor<EntityReparented>
             // In some cases, the affected entity may be pending spawning or out of range.
             // we only require the parent (in this case, the visible entity is undergoing
             // some change that must be shown, and if not is an error).
+            entities.RequireResync(packet.Id);
             return;
         }
 

--- a/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -14,10 +14,12 @@ public class PlayerHeldItemChangedProcessor : ClientPacketProcessor<PlayerHeldIt
     private int defaultLayer;
     private int viewModelLayer;
     private readonly PlayerManager playerManager;
+    private readonly Entities entities;
 
-    public PlayerHeldItemChangedProcessor(PlayerManager playerManager)
+    public PlayerHeldItemChangedProcessor(PlayerManager playerManager, Entities entities)
     {
         this.playerManager = playerManager;
+        this.entities = entities;
 
         if (NitroxEnvironment.IsNormal)
         {
@@ -38,6 +40,7 @@ public class PlayerHeldItemChangedProcessor : ClientPacketProcessor<PlayerHeldIt
 
         if (!NitroxEntity.TryGetObjectFrom(packet.ItemId, out GameObject item))
         {
+            entities.RequireResync(packet.ItemId);
             return; // Item can be not spawned yet bc async.
         }
 

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NitroxClient.Communication;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
+using NitroxClient.GameLogic.Settings;
 using NitroxClient.GameLogic.Spawning;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.Bases;
@@ -24,7 +25,7 @@ using UWE;
 
 namespace NitroxClient.GameLogic
 {
-    public class Entities
+    public partial class Entities
     {
         private readonly IPacketSender packetSender;
         private readonly ThrottledPacketSender throttledPacketSender;
@@ -133,6 +134,7 @@ namespace NitroxClient.GameLogic
             {
                 entityMetadataManager.ClearNewerMetadata();
                 deletedEntitiesIds.Clear();
+                RequestEntityResyncs();
             }
         }
 
@@ -320,6 +322,7 @@ namespace NitroxClient.GameLogic
         public void MarkAsSpawned(Entity entity)
         {
             spawnedAsType[entity.Id] = entity.GetType();
+            requiredEntityResyncs.Remove(entity.Id);
         }
 
         public void RemoveEntity(NitroxId id) => spawnedAsType.Remove(id);

--- a/NitroxClient/GameLogic/EntityResyncer.cs
+++ b/NitroxClient/GameLogic/EntityResyncer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using NitroxClient.GameLogic.Settings;
+using NitroxModel.DataStructures;
+using NitroxModel.Packets;
+
+namespace NitroxClient.GameLogic;
+
+public partial class Entities
+{
+    private readonly HashSet<NitroxId> requiredEntityResyncs = [];
+
+    public int Requests;
+
+    public void RequireResync(NitroxId nitroxId)
+    {
+        if (NitroxPrefs.EntitiesAutoResync.Value)
+        {
+            requiredEntityResyncs.Add(nitroxId);
+            RequestEntityResyncs();
+        }
+    }
+
+    public void RequestEntityResyncs()
+    {
+        if (spawningEntities || !NitroxPrefs.EntitiesAutoResync.Value || requiredEntityResyncs.Count == 0)
+        {
+            return;
+        }
+        Requests += requiredEntityResyncs.Count;
+        packetSender.Send(new EntityResyncRequest([.. requiredEntityResyncs]));
+        requiredEntityResyncs.Clear();
+    }
+}

--- a/NitroxClient/GameLogic/Settings/NitroxPrefs.cs
+++ b/NitroxClient/GameLogic/Settings/NitroxPrefs.cs
@@ -11,6 +11,7 @@ namespace NitroxClient.GameLogic.Settings
         public static readonly NitroxPref<bool> ChatUsed = new("Nitrox.chatUsed");
         public static readonly NitroxPref<bool> SafeBuilding = new("Nitrox.safeBuilding", true);
         public static readonly NitroxPref<bool> SafeBuildingLog = new("Nitrox.safeBuildingLog", true);
+        public static readonly NitroxPref<bool> EntitiesAutoResync = new("Nitrox.entitiesAutoResync", true);
     }
 
     public abstract class NitroxPref { }

--- a/NitroxClient/GameLogic/Settings/NitroxSettingsManager.cs
+++ b/NitroxClient/GameLogic/Settings/NitroxSettingsManager.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
 using NitroxClient.GameLogic.Bases;
+using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.Gui.MainMenu;
+using NitroxModel.Core;
 using UnityEngine.Events;
 
 namespace NitroxClient.GameLogic.Settings;
 
 public class NitroxSettingsManager
 {
+    private readonly Lazy<Vehicles> vehicles = new(NitroxServiceLocator.LocateService<Vehicles>);
     /// <summary>
     /// Settings grouped by their headings
     /// </summary>
@@ -48,6 +51,17 @@ public class NitroxSettingsManager
                 BuildingHandler.Main.AskForResync();
             }
         }));
+
+        AddSetting("Nitrox_ResyncSettings", new Setting("Nitrox_ResyncVehicles", () =>
+        {
+            if (Multiplayer.Main && Multiplayer.Main.InitialSyncCompleted)
+            {
+                vehicles.Value.AskForResync();
+            }
+        }));
+
+        AddSetting("Nitrox_ResyncSettings", new Setting("Nitrox_EntitiesAutoResync", NitroxPrefs.EntitiesAutoResync, autoResync => NitroxPrefs.EntitiesAutoResync.Value = autoResync));
+        
 
         AddSetting("Nitrox_BuildingSettings", new Setting("Nitrox_SafeBuilding", NitroxPrefs.SafeBuilding, safe => NitroxPrefs.SafeBuilding.Value = safe));
         AddSetting("Nitrox_BuildingSettings", new Setting("Nitrox_SafeBuildingLog", NitroxPrefs.SafeBuildingLog, safeLog => NitroxPrefs.SafeBuildingLog.Value = safeLog));

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
@@ -1,7 +1,9 @@
 using System.Collections;
+using System.Linq;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.CinematicController;
 using NitroxClient.Unity.Helper;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.GameLogic.Entities;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
@@ -46,7 +48,9 @@ public class VehicleWorldEntitySpawner : IWorldEntitySpawner
             }
         }
 
-        yield return SpawnInWorld(vehicleEntity, result, parent);            
+        yield return SpawnInWorld(vehicleEntity, result, parent);
+
+        yield return entities.SpawnBatchAsync(entity.ChildEntities);
     }
 
     private IEnumerator SpawnInWorld(VehicleWorldEntity vehicleEntity, TaskResult<Optional<GameObject>> result, Optional<GameObject> parent)
@@ -192,7 +196,7 @@ public class VehicleWorldEntitySpawner : IWorldEntitySpawner
 
     public bool SpawnsOwnChildren()
     {
-        return false;
+        return true;
     }
     
     private float GetCraftDuration(TechType techType)

--- a/NitroxModel/Packets/EntityResyncRequest.cs
+++ b/NitroxModel/Packets/EntityResyncRequest.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using NitroxModel.DataStructures;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public sealed class EntityResyncRequest : Packet
+{
+    public List<NitroxId> RequestedIds { get; }
+
+    public EntityResyncRequest(List<NitroxId> requestedIds)
+    {
+        RequestedIds = requestedIds;
+    }
+}

--- a/NitroxModel/Packets/VehiclesResyncRequest.cs
+++ b/NitroxModel/Packets/VehiclesResyncRequest.cs
@@ -1,0 +1,17 @@
+using System;
+using NitroxModel.DataStructures;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public sealed class VehiclesResyncRequest : Packet
+{
+    public NitroxId EntityId { get; }
+    public bool ResyncEverything { get; }
+
+    public VehiclesResyncRequest(NitroxId entityId = null, bool resyncEverything = true)
+    {
+        EntityId = entityId;
+        ResyncEverything = resyncEverything;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/FPSCounter_UpdateDisplay_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FPSCounter_UpdateDisplay_Patch.cs
@@ -1,5 +1,8 @@
 #if DEBUG
 using System.Reflection;
+using LiteNetLib;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.NetworkingLayer.LiteNetLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.Helper;
@@ -10,6 +13,8 @@ public sealed partial class FPSCounter_UpdateDisplay_Patch : NitroxPatch, IDynam
 {
     public static readonly MethodInfo TARGET_METHOD = Reflect.Method((FPSCounter t) => t.UpdateDisplay());
 
+    private static LiteNetLibClient client => Resolve<IClient>() as LiteNetLibClient;
+
     public static void Postfix(FPSCounter __instance)
     {
         if (!Multiplayer.Active)
@@ -18,6 +23,12 @@ public sealed partial class FPSCounter_UpdateDisplay_Patch : NitroxPatch, IDynam
         }
         __instance.strBuffer.Append("Loading entities: ").AppendLine(Resolve<Entities>().EntitiesToSpawn.Count.ToString());
         __instance.strBuffer.Append("Real time elapsed: ").AppendLine(Resolve<TimeManager>().RealTimeElapsed.ToString());
+        __instance.strBuffer.Append("Requested entity resyncs: ").AppendLine(Resolve<Entities>().Requests.ToString());
+        if (client.IsConnected)
+        {
+            NetStatistics stats = client.GetStatistics();
+            __instance.strBuffer.Append("Packet Loss: ").AppendLine($"{stats.PacketLoss} [{stats.PacketLossPercent}%]");
+        }
         __instance.text.SetText(__instance.strBuffer);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
+using NitroxClient.GameLogic;
 using NitroxModel.Helper;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -10,55 +12,37 @@ public sealed partial class Inventory_LoseItems_Patch : NitroxPatch, IDynamicPat
 {
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((Inventory t) => t.LoseItems());
 
-    internal static readonly OpCode INJECTION_OPCODE = OpCodes.Call;
-    internal static readonly object INJECTION_OPERAND = Reflect.Method((Inventory t) => t.InternalDropItem(default, default));
-
-    public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+    /*
+     * if (this.InternalDropItem(list[i].item, false))
+     * {
+     *     BroadcastItemDropped(list[i].item);      <--------- [INSERTED LINE]
+     *     flag = true;
+     * }
+     */
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        List<CodeInstruction> codeInstructions = new(instructions);
-        for (int i = 0; i < codeInstructions.Count; i++)
-        {
-            CodeInstruction instruction = codeInstructions[i];
-            /* if (this.InternalDropItem(list[i].item, false))
-             * becomes:
-             * if (Inventory_LoseItems_Patch.DropAndDeleteItem(list[i].item))
-             */
-
-            // Clear some useless lines
-            if (instruction.opcode.Equals(OpCodes.Ldarg_0) &&
-                codeInstructions[i + 1].opcode.Equals(OpCodes.Ldloc_0) &&
-                codeInstructions[i - 1].opcode.Equals(OpCodes.Br))
-            {
-                // We still need to transfer these labels to the following instruction
-                codeInstructions[i + 1].labels.AddRange(instruction.labels);
-                continue;
-            }
-            if (instruction.opcode.Equals(OpCodes.Ldc_I4_0) &&
-                codeInstructions[i + 1].opcode.Equals(OpCodes.Call) &&
-                codeInstructions[i - 1].opcode.Equals(OpCodes.Callvirt))
-            {
-                continue;
-            }
-
-            // And modify the call instruction
-            if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))
-            {
-                instruction.operand = Reflect.Method(() => DropAndDeleteItem(default));
-            }
-            yield return instruction;
-        }
+        return new CodeMatcher(instructions).MatchEndForward([
+                                                new CodeMatch(OpCodes.Call, Reflect.Method((Inventory t) => t.InternalDropItem(default, default))),
+                                                new CodeMatch(OpCodes.Brfalse),
+                                                new CodeMatch(OpCodes.Ldc_I4_1),
+                                                new CodeMatch(OpCodes.Stloc_1),
+                                            ])
+                                            .Advance(1)
+                                            .InsertAndAdvance([
+                                                new CodeInstruction(OpCodes.Ldloc_0), // Get "list" reference
+                                                TARGET_METHOD.Ldloc<int>(), // Get "i" reference
+                                                new CodeInstruction(OpCodes.Callvirt, Reflect.Method((List<InventoryItem> t) => t[default])), // Get item at index "i" from "list"
+                                                new CodeInstruction(OpCodes.Callvirt, Reflect.Property((InventoryItem t) => t.item).GetGetMethod()), // Get reference from InventoryItem.item
+                                                new CodeInstruction(OpCodes.Callvirt, Reflect.Method(() => BroadcastItemDropped(default)))
+                                            ])
+                                            .InstructionEnumeration();
     }
 
-    public static bool DropAndDeleteItem(Pickupable pickupable)
+    public static void BroadcastItemDropped(Pickupable pickupable)
     {
-        if (Inventory.CanDropItemHere(pickupable, false))
-        {
-            // Here limit the part that spreads the stuff around by deactivating the rigidbody (for when we drop them)
-            pickupable.Drop(pickupable.transform.position, default, false);
-            // And we destroy the item to make sure that it won't stay after the zone unloads
-            UnityEngine.Object.Destroy(pickupable.gameObject);
-            return true;
-        }
-        return false;
+        Rigidbody rigidbody = pickupable.GetComponent<Rigidbody>();
+        rigidbody.velocity = Vector3.zero;
+        rigidbody.angularVelocity = Vector3.zero;
+        Resolve<Items>().Dropped(pickupable.gameObject);
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/EntityResyncRequestProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/EntityResyncRequestProcessor.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using NitroxServer.GameLogic.Entities;
+
+namespace NitroxServer.Communication.Packets.Processors;
+
+public class EntityResyncRequestProcessor : AuthenticatedPacketProcessor<EntityResyncRequest>
+{
+    private readonly EntityRegistry entityRegistry;
+
+    public EntityResyncRequestProcessor(EntityRegistry entityRegistry)
+    {
+        this.entityRegistry = entityRegistry;
+    }
+
+    public override void Process(EntityResyncRequest packet, Player player)
+    {
+        if (packet.RequestedIds.Count == 0)
+        {
+            return;
+        }
+
+        List<Entity> entitiesToSend = [];
+        foreach (NitroxId requestedId in packet.RequestedIds)
+        {
+            if (entityRegistry.TryGetEntityById(requestedId, out Entity entity))
+            {
+                entitiesToSend.Add(entity);
+            }
+        }
+
+        if (entitiesToSend.Count > 0)
+        {
+            Log.Debug($"Sending {entitiesToSend.Count} missing entities to {player.Name}: [{string.Join(", ", entitiesToSend.Select(e => e.Id))}]");
+            player.SendPacket(new SpawnEntities(entitiesToSend, true));
+        }
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/VehiclesResyncRequestProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/VehiclesResyncRequestProcessor.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic.Entities;
+using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using NitroxServer.GameLogic.Entities;
+
+namespace NitroxServer.Communication.Packets.Processors;
+
+public class VehiclesResyncRequestProcessor : AuthenticatedPacketProcessor<VehiclesResyncRequest>
+{
+    private readonly EntityRegistry entityRegistry;
+    private readonly WorldEntityManager worldEntityManager;
+
+    public VehiclesResyncRequestProcessor(EntityRegistry entityRegistry, WorldEntityManager worldEntityManager)
+    {
+        this.entityRegistry = entityRegistry;
+        this.worldEntityManager = worldEntityManager;
+    }
+
+    public override void Process(VehiclesResyncRequest packet, Player player)
+    {
+        List<Entity> entitiesToSend = [];
+
+        if (packet.ResyncEverything)
+        {
+            entitiesToSend.AddRange(worldEntityManager.GetGlobalRootEntities<VehicleWorldEntity>(true));
+        }
+        else if (packet.EntityId != null && entityRegistry.TryGetEntityById(packet.EntityId, out Entity entity))
+        {
+            entitiesToSend.Add(entity);
+        }
+
+        if (entitiesToSend.Count > 0)
+        {
+            Log.Debug($"sending {entitiesToSend.Count} entities");
+            player.SendPacket(new SpawnEntities(entitiesToSend, true));
+        }
+    }
+}

--- a/NitroxServer/GameLogic/Entities/EntitySimulation.cs
+++ b/NitroxServer/GameLogic/Entities/EntitySimulation.cs
@@ -73,13 +73,13 @@ public class EntitySimulation
 
     public SimulatedEntity AssignNewEntityToPlayer(Entity entity, Player player, bool shouldEntityMove = true)
     {
+        bool doesEntityMove = shouldEntityMove && entity is WorldEntity worldEntity && ShouldSimulateEntityMovement(worldEntity);
         if (simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
         {
-            bool doesEntityMove = shouldEntityMove && entity is WorldEntity worldEntity && ShouldSimulateEntityMovement(worldEntity);
             return new SimulatedEntity(entity.Id, player.Id, doesEntityMove, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
         }
-
-        throw new Exception($"New entity was already being simulated by someone else: {entity.Id}");
+        Log.Error($"New entity was already being simulated by someone else: {entity.Id}");
+        return new(entity.Id, simulationOwnershipData.GetPlayerForLock(entity.Id).Id, doesEntityMove, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
     }
 
     public List<SimulatedEntity> AssignGlobalRootEntitiesAndGetData(Player player)

--- a/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
@@ -52,18 +52,19 @@ public class WorldEntityManager
 
     public List<GlobalRootEntity> GetGlobalRootEntities(bool rootOnly = false)
     {
-        if (rootOnly)
-        {
-            return GetGlobalRootEntities<GlobalRootEntity>().Where(entity => entity.ParentId == null).ToList();
-        }
-        return GetGlobalRootEntities<GlobalRootEntity>();
+        return GetGlobalRootEntities<GlobalRootEntity>(rootOnly);
     }
 
-    public List<T> GetGlobalRootEntities<T>() where T : GlobalRootEntity
+    public List<T> GetGlobalRootEntities<T>(bool rootOnly = false) where T : GlobalRootEntity
     {
         lock (globalRootEntitiesLock)
         {
-            return new(globalRootEntitiesById.Values.OfType<T>());
+            IEnumerable<T> entities = globalRootEntitiesById.Values.OfType<T>();
+            if (rootOnly)
+            {
+                return entities.Where(entity => entity.ParentId == null).ToList();
+            }
+            return entities.ToList();
         }
     }
 


### PR DESCRIPTION
- [x] Automatically request an entity resync when they were missing in a ReparentProcessor or in PlayerHeldItemChanged (client-side) **[needs to be tested]**
- [x] Fix old transpiler to now broadcast items drop on death
- [ ] Add a button to request resync for all vehicles **[children respawning is currently not correctly handled for this resync]**