### PR TITLE
Fix for disconnection modal not showing

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/Modals/Modal.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Modals/Modal.cs
@@ -73,7 +73,7 @@ public abstract class Modal
     {
         CurrentModal?.Hide();
         CurrentModal = this;
-        CoroutineHost.StartCoroutine(Show_Impl());
+        CoroutineHost.StartCoroutine(ShowImplementation());
     }
 
     /// <summary>
@@ -169,7 +169,7 @@ public abstract class Modal
     public virtual void ClickYes() { }
     public virtual void ClickNo() { }
 
-    private IEnumerator Show_Impl()
+    private IEnumerator ShowImplementation()
     {
         // Execute frame-by-frame to allow UI scripts to initialize.
         InitSubWindow();

--- a/NitroxClient/MonoBehaviours/Gui/Modals/Modal.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Modals/Modal.cs
@@ -71,10 +71,6 @@ public abstract class Modal
     /// </summary>
     public void Show()
     {
-        if (FreezeGame)
-        {
-            FreezeTime.Begin(FreezeTime.Id.Quit);
-        }
         CurrentModal?.Hide();
         CurrentModal = this;
         CoroutineHost.StartCoroutine(Show_Impl());
@@ -181,6 +177,11 @@ public abstract class Modal
         IngameMenu.main.Open();
         yield return new WaitForEndOfFrame();
         IngameMenu.main.ChangeSubscreen(SubWindowName);
+        yield return new WaitForEndOfFrame();
+        if (FreezeGame)
+        {
+            FreezeTime.Begin(FreezeTime.Id.Quit);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixes issue #2157 
- Changes a method name to be more readable and adhere to the C# styling guidelines
Testing(what I have tested):
- All modals(KickedModal, ConfirmModal, LostConnnectionModal, and ServerStoppedModal)
- Other menu elements still function as intended
- Player is properly kicked and appears that way to server and other clients(player is actually removed from the game)
- Kicking player from both server console and an admin player in game displays the correct modal and kicks the player
- Abruptly killing the server(AltF4/taskkill /f) disconnects all players with the appropriate modal shown(LostConnectionModal)
- Stopping the server(using the stop command) disconnects all players with the appropriate modal shown(ServerStoppedModal)