### PR TITLE
Fix for attached storage module inventory

### DIFF
--- a/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
@@ -51,7 +51,7 @@ public class InstalledModuleEntitySpawner : SyncEntitySpawner<InstalledModuleEnt
         return true;
     }
 
-    protected override bool SpawnsOwnChildren(InstalledModuleEntity entity) => true;
+    protected override bool SpawnsOwnChildren(InstalledModuleEntity entity) => false;
 
     private bool CanSpawn(InstalledModuleEntity entity, out GameObject parentObject, out Equipment equipment, out string errorLog)
     {


### PR DESCRIPTION
- Fixes #1989 
- Apparent regression of inventory module not restoring inventory items upon server reload
- No code in `InstalledModuleEntitySpawner` indicates that it handles it's own children spawning
- Setting to false resolves the issue with Seamoth & Prawnsuit inventories not having their items placed in the chest
  - Child spawning now managed by [https://github.com/SubnauticaNitrox/Nitrox/blob/cfc08f3cc1174e551bddfb2dabaec1f6f34cc1a3/NitroxClient/GameLogic/Entities.cs#L217](https://github.com/SubnauticaNitrox/Nitrox/blob/cfc08f3cc1174e551bddfb2dabaec1f6f34cc1a3/NitroxClient/GameLogic/Entities.cs#L217)

### Context

I am new to the project and definitely lack the context for the big picture of impact this change could produce, but I have validated all module related storage behaves as expected with multiple local clients running / rejoining / joining for first time.