### PR TITLE
Fix engine speed menu being enabled when engine is off

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using NitroxModel.Helper;
-using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -19,13 +18,16 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
         {
             __instance.hudActive = true;
         }
-        if (__instance.motorMode.engineOn)
+        if (__instance.subLiveMixin.IsAlive())
         {
-            __instance.engineToggleAnimator.SetTrigger("EngineOn");
-        }
-        else
-        {
-            __instance.engineToggleAnimator.SetTrigger("EngineOff");
+            if (__instance.motorMode.engineOn)
+            {
+                __instance.engineToggleAnimator.SetTrigger("EngineOn");
+            }
+            else
+            {
+                __instance.engineToggleAnimator.SetTrigger("EngineOff");
+            }
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -1,5 +1,6 @@
-﻿using System.Reflection;
+using System.Reflection;
 using NitroxModel.Helper;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -17,6 +18,17 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
         else if (!__instance.hudActive)
         {
             __instance.hudActive = true;
+        }
+        if (__instance.subLiveMixin.IsAlive() && !(__instance.engineToggleAnimator.GetCurrentAnimatorStateInfo(0).IsName("StartEngine") || __instance.engineToggleAnimator.GetCurrentAnimatorStateInfo(0).IsName("StopEngine")))
+        {
+            if (__instance.motorMode.engineOn)
+            {
+                __instance.engineToggleAnimator.SetTrigger("EngineOn");
+            }
+            else
+            {
+                __instance.engineToggleAnimator.SetTrigger("EngineOff");
+            }
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -19,16 +19,13 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
         {
             __instance.hudActive = true;
         }
-        if (__instance.subLiveMixin.IsAlive() && !(__instance.engineToggleAnimator.GetCurrentAnimatorStateInfo(0).IsName("StartEngine") || __instance.engineToggleAnimator.GetCurrentAnimatorStateInfo(0).IsName("StopEngine")))
+        if (__instance.motorMode.engineOn)
         {
-            if (__instance.motorMode.engineOn)
-            {
-                __instance.engineToggleAnimator.SetTrigger("EngineOn");
-            }
-            else
-            {
-                __instance.engineToggleAnimator.SetTrigger("EngineOff");
-            }
+            __instance.engineToggleAnimator.SetTrigger("EngineOn");
+        }
+        else
+        {
+            __instance.engineToggleAnimator.SetTrigger("EngineOff");
         }
     }
 }


### PR DESCRIPTION
Seems to just be an issue of the state never being initially effected, or maybe some sort of race condition due to coroutines being used to effect the change in states? Likely will never know, I couldn't find the source myself. The CyclopsHelmHUDManager already sets the engine off text in its update loop, so I just added a bit to the existing Postfix patch for the method to also set the animator trigger that controls the engine speed menu. 