### PR TITLE
Sync footstep audio

### DIFF
--- a/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
+++ b/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
@@ -281,9 +281,9 @@ event:/player/enzyme_cure;false;false;0
 event:/player/food_critical;false;false;0
 event:/player/food_low;false;false;0
 event:/player/food_very_low;false;false;0
-event:/player/footstep_dirt;false;false;0
-event:/player/footstep_metal;false;false;0
-event:/player/footstep_precursor_base;false;false;0
+event:/player/footstep_dirt;false;false;20
+event:/player/footstep_metal;false;false;20
+event:/player/footstep_precursor_base;false;false;20
 event:/player/goal_airsack;false;false;0
 event:/player/goal_BiomeKelpForest;false;false;0
 event:/player/goal_BiomePrecursorGunUpper;false;false;0

--- a/Nitrox.Test/Model/DataStructures/Util/OptionalTest.cs
+++ b/Nitrox.Test/Model/DataStructures/Util/OptionalTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -99,6 +99,25 @@ namespace NitroxModel.DataStructures.Util
             Optional<object> cAsObj = Optional<object>.Of(new C());
             cAsObj.HasValue.Should().BeTrue();
             ((C)cAsObj.Value).Threshold.Should().Be(203);
+        }
+        [TestMethod]
+        public void OptionalEqualsCheck()
+        {
+            Optional<string> op = Optional.OfNullable<string>(null);
+            Optional<string> op1 = Optional.OfNullable<string>(null);
+            Optional<string> op2 = Optional.Of("Test");
+            Optional<string> op3 = Optional.Of("Test2");
+            Optional<string> op4 = Optional.Of("Test");
+
+            Assert.IsFalse(op.Equals(op2));
+            Assert.IsFalse(op.Equals(op3));
+            Assert.IsFalse(op2.Equals(op3));
+
+            Assert.IsTrue(op.Equals(op1));
+            Assert.IsTrue(op2.Equals(op4));
+
+            Assert.IsTrue(op != op2);
+            Assert.IsTrue(op2 == op4);
         }
 
         private class Base

--- a/Nitrox.Test/Patcher/Patches/Dynamic/FootstepSounds_OnStep_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/FootstepSounds_OnStep_PatchTest.cs
@@ -15,6 +15,6 @@ public class FootstepSounds_OnStep_PatchTest
         IEnumerable<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(FootstepSounds_OnStep_Patch.TARGET_METHOD);
         IEnumerable<CodeInstruction> result = FootstepSounds_OnStep_Patch.Transpiler(beforeInstructions);
 
-        Assert.AreEqual(beforeInstructions.Count() + 4, result.Count());
+        Assert.AreEqual(beforeInstructions.Count() + 6, result.Count());
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -6,17 +6,95 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NitroxModel.Packets;
+using NitroxClient.MonoBehaviours;
+using NitroxClient.GameLogic;
+using UnityEngine;
+using FMOD;
+using FMOD.Studio;
+using FMODUnity;
+using NitroxClient.GameLogic.FMOD;
+using NitroxClient.Unity.Helper;
+using System.Collections;
 
 namespace NitroxClient.Communication.Packets.Processors;
 public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
 {
     private readonly float footstepAudioRange;
-    public FootstepPacketProcessor(float footstepAudioRange)
+    private readonly PlayerManager remotePlayerManager;
+    private FootstepSounds localFootstepSounds;
+    private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
+    private float footstepAudioRadius = 20f;
+    private float footstepAudioMaxVolume = 1f;
+    private Dictionary<ushort, Vector3> playerPositions = new();
+    public FootstepPacketProcessor(float footstepAudioRange, PlayerManager remotePlayerManager)
     {
         this.footstepAudioRange = footstepAudioRange;
+        this.remotePlayerManager = remotePlayerManager;
+        this.localFootstepSounds = Player.mainObject.GetComponent<FootstepSounds>();
+        UWE.CoroutineHost.StartCoroutine(UpdatePlayerPositions());
     }
     public override void Process(FootstepPacket packet)
     {
         Log.Info("Processing footstep packet on client");
+        var player = remotePlayerManager.Find(packet.playerID);
+        if (!player.HasValue)
+        {
+            Log.Warn("Could not find player for footstep audio");
+            return;
+        }
+        else
+        {
+            Log.Info("Player found for footstep packet on client " + player.Value.PlayerName);
+            FMODAsset asset;
+            switch (packet.assetIndex)
+            {
+                case 1:
+                    // Precursor footstep sound
+                    Log.Info("Precursor footstep sound identified");
+                    asset = localFootstepSounds.precursorInteriorSound;
+                    break;
+                case 2:
+                    // Metal footstep sound
+                    Log.Info("Metal footstep sound identified");
+                    asset = localFootstepSounds.metalSound;
+                    break;
+                case 3:
+                    // Land footstep sound
+                    Log.Info("Land footstep sound identified");
+                    asset = localFootstepSounds.landSound;
+                    break;
+                default:
+                    asset = null;
+                    Log.Warn("Weird asset index for footstep audio");
+                    break;
+            }
+            EventInstance @event = FMODUWE.GetEvent(asset);
+            if (@event.isValid())
+            {
+                if (FMODUWE.IsInvalidParameterId(fmodIndexSpeed))
+                {
+                    fmodIndexSpeed = FMODUWE.GetEventInstanceParameterIndex(@event, "speed");
+                }
+                ATTRIBUTES_3D attributes = player.Value.Body.To3DAttributes();
+                @event.set3DAttributes(attributes);
+                var playerVelocity = (player.Value.Body.transform.position - playerPositions[player.Value.PlayerId]) / Time.deltaTime;
+                @event.setParameterValueByIndex(fmodIndexSpeed, playerVelocity.magnitude);
+                @event.setVolume(FMODSystem.CalculateVolume(Player.mainObject.transform.position, player.Value.Body.transform.position, footstepAudioRadius, footstepAudioMaxVolume));
+                @event.start();
+                @event.release();
+            }
+        }
+    }
+    IEnumerator UpdatePlayerPositions()
+    {
+        while (true)
+        {
+            var players = remotePlayerManager.GetAll();
+            foreach(RemotePlayer player in players)
+            {
+                playerPositions[player.PlayerId] = player.Body.transform.position;
+            }
+            yield return new WaitForEndOfFrame();
+        }
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -33,9 +33,9 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
         {
             FMODAsset asset = packet.AssetIndex switch
             {
-                FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND => localFootstepSounds.precursorInteriorSound,
-                FootstepPacket.StepSounds.METAL_STEP_SOUND => localFootstepSounds.metalSound,
-                FootstepPacket.StepSounds.LAND_STEP_SOUND => localFootstepSounds.landSound,
+                FootstepPacket.StepSounds.PRECURSOR => localFootstepSounds.precursorInteriorSound,
+                FootstepPacket.StepSounds.METAL => localFootstepSounds.metalSound,
+                FootstepPacket.StepSounds.LAND => localFootstepSounds.landSound,
                 _ => null
             };
             EventInstance evt = FMODUWE.GetEvent(asset);

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -16,7 +16,7 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
     private readonly FootstepSounds localFootstepSounds;
     private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
     private readonly float footstepAudioRadius = 20f;
-    private readonly float footstepAudioMaxVolume = 1f;
+    private readonly float footstepAudioMaxVolume = 0.5f;
     public FootstepPacketProcessor(PlayerManager remotePlayerManager)
     {
         this.remotePlayerManager = remotePlayerManager;

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -13,7 +13,7 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
     private readonly PlayerManager remotePlayerManager;
     private readonly FootstepSounds localFootstepSounds;
     private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
-    private const float footstepAudioRadius = 20f;
+    private const float footstepAudioRadius = 20f; // Make sure this matches the value in the server packet processor FootstepPacketProcessor.cs
     private const float footstepAudioMaxVolume = 0.5f;
 
     public FootstepPacketProcessor(PlayerManager remotePlayerManager)

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -24,34 +24,27 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
     }
     public override void Process(FootstepPacket packet)
     {
-        Log.Info("Processing footstep packet on client");
         var player = remotePlayerManager.Find(packet.playerID);
         if (!player.HasValue)
         {
-            Log.Warn("Could not find player for footstep audio");
             return;
         }
         else
         {
-            Log.Info($"Player found for footstep packet on client {player.Value.PlayerName}");
             FMODAsset asset;
             switch (packet.assetIndex)
             {
                 case FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND:
-                    Log.Info("Precursor footstep sound identified");
                     asset = localFootstepSounds.precursorInteriorSound;
                     break;
                 case FootstepPacket.StepSounds.METAL_STEP_SOUND:
-                    Log.Info("Metal footstep sound identified");
                     asset = localFootstepSounds.metalSound;
                     break;
                 case FootstepPacket.StepSounds.LAND_STEP_SOUND:
-                    Log.Info("Land footstep sound identified");
                     asset = localFootstepSounds.landSound;
                     break;
                 default:
                     asset = null;
-                    Log.Warn("Weird asset index for footstep audio");
                     break;
             }
             EventInstance @event = FMODUWE.GetEvent(asset);

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,13 +1,10 @@
-using NitroxClient.Communication.Packets.Processors.Abstract;
-using NitroxModel.Packets;
-using NitroxClient.GameLogic;
 using FMOD;
 using FMOD.Studio;
 using FMODUnity;
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.FMOD;
-using NitroxModel.Helper;
-using System.Collections.Generic;
-using System.Reflection.Emit;
+using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
 public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,20 +1,13 @@
 using NitroxClient.Communication.Packets.Processors.Abstract;
-using NitroxClient.MonoBehaviours.Gui.HUD;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NitroxModel.Packets;
-using NitroxClient.MonoBehaviours;
 using NitroxClient.GameLogic;
-using UnityEngine;
 using FMOD;
 using FMOD.Studio;
 using FMODUnity;
 using NitroxClient.GameLogic.FMOD;
-using NitroxClient.Unity.Helper;
-using System.Collections;
+using NitroxModel.Helper;
+using System.Collections.Generic;
+using System.Reflection.Emit;
 
 namespace NitroxClient.Communication.Packets.Processors;
 public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
@@ -44,18 +37,15 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
             FMODAsset asset;
             switch (packet.assetIndex)
             {
-                case 1:
-                    // Precursor footstep sound
+                case FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND:
                     Log.Info("Precursor footstep sound identified");
                     asset = localFootstepSounds.precursorInteriorSound;
                     break;
-                case 2:
-                    // Metal footstep sound
+                case FootstepPacket.StepSounds.METAL_STEP_SOUND:
                     Log.Info("Metal footstep sound identified");
                     asset = localFootstepSounds.metalSound;
                     break;
-                case 3:
-                    // Land footstep sound
+                case FootstepPacket.StepSounds.LAND_STEP_SOUND:
                     Log.Info("Land footstep sound identified");
                     asset = localFootstepSounds.landSound;
                     break;

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -4,6 +4,7 @@ using FMODUnity;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.FMOD;
+using NitroxModel.DataStructures.Util;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Packets;
 
@@ -27,7 +28,7 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
 
     public override void Process(FootstepPacket packet)
     {
-        var player = remotePlayerManager.Find(packet.PlayerID);
+        Optional<RemotePlayer> player = remotePlayerManager.Find(packet.PlayerID);
         if (player.HasValue)
         {
             FMODAsset asset = packet.AssetIndex switch

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -4,6 +4,7 @@ using FMODUnity;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.FMOD;
+using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
@@ -13,13 +14,15 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
     private readonly PlayerManager remotePlayerManager;
     private readonly FootstepSounds localFootstepSounds;
     private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
-    private const float footstepAudioRadius = 20f; // Make sure this matches the value in the server packet processor FootstepPacketProcessor.cs
+    private readonly float footstepAudioRadius; // To modify this value, modify the last value in the SoundWhitelist_Subnautica.csv file
     private const float footstepAudioMaxVolume = 0.5f;
 
-    public FootstepPacketProcessor(PlayerManager remotePlayerManager)
+    public FootstepPacketProcessor(PlayerManager remotePlayerManager, FMODWhitelist whitelist)
     {
         this.remotePlayerManager = remotePlayerManager;
         localFootstepSounds = Player.mainObject.GetComponent<FootstepSounds>();
+        whitelist.TryGetSoundData("event:/player/footstep_precursor_base", out SoundData soundData);
+        footstepAudioRadius = soundData.Radius;
     }
 
     public override void Process(FootstepPacket packet)

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -7,6 +7,7 @@ using NitroxClient.GameLogic.FMOD;
 using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
+
 public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
 {
     private readonly PlayerManager remotePlayerManager;
@@ -14,11 +15,13 @@ public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
     private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
     private readonly float footstepAudioRadius = 20f;
     private readonly float footstepAudioMaxVolume = 0.5f;
+
     public FootstepPacketProcessor(PlayerManager remotePlayerManager)
     {
         this.remotePlayerManager = remotePlayerManager;
         this.localFootstepSounds = Player.mainObject.GetComponent<FootstepSounds>();
     }
+
     public override void Process(FootstepPacket packet)
     {
         var player = remotePlayerManager.Find(packet.playerID);

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,0 +1,22 @@
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.MonoBehaviours.Gui.HUD;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NitroxModel.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
+{
+    private readonly float footstepAudioRange;
+    public FootstepPacketProcessor(float footstepAudioRange)
+    {
+        this.footstepAudioRange = footstepAudioRange;
+    }
+    public override void Process(FootstepPacket packet)
+    {
+        Log.Info("Processing footstep packet on client");
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -19,15 +19,13 @@ using System.Collections;
 namespace NitroxClient.Communication.Packets.Processors;
 public class FootstepPacketProcessor : ClientPacketProcessor<FootstepPacket>
 {
-    private readonly float footstepAudioRange;
     private readonly PlayerManager remotePlayerManager;
-    private FootstepSounds localFootstepSounds;
+    private readonly FootstepSounds localFootstepSounds;
     private PARAMETER_ID fmodIndexSpeed = FMODUWE.invalidParameterId;
     private readonly float footstepAudioRadius = 20f;
     private readonly float footstepAudioMaxVolume = 1f;
-    public FootstepPacketProcessor(float footstepAudioRange, PlayerManager remotePlayerManager)
+    public FootstepPacketProcessor(PlayerManager remotePlayerManager)
     {
-        this.footstepAudioRange = footstepAudioRange;
         this.remotePlayerManager = remotePlayerManager;
         this.localFootstepSounds = Player.mainObject.GetComponent<FootstepSounds>();
     }

--- a/NitroxModel/DataStructures/Optional.cs
+++ b/NitroxModel/DataStructures/Optional.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
@@ -149,6 +149,30 @@ namespace NitroxModel.DataStructures.Util
         public static explicit operator T(Optional<T> value)
         {
             return value.Value;
+        }
+        public bool Equals(Optional<T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Optional<T> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T>.Default.GetHashCode(Value);
+        }
+
+        public static bool operator ==(Optional<T> left, Optional<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Optional<T> left, Optional<T> right)
+        {
+            return !left.Equals(right);
         }
     }
 

--- a/NitroxModel/DataStructures/Optional.cs
+++ b/NitroxModel/DataStructures/Optional.cs
@@ -16,7 +16,7 @@ namespace NitroxModel.DataStructures.Util
     /// <typeparam name="T"></typeparam>
     [Serializable]
     [DataContract]
-    public struct Optional<T> : ISerializable where T : class
+    public struct Optional<T> : ISerializable, IEquatable<Optional<T>> where T : class
     {
         private delegate bool HasValueDelegate(T value);
 

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -1,24 +1,22 @@
 using System;
 
-namespace NitroxModel.Packets
+namespace NitroxModel.Packets;
+[Serializable]
+public class FootstepPacket : Packet
 {
-    [Serializable]
-    public class FootstepPacket : Packet
+    public ushort PlayerID { get; }
+    public StepSounds AssetIndex { get; }
+
+    public FootstepPacket(ushort playerID, StepSounds assetIndex)
     {
-        public ushort playerID { get; }
-        public StepSounds assetIndex { get; }
+        this.PlayerID = playerID;
+        this.AssetIndex = assetIndex;
+    }
 
-        public FootstepPacket(ushort playerID, StepSounds assetIndex)
-        {
-            this.playerID = playerID;
-            this.assetIndex = assetIndex;
-        }
-
-        public enum StepSounds : byte
-        {
-            PRECURSOR_STEP_SOUND,
-            METAL_STEP_SOUND,
-            LAND_STEP_SOUND
-        }
+    public enum StepSounds : byte
+    {
+        PRECURSOR_STEP_SOUND,
+        METAL_STEP_SOUND,
+        LAND_STEP_SOUND
     }
 }

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 namespace NitroxModel.Packets
 {
+    [Serializable]
     public class FootstepPacket : Packet
     {
-        public readonly ushort playerID;
-        public readonly byte assetIndex;
+        public ushort playerID { get; }
+        public byte assetIndex { get; }
         public FootstepPacket(ushort playerID, byte assetIndex)
         {
             Log.Info("Creating footstep packet");

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -1,20 +1,22 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 namespace NitroxModel.Packets
 {
     [Serializable]
     public class FootstepPacket : Packet
     {
         public ushort playerID { get; }
-        public byte assetIndex { get; }
-        public FootstepPacket(ushort playerID, byte assetIndex)
+        public StepSounds assetIndex { get; }
+        public FootstepPacket(ushort playerID, StepSounds assetIndex)
         {
             Log.Info("Creating footstep packet");
             this.playerID = playerID;
             this.assetIndex = assetIndex;
+        }
+        public enum StepSounds : byte
+        {
+            PRECURSOR_STEP_SOUND,
+            METAL_STEP_SOUND,
+            LAND_STEP_SOUND
         }
     }
 }

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -10,8 +10,8 @@ public class FootstepPacket : Packet
 
     public FootstepPacket(ushort playerID, StepSounds assetIndex)
     {
-        this.PlayerID = playerID;
-        this.AssetIndex = assetIndex;
+        PlayerID = playerID;
+        AssetIndex = assetIndex;
     }
 
     public enum StepSounds : byte

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -8,8 +8,8 @@ namespace NitroxModel.Packets
 {
     public class FootstepPacket : Packet
     {
-        private ushort playerID;
-        byte assetIndex;
+        public readonly ushort playerID;
+        public readonly byte assetIndex;
         public FootstepPacket(ushort playerID, byte assetIndex)
         {
             Log.Info("Creating footstep packet");

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -16,8 +16,8 @@ public class FootstepPacket : Packet
 
     public enum StepSounds : byte
     {
-        PRECURSOR_STEP_SOUND,
-        METAL_STEP_SOUND,
-        LAND_STEP_SOUND
+        PRECURSOR,
+        METAL,
+        LAND
     }
 }

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NitroxModel.Packets
+{
+    public class FootstepPacket : Packet
+    {
+        private ushort playerID;
+        byte assetIndex;
+        public FootstepPacket(ushort playerID, byte assetIndex)
+        {
+            Log.Info("Creating footstep packet");
+            this.playerID = playerID;
+            this.assetIndex = assetIndex;
+        }
+    }
+}

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -8,7 +8,6 @@ namespace NitroxModel.Packets
         public StepSounds assetIndex { get; }
         public FootstepPacket(ushort playerID, StepSounds assetIndex)
         {
-            Log.Info("Creating footstep packet");
             this.playerID = playerID;
             this.assetIndex = assetIndex;
         }

--- a/NitroxModel/Packets/FootstepPacket.cs
+++ b/NitroxModel/Packets/FootstepPacket.cs
@@ -1,4 +1,5 @@
 using System;
+
 namespace NitroxModel.Packets
 {
     [Serializable]
@@ -6,11 +7,13 @@ namespace NitroxModel.Packets
     {
         public ushort playerID { get; }
         public StepSounds assetIndex { get; }
+
         public FootstepPacket(ushort playerID, StepSounds assetIndex)
         {
             this.playerID = playerID;
             this.assetIndex = assetIndex;
         }
+
         public enum StepSounds : byte
         {
             PRECURSOR_STEP_SOUND,

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -88,13 +88,13 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
             switch (asset.path)
             {
                 case PRECURSOR_STEP_SOUND_PATH:
-                    assetIndex = FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND;
+                    assetIndex = FootstepPacket.StepSounds.PRECURSOR;
                     break;
                 case METAL_STEP_SOUND_PATH:
-                    assetIndex = FootstepPacket.StepSounds.METAL_STEP_SOUND;
+                    assetIndex = FootstepPacket.StepSounds.METAL;
                     break;
                 default:
-                    assetIndex = FootstepPacket.StepSounds.LAND_STEP_SOUND;
+                    assetIndex = FootstepPacket.StepSounds.LAND;
                     break;
             }
             FootstepPacket footstepPacket = new(Resolve<LocalPlayer>().PlayerId.Value, assetIndex);

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -83,25 +83,26 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
 
     private static void SendFootstepPacket(FMODAsset asset)
     {
-        if (Resolve<LocalPlayer>().PlayerId.HasValue)
+        if (!Resolve<LocalPlayer>().PlayerId.HasValue)
         {
-            FootstepPacket.StepSounds assetIndex;
-            switch (asset.path)
-            {
-                case PRECURSOR_STEP_SOUND_PATH:
-                    assetIndex = FootstepPacket.StepSounds.PRECURSOR;
-                    break;
-                case METAL_STEP_SOUND_PATH:
-                    assetIndex = FootstepPacket.StepSounds.METAL;
-                    break;
-                case LAND_STEP_SOUND_PATH:
-                    assetIndex = FootstepPacket.StepSounds.LAND;
-                    break;
-                default:
-                    return;
-            }
-            FootstepPacket footstepPacket = new(Resolve<LocalPlayer>().PlayerId.Value, assetIndex);
-            Resolve<IPacketSender>().Send(footstepPacket);
+            return;
         }
+        FootstepPacket.StepSounds assetIndex;
+        switch (asset.path)
+        {
+            case PRECURSOR_STEP_SOUND_PATH:
+                assetIndex = FootstepPacket.StepSounds.PRECURSOR;
+                break;
+            case METAL_STEP_SOUND_PATH:
+                assetIndex = FootstepPacket.StepSounds.METAL;
+                break;
+            case LAND_STEP_SOUND_PATH:
+                assetIndex = FootstepPacket.StepSounds.LAND;
+                break;
+            default:
+                return;
+        }
+        FootstepPacket footstepPacket = new(Resolve<LocalPlayer>().PlayerId.Value, assetIndex);
+        Resolve<IPacketSender>().Send(footstepPacket);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -16,7 +16,6 @@ namespace NitroxPatcher.Patches.Dynamic;
 
 public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicPatch
 {
-    private const string EXO_STEP_SOUND_PATH = "event:/sub/exo/step";
     private const string PRECURSOR_STEP_SOUND_PATH = "event:/player/footstep_precursor_base";
     private const string METAL_STEP_SOUND_PATH = "event:/player/footstep_metal";
     private const string LAND_STEP_SOUND_PATH = "event:/player/footstep_dirt";
@@ -66,7 +65,7 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
     private static float CalculateVolume(float originalVolume, FootstepSounds instance, FMODAsset asset, Transform xform)
     {
         // For exosuits only "event:/sub/exo/step" is used inside FootstepSounds
-        if (asset.path.Equals(EXO_STEP_SOUND_PATH, StringComparison.Ordinal) && (!Player.main.currentMountedVehicle || Player.main.currentMountedVehicle.gameObject != instance.gameObject))
+        if (asset.path.Equals(LAND_STEP_SOUND_PATH, StringComparison.Ordinal) && (!Player.main.currentMountedVehicle || Player.main.currentMountedVehicle.gameObject != instance.gameObject))
         {
             // Origin is Exosuit which is controlled by remote player
             return FMODSystem.CalculateVolume(xform.position, Player.main.transform.position, stepSoundRadius.Value, originalVolume);
@@ -77,7 +76,7 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
 
     private static readonly Lazy<float> stepSoundRadius = new(() =>
     {
-        Resolve<FMODWhitelist>().TryGetSoundData(EXO_STEP_SOUND_PATH, out SoundData soundData);
+        Resolve<FMODWhitelist>().TryGetSoundData(LAND_STEP_SOUND_PATH, out SoundData soundData);
         return soundData.Radius;
     });
 

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -19,6 +19,7 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
     private const string EXO_STEP_SOUND_PATH = "event:/sub/exo/step";
     private const string PRECURSOR_STEP_SOUND_PATH = "event:/player/footstep_precursor_base";
     private const string METAL_STEP_SOUND_PATH = "event:/player/footstep_metal";
+    private const string LAND_STEP_SOUND_PATH = "event:/player/footstep_dirt";
 
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((FootstepSounds t) => t.OnStep(default));
 
@@ -93,9 +94,11 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
                 case METAL_STEP_SOUND_PATH:
                     assetIndex = FootstepPacket.StepSounds.METAL;
                     break;
-                default:
+                case LAND_STEP_SOUND_PATH:
                     assetIndex = FootstepPacket.StepSounds.LAND;
                     break;
+                default:
+                    return;
             }
             FootstepPacket footstepPacket = new(Resolve<LocalPlayer>().PlayerId.Value, assetIndex);
             Resolve<IPacketSender>().Send(footstepPacket);

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -80,26 +80,24 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
         return soundData.Radius;
     });
 
-    public static void SendFootstepPacket(FMODAsset asset)
+    private static void SendFootstepPacket(FMODAsset asset)
     {
-        // Send footstep packet with the asset
-        var localPlayer = Resolve<LocalPlayer>();
-        if (localPlayer.PlayerId.HasValue)
+        if (Resolve<LocalPlayer>().PlayerId.HasValue)
         {
             FootstepPacket.StepSounds assetIndex;
-            if (asset.path == PRECURSOR_STEP_SOUND_PATH)
+            switch (asset.path)
             {
-                assetIndex = FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND;
+                case PRECURSOR_STEP_SOUND_PATH:
+                    assetIndex = FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND;
+                    break;
+                case METAL_STEP_SOUND_PATH:
+                    assetIndex = FootstepPacket.StepSounds.METAL_STEP_SOUND;
+                    break;
+                default:
+                    assetIndex = FootstepPacket.StepSounds.LAND_STEP_SOUND;
+                    break;
             }
-            else if (asset.path == METAL_STEP_SOUND_PATH)
-            {
-                assetIndex = FootstepPacket.StepSounds.METAL_STEP_SOUND;
-            }
-            else
-            {
-                assetIndex = FootstepPacket.StepSounds.LAND_STEP_SOUND;
-            }
-            var footstepPacket = new FootstepPacket(localPlayer.PlayerId.Value, assetIndex);
+            FootstepPacket footstepPacket = new(Resolve<LocalPlayer>().PlayerId.Value, assetIndex);
             Resolve<IPacketSender>().Send(footstepPacket);
         }
     }

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 using FMOD.Studio;
 using HarmonyLib;
 using NitroxClient.Communication.Abstract;
@@ -10,6 +6,10 @@ using NitroxClient.GameLogic.FMOD;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using FMOD.Studio;
 using HarmonyLib;
 using NitroxClient.Communication.Abstract;
@@ -6,10 +10,6 @@ using NitroxClient.GameLogic.FMOD;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -1,17 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 using FMOD.Studio;
 using HarmonyLib;
+using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.FMOD;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
-using NitroxPatcher.PatternMatching;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
-using NitroxClient.Communication.Abstract;
 namespace NitroxPatcher.Patches.Dynamic;
 
 public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicPatch

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -19,7 +19,7 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
     private const string EXO_STEP_SOUND_PATH = "event:/sub/exo/step";
     private const string PRECURSOR_STEP_SOUND_PATH = "event:/player/footstep_precursor_base";
     private const string METAL_STEP_SOUND_PATH = "event:/player/footstep_metal";
-    
+
 
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((FootstepSounds t) => t.OnStep(default));
 

--- a/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FootstepSounds_OnStep_Patch.cs
@@ -1,19 +1,25 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using FMOD.Studio;
 using HarmonyLib;
+using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.FMOD;
 using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Helper;
+using NitroxModel.Packets;
+using NitroxPatcher.PatternMatching;
 using UnityEngine;
-
+using NitroxClient.Communication.Abstract;
 namespace NitroxPatcher.Patches.Dynamic;
 
 public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicPatch
 {
     private const string EXO_STEP_SOUND_PATH = "event:/sub/exo/step";
+    private const string PRECURSOR_STEP_SOUND_PATH = "event:/player/footstep_precursor_base";
+    private const string METAL_STEP_SOUND_PATH = "event:/player/footstep_metal";
+    
 
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((FootstepSounds t) => t.OnStep(default));
 
@@ -39,8 +45,16 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
                    new CodeInstruction(OpCodes.Ldloc_0),
                    new CodeInstruction(OpCodes.Ldarg_1),
                    new CodeInstruction(OpCodes.Call, Reflect.Method(() => CalculateVolume(default, default, default, default)))
-               )
-               .InstructionEnumeration();
+               ).MatchEndForward(new CodeMatch(OpCodes.Call, Reflect.Method((FMOD.Studio.EventInstance t) => t.release())),
+                                                               new CodeMatch(OpCodes.Pop))
+                                            .Advance(1)
+                                            .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_0))
+                                            .Insert(new CodeInstruction(OpCodes.Call, Reflect.Method(() => SendFootstepPacket(default))))
+                                            .InstructionEnumeration();
+        /* event.release();
+         * SendFootstepPacket(asset);
+         * asset in this case is the FMOD asset of the footstep sound that was played
+         * */
     }
 
     // This method is called very often and should therefore be performant
@@ -61,4 +75,27 @@ public sealed partial class FootstepSounds_OnStep_Patch : NitroxPatch, IDynamicP
         Resolve<FMODWhitelist>().TryGetSoundData(EXO_STEP_SOUND_PATH, out SoundData soundData);
         return soundData.Radius;
     });
+    public static void SendFootstepPacket(FMODAsset asset)
+    {
+        // Send footstep packet with the asset
+        var localPlayer = Resolve<LocalPlayer>();
+        if (localPlayer.PlayerId.HasValue)
+        {
+            FootstepPacket.StepSounds assetIndex;
+            if (asset.path == PRECURSOR_STEP_SOUND_PATH)
+            {
+                assetIndex = FootstepPacket.StepSounds.PRECURSOR_STEP_SOUND;
+            }
+            else if (asset.path == METAL_STEP_SOUND_PATH)
+            {
+                assetIndex = FootstepPacket.StepSounds.METAL_STEP_SOUND;
+            }
+            else
+            {
+                assetIndex = FootstepPacket.StepSounds.LAND_STEP_SOUND;
+            }
+            var footstepPacket = new FootstepPacket(localPlayer.PlayerId.Value, assetIndex);
+            Resolve<IPacketSender>().Send(footstepPacket);
+        }
+    }
 }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -30,13 +30,7 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
             {
                 continue;
             }
-            if (player.SubRootId.HasValue && sendingPlayer.SubRootId.HasValue &&
-                player.SubRootId.Value == sendingPlayer.SubRootId.Value)
-            {
-                player.SendPacket(footstepPacket);
-            }
-            else if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
-                    !player.SubRootId.HasValue)
+            if(player.SubRootId.Equals(sendingPlayer.SubRootId))
             {
                 player.SendPacket(footstepPacket);
             }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -29,14 +29,11 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
             {
                 player.SendPacket(footstepPacket);
             }
-            else
-            {
-                if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
+            else if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
                     player != sendingPlayer &&
                     !player.SubRootId.HasValue)
-                {
-                    player.SendPacket(footstepPacket);
-                }
+            {
+                player.SendPacket(footstepPacket);
             }
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -20,7 +20,7 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
 
     public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
     {
-        foreach (Player player in playerManager.GetAllPlayers())
+        foreach (Player player in playerManager.GetConnectedPlayers())
         {
             if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) >= footstepAudioRange ||
                 player == sendingPlayer)

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -43,9 +43,9 @@ namespace NitroxServer.Communication.Packets.Processors
                         }
                     }
                     // If one player doesn't have an id and other does, automatically false
-            
-                    }
+
                 }
+            }
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,0 +1,23 @@
+using NitroxModel.Packets;
+using NitroxServer.Communication.Packets.Processors.Abstract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NitroxServer.Communication.Packets.Processors
+{
+    public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
+    {
+        private readonly float footstepAudioRange;
+        public FootstepPacketProcessor(float footstepAudioRange)
+        {
+            this.footstepAudioRange = footstepAudioRange;
+        }
+        public override void Process(FootstepPacket packet, Player sendingPlayer)
+        {
+            Log.Info("Processing footstep packet on server from " + sendingPlayer.Name);
+        }
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -2,17 +2,15 @@ using NitroxModel.DataStructures.Unity;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
-using System.Numerics;
 
 namespace NitroxServer.Communication.Packets.Processors
 {
     public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
     {
-        private readonly float footstepAudioRange;
+        private readonly float footstepAudioRange = 20f;
         private readonly PlayerManager playerManager;
-        public FootstepPacketProcessor(float footstepAudioRange, PlayerManager playerManager)
+        public FootstepPacketProcessor(PlayerManager playerManager)
         {
-            this.footstepAudioRange = footstepAudioRange;
             this.playerManager = playerManager;
         }
         public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -17,12 +17,13 @@ namespace NitroxServer.Communication.Packets.Processors
         {
             Log.Info("Processing footstep packet on server from " + sendingPlayer.Name);
             var players = playerManager.GetAllPlayers();
-            foreach(Player player in players)
+            foreach (Player player in players)
             {
-                if(NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange)
+                if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player.SubRootId.Equals(sendingPlayer.SubRootId.Value)
+                    && player != sendingPlayer)
                 {
-                    // Forward footstep packet to players if they are within range to hear it
-                    playerManager.SendPacketToOtherPlayers(footstepPacket, sendingPlayer);
+                    // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
+                    player.SendPacket(footstepPacket);
                 }
             }
         }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,4 +1,5 @@
 using NitroxModel.DataStructures.Unity;
+using NitroxModel.GameLogic.FMOD;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
@@ -6,45 +7,46 @@ using NitroxServer.GameLogic;
 namespace NitroxServer.Communication.Packets.Processors;
 public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
 {
-    private const float footstepAudioRange = 20f; // Make sure this matches the value in the client-side packet processor FootstepPacketProcessor.cs
+    private readonly float footstepAudioRange; // To modify this value, modify the last value in the SoundWhitelist_Subnautica.csv file
     private readonly PlayerManager playerManager;
 
-    public FootstepPacketProcessor(PlayerManager playerManager)
+    public FootstepPacketProcessor(PlayerManager playerManager, FMODWhitelist whitelist)
     {
         this.playerManager = playerManager;
+        whitelist.TryGetSoundData("event:/player/footstep_precursor_base", out SoundData soundData);
+        footstepAudioRange = soundData.Radius;
     }
 
-        public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
+    public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
+    {
+        var players = playerManager.GetAllPlayers();
+        foreach (Player player in players)
         {
-            var players = playerManager.GetAllPlayers();
-            foreach (Player player in players)
+            if (sendingPlayer.SubRootId.HasValue)
             {
-                if (sendingPlayer.SubRootId.HasValue)
+                if (player.SubRootId.HasValue)
                 {
-                    if (player.SubRootId.HasValue)
+                    // If both players have id's, check if they are the same
+                    if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer && player.SubRootId.Value == sendingPlayer.SubRootId.Value)
                     {
-                        // If both players have id's, check if they are the same
-                        if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer && player.SubRootId.Value == sendingPlayer.SubRootId.Value)
-                        {
-                            // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
-                            player.SendPacket(footstepPacket);
-                        }
+                        // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
+                        player.SendPacket(footstepPacket);
                     }
-                    // If one player has an id and the other doesn't, automatically false
                 }
-                else
+                // If one player has an id and the other doesn't, automatically false
+            }
+            else
+            {
+                // if both player's don't have SubRootIds
+                if (!player.SubRootId.HasValue)
                 {
-                    // if both player's don't have SubRootIds
-                    if (!player.SubRootId.HasValue)
+                    if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer)
                     {
-                        if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer)
-                        {
-                            // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
-                            player.SendPacket(footstepPacket);
-                        }
+                        // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
+                        player.SendPacket(footstepPacket);
                     }
-                    // If one player doesn't have an id and other does, automatically false
                 }
+                // If one player doesn't have an id and other does, automatically false
             }
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -9,10 +9,12 @@ namespace NitroxServer.Communication.Packets.Processors
     {
         private readonly float footstepAudioRange = 20f;
         private readonly PlayerManager playerManager;
+
         public FootstepPacketProcessor(PlayerManager playerManager)
         {
             this.playerManager = playerManager;
         }
+
         public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
         {
             var players = playerManager.GetAllPlayers();
@@ -43,7 +45,6 @@ namespace NitroxServer.Communication.Packets.Processors
                         }
                     }
                     // If one player doesn't have an id and other does, automatically false
-
                 }
             }
         }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -8,7 +8,7 @@ namespace NitroxServer.Communication.Packets.Processors;
 
 public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
 {
-    private readonly float footstepAudioRange; // To modify this value, modify the last value in the SoundWhitelist_Subnautica.csv file
+    private readonly float footstepAudioRange; // To modify this value, modify the last value of the event:/player/footstep_precursor_base sound in the SoundWhitelist_Subnautica.csv file
     private readonly PlayerManager playerManager;
 
     public FootstepPacketProcessor(PlayerManager playerManager, FMODWhitelist whitelist)

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -6,7 +6,7 @@ using NitroxServer.GameLogic;
 namespace NitroxServer.Communication.Packets.Processors;
 public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
 {
-    private readonly float footstepAudioRange = 20f;
+    private const float footstepAudioRange = 20f; // Make sure this matches the value in the client-side packet processor FootstepPacketProcessor.cs
     private readonly PlayerManager playerManager;
 
     public FootstepPacketProcessor(PlayerManager playerManager)

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -19,34 +19,23 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
 
     public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
     {
-        var players = playerManager.GetAllPlayers();
-        foreach (Player player in players)
+        foreach (Player player in playerManager.GetAllPlayers())
         {
-            if (sendingPlayer.SubRootId.HasValue)
+            if (player.SubRootId.HasValue && sendingPlayer.SubRootId.HasValue &&
+                NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
+                player != sendingPlayer &&
+                player.SubRootId.Value == sendingPlayer.SubRootId.Value)
             {
-                if (player.SubRootId.HasValue)
-                {
-                    // If both players have id's, check if they are the same
-                    if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer && player.SubRootId.Value == sendingPlayer.SubRootId.Value)
-                    {
-                        // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
-                        player.SendPacket(footstepPacket);
-                    }
-                }
-                // If one player has an id and the other doesn't, automatically false
+                player.SendPacket(footstepPacket);
             }
             else
             {
-                // if both player's don't have SubRootIds
-                if (!player.SubRootId.HasValue)
+                if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
+                    player != sendingPlayer &&
+                    !player.SubRootId.HasValue)
                 {
-                    if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer)
-                    {
-                        // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
-                        player.SendPacket(footstepPacket);
-                    }
+                    player.SendPacket(footstepPacket);
                 }
-                // If one player doesn't have an id and other does, automatically false
             }
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -22,11 +22,8 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
     {
         foreach (Player player in playerManager.GetAllPlayers())
         {
-            if(NitroxVector3.Distance(player.Position, sendingPlayer.Position) >= footstepAudioRange)
-            {
-                continue;
-            }
-            if(player != sendingPlayer)
+            if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) >= footstepAudioRange ||
+                player == sendingPlayer)
             {
                 continue;
             }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -15,17 +15,37 @@ namespace NitroxServer.Communication.Packets.Processors
         }
         public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
         {
-            Log.Info("Processing footstep packet on server from " + sendingPlayer.Name);
             var players = playerManager.GetAllPlayers();
             foreach (Player player in players)
             {
-                if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player.SubRootId.Equals(sendingPlayer.SubRootId.Value)
-                    && player != sendingPlayer)
+                if (sendingPlayer.SubRootId.HasValue)
                 {
-                    // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
-                    player.SendPacket(footstepPacket);
+                    if (player.SubRootId.HasValue)
+                    {
+                        // If both players have id's, check if they are the same
+                        if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer && player.SubRootId.Value == sendingPlayer.SubRootId.Value)
+                        {
+                            // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
+                            player.SendPacket(footstepPacket);
+                        }
+                    }
+                    // If one player has an id and the other doesn't, automatically false
                 }
-            }
+                else
+                {
+                    // if both player's don't have SubRootIds
+                    if (!player.SubRootId.HasValue)
+                    {
+                        if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange && player != sendingPlayer)
+                        {
+                            // Forward footstep packet to players if they are within range to hear it and are in the same structure / submarine
+                            player.SendPacket(footstepPacket);
+                        }
+                    }
+                    // If one player doesn't have an id and other does, automatically false
+            
+                    }
+                }
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -1,23 +1,32 @@
+using NitroxModel.DataStructures.Unity;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NitroxServer.GameLogic;
+using System.Numerics;
 
 namespace NitroxServer.Communication.Packets.Processors
 {
     public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPacket>
     {
         private readonly float footstepAudioRange;
-        public FootstepPacketProcessor(float footstepAudioRange)
+        private readonly PlayerManager playerManager;
+        public FootstepPacketProcessor(float footstepAudioRange, PlayerManager playerManager)
         {
             this.footstepAudioRange = footstepAudioRange;
+            this.playerManager = playerManager;
         }
-        public override void Process(FootstepPacket packet, Player sendingPlayer)
+        public override void Process(FootstepPacket footstepPacket, Player sendingPlayer)
         {
             Log.Info("Processing footstep packet on server from " + sendingPlayer.Name);
+            var players = playerManager.GetAllPlayers();
+            foreach(Player player in players)
+            {
+                if(NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange)
+                {
+                    // Forward footstep packet to players if they are within range to hear it
+                    playerManager.SendPacketToOtherPlayers(footstepPacket, sendingPlayer);
+                }
+            }
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -22,15 +22,20 @@ public class FootstepPacketProcessor : AuthenticatedPacketProcessor<FootstepPack
     {
         foreach (Player player in playerManager.GetAllPlayers())
         {
+            if(NitroxVector3.Distance(player.Position, sendingPlayer.Position) >= footstepAudioRange)
+            {
+                continue;
+            }
+            if(player != sendingPlayer)
+            {
+                continue;
+            }
             if (player.SubRootId.HasValue && sendingPlayer.SubRootId.HasValue &&
-                NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
-                player != sendingPlayer &&
                 player.SubRootId.Value == sendingPlayer.SubRootId.Value)
             {
                 player.SendPacket(footstepPacket);
             }
             else if (NitroxVector3.Distance(player.Position, sendingPlayer.Position) <= footstepAudioRange &&
-                    player != sendingPlayer &&
                     !player.SubRootId.HasValue)
             {
                 player.SendPacket(footstepPacket);


### PR DESCRIPTION
Fixes issue #2164 
Does what the title says
- Footstep audio radius is currently set to 20m feel free to change it depending on your preference
- Footstep max audio multiplier is 0.5f, once again feel free to change it depending on your preference
- Server checks for same structure and will not send footstep packets to players who are outside of the sending player's structure
- Footstep sound volume scales with distance
- Uses reflection to create and send footstep packet when local game plays footstep sound