### PR TITLE
Allow chat to refocus from any view

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
@@ -7,11 +7,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions
     {
         public override void Execute()
         {
-            // If no other UWE input field is currently active then allow chat to open.
-            if (FPSInputModule.current.lastGroup == null)
-            {
-                NitroxServiceLocator.LocateService<PlayerChatManager>().SelectChat();
-            }
+            NitroxServiceLocator.LocateService<PlayerChatManager>().SelectChat();
         }
     }
 }


### PR DESCRIPTION
Such as Tab menu (inventory, databank, etc.), ESC menu and such.
Fulfills the second point of #2159.

Could have done this in the previous PR, but being tired at the time I didn't realize there was a second point in the issue.