### PR TITLE
Fixed server starting with errored entities (1.7.1.0)

### DIFF
--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -31,7 +31,6 @@ namespace NitroxServer.GameLogic.Entities
             entitiesById = new Dictionary<NitroxId, Entity>(entities.Count);
             globalRootEntitiesById = new Dictionary<NitroxId, Entity>();
             phasingEntitiesByAbsoluteCell = new Dictionary<AbsoluteEntityCell, List<Entity>>();
-            bool toWarn = false;
 
             for (int i = 0; i < entities.Count; i++)
             {
@@ -60,13 +59,11 @@ namespace NitroxServer.GameLogic.Entities
                 }
                 catch (System.Exception ex)
                 {
-                    toWarn = true;
+                    Log.Warn($"Entity of type {entity.TechType.Name ?? "Unknown"} with GUID {entity.Id?.ToString() ?? "Unknown"} failed to load");
+#if DEBUG
                     Log.Error(ex);
+#endif
                 }
-            }
-            if (toWarn)
-            {
-                Log.Warn("One or more entities have failed to load");
             }
 
             this.batchEntitySpawner = batchEntitySpawner;

--- a/NitroxServer/GameLogic/Entities/EntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/EntityManager.cs
@@ -64,7 +64,7 @@ namespace NitroxServer.GameLogic.Entities
 #if DEBUG
                     Log.Error(ex);
 #endif
-                    // TODO - Teleport entity back to where it belongs, rather than just towards the center.
+                    // TODO - Add options for manual relocation and "natural respawning"
                     Log.Info("Press D to delete the entity, or any other key to teleport it between other things in its parent");
                     System.ConsoleKeyInfo key = System.Console.ReadKey();
                     if (key.Key != System.ConsoleKey.D)


### PR DESCRIPTION
Fixed server starting with errored entities, most notably the issue where occasionally an entity will have a NaN location, causing the entire save file to be unloadable.
Refactored sorting into a single enumeration pass, in part to allow easy insertion of the try-catch.

I've noticed several people having this issue occasionally on the current version, and this is intended to be a small patch to allow the current public version to not occasionally end up losing entire saves due to "corrupted" data when the user has no idea of how to find or fix it.