### PR TITLE
Fixed NuGet failing to resolve properly in Visual Studio

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,7 +61,7 @@
                     <PrivateAssets>all</PrivateAssets>
                     <IncludeAssets>build; native; contentfiles; analyzers</IncludeAssets>
                 </PackageReference>
-                <PackageReference Include="Nitrox.Discovery.MSBuild" Version="0.0.3">
+                <PackageReference Include="Nitrox.Discovery.MSBuild" Version="0.0.5">
                     <PrivateAssets>all</PrivateAssets>
                     <IncludeAssets>build; native; contentfiles; analyzers</IncludeAssets>
                 </PackageReference>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="FindGameAndIncludeReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(UnityModLibrary)' == 'true' or '$(TestLibrary)' == 'true'">
+    <Target Name="FindGameAndIncludeReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(_NitroxDiscovery_TaskAssembly)' != '' and ('$(UnityModLibrary)' == 'true' or '$(TestLibrary)' == 'true')">
         <DiscoverGame GameName="Subnautica" IntermediateOutputPath="$(IntermediateOutputPath)">
             <Output TaskParameter="GamePath" PropertyName="GameDir" />
         </DiscoverGame>


### PR DESCRIPTION
This was a regression from changing build process to a custom task. VS tried to resolve custom task during NuGet resolve but NuGet resolve is required to find the task, this lead to a kind of deadlock.

Closes #2171