### PR TITLE
Make sure all unit tests are passing

### DIFF
--- a/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
+++ b/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
@@ -26,6 +26,7 @@ public class PatchesTranspilerTest
         [typeof(CrashHome_Update_Patch), -5],
         [typeof(CreatureDeath_OnKillAsync_Patch), 9],
         [typeof(CreatureDeath_SpawnRespawner_Patch), 2],
+        [typeof(CyclopsDestructionEvent_SpawnLootAsync_Patch), 7],
         [typeof(CyclopsShieldButton_OnClick_Patch), -6],
         [typeof(CyclopsSonarButton_Update_Patch), 3],
         [typeof(CyclopsSonarDisplay_NewEntityOnSonar_Patch), 3],

--- a/NitroxModel/Packets/VehicleMovements.cs
+++ b/NitroxModel/Packets/VehicleMovements.cs
@@ -21,8 +21,11 @@ public class VehicleMovements : Packet
     }
 }
 
+[Serializable]
 public abstract record class MovementData(NitroxId Id, NitroxVector3 Position, NitroxQuaternion Rotation) { }
 
+[Serializable]
 public record class SimpleMovementData(NitroxId Id, NitroxVector3 Position, NitroxQuaternion Rotation) : MovementData(Id, Position, Rotation) { }
 
+[Serializable]
 public record class DrivenVehicleMovementData(NitroxId Id, NitroxVector3 Position, NitroxQuaternion Rotation, sbyte SteeringWheelYaw, sbyte SteeringWheelPitch, bool ThrottleApplied) : MovementData(Id, Position, Rotation) { }


### PR DESCRIPTION
There are still two unit tests (PacketSerializationTest and PacketProcessorTest) that pass when ran individually but fail when ran alongside all the other tests. This might be due to race conditions or problems with how assemblies get loaded during tests.