### PR TITLE
UI improvements for player name input

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
@@ -56,6 +56,7 @@ public static class JoinServerBackend
                     Log.InGame(Language.main.Get("Nitrox_WaitingPassword"));
                     MainMenuEnterPasswordPanel.ResetLastEnteredPassword();
                     MainMenuRightSide.main.OpenGroup(MainMenuEnterPasswordPanel.NAME);
+                    MainMenuEnterPasswordPanel.Instance.OnOpened();
                     break;
                 }
 

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
@@ -56,14 +56,14 @@ public static class JoinServerBackend
                     Log.InGame(Language.main.Get("Nitrox_WaitingPassword"));
                     MainMenuEnterPasswordPanel.ResetLastEnteredPassword();
                     MainMenuRightSide.main.OpenGroup(MainMenuEnterPasswordPanel.NAME);
-                    MainMenuEnterPasswordPanel.Instance.OnOpened();
+                    MainMenuEnterPasswordPanel.Instance.FocusPasswordField();
                     break;
                 }
 
                 Log.Info("Waiting for user input");
                 Log.InGame(Language.main.Get("Nitrox_WaitingUserInput"));
                 MainMenuRightSide.main.OpenGroup(MainMenuJoinServerPanel.NAME);
-                MainMenuJoinServerPanel.Instance.OnOpened();
+                MainMenuJoinServerPanel.Instance.FocusNameInputField();
                 break;
 
             case MultiplayerSessionConnectionStage.SESSION_RESERVED:

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
@@ -9,9 +9,9 @@ using NitroxClient.GameLogic.PlayerLogic.PlayerPreferences;
 using NitroxClient.MonoBehaviours.Gui.MainMenu.ServersList;
 using NitroxModel.Core;
 using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
 using NitroxModel.MultiplayerSession;
 using NitroxModel_Subnautica.DataStructures;
-using NitroxModel.Helper;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours.Gui.MainMenu.ServerJoin;
@@ -62,6 +62,7 @@ public static class JoinServerBackend
                 Log.Info("Waiting for user input");
                 Log.InGame(Language.main.Get("Nitrox_WaitingUserInput"));
                 MainMenuRightSide.main.OpenGroup(MainMenuJoinServerPanel.NAME);
+                MainMenuJoinServerPanel.Instance.OnOpened();
                 break;
 
             case MultiplayerSessionConnectionStage.SESSION_RESERVED:

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuEnterPasswordPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuEnterPasswordPanel.cs
@@ -71,21 +71,24 @@ public class MainMenuEnterPasswordPanel : MonoBehaviour, uGUI_INavigableIconGrid
         legendChange.legendButtonConfiguration = confirmButtonButton.GetComponent<mGUI_Change_Legend_On_Select>().legendButtonConfiguration.Take(1).ToArray();
     }
 
-    public void OnOpened() => StartCoroutine(OpenedRoutine());
-
-    private IEnumerator OpenedRoutine()
+    public void FocusPasswordField()
     {
-        passwordInput.Select();
-        EventSystem.current.SetSelectedGameObject(passwordInput.gameObject);
-        yield return null;
-        passwordInput.MoveToEndOfLine(false, true);
+        StartCoroutine(Coroutine());
+
+        IEnumerator Coroutine()
+        {
+            passwordInput.Select();
+            EventSystem.current.SetSelectedGameObject(passwordInput.gameObject);
+            yield return null;
+            passwordInput.MoveToEndOfLine(false, true);
+        }
     }
 
     private void OnConfirmButtonClicked()
     {
         lastEnteredPassword = passwordInput.text;
         MainMenuRightSide.main.OpenGroup(MainMenuJoinServerPanel.NAME);
-        MainMenuJoinServerPanel.Instance.OnOpened();
+        MainMenuJoinServerPanel.Instance.FocusNameInputField();
     }
 
     private static void OnCancelClick()

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuEnterPasswordPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuEnterPasswordPanel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Linq;
 using FMODUnity;
 using NitroxClient.MonoBehaviours.Gui.MainMenu.ServersList;
@@ -15,6 +16,8 @@ public class MainMenuEnterPasswordPanel : MonoBehaviour, uGUI_INavigableIconGrid
 {
     public const string NAME = "MultiplayerEnterPassword";
 
+    public static MainMenuEnterPasswordPanel Instance { get; private set; }
+
     private TMP_InputField passwordInput;
     private mGUI_Change_Legend_On_Select legendChange;
 
@@ -27,6 +30,8 @@ public class MainMenuEnterPasswordPanel : MonoBehaviour, uGUI_INavigableIconGrid
 
     public void Setup(GameObject savedGamesRef)
     {
+        Instance = this;
+
         GameObject multiplayerButtonRef = savedGamesRef.RequireGameObject("Scroll View/Viewport/SavedGameAreaContent/NewGame");
         GameObject generalTextRef = multiplayerButtonRef.GetComponentInChildren<TextMeshProUGUI>().gameObject;
         GameObject inputFieldRef = GameObject.Find("/Menu canvas/Panel/MainMenu/RightSide/Home/EmailBox/InputField");
@@ -37,7 +42,7 @@ public class MainMenuEnterPasswordPanel : MonoBehaviour, uGUI_INavigableIconGrid
         passwordInput = passwordInputGameObject.GetComponent<TMP_InputField>();
         passwordInput.characterValidation = TMP_InputField.CharacterValidation.None;
         passwordInput.onSubmit = new TMP_InputField.SubmitEvent();
-        passwordInput.onSubmit.AddListener(_ => { SelectItemInDirection(0, 1); });
+        passwordInput.onSubmit.AddListener(_ => OnConfirmButtonClicked());
         passwordInput.placeholder.GetComponent<TranslationLiveUpdate>().translationKey = Language.main.Get("Nitrox_JoinServerPlaceholder");
         GameObject passwordInputDesc = Instantiate(generalTextRef, passwordInputGameObject.transform, false);
         passwordInputDesc.transform.localPosition = new Vector3(-200, 0, 0);
@@ -66,10 +71,21 @@ public class MainMenuEnterPasswordPanel : MonoBehaviour, uGUI_INavigableIconGrid
         legendChange.legendButtonConfiguration = confirmButtonButton.GetComponent<mGUI_Change_Legend_On_Select>().legendButtonConfiguration.Take(1).ToArray();
     }
 
+    public void OnOpened() => StartCoroutine(OpenedRoutine());
+
+    private IEnumerator OpenedRoutine()
+    {
+        passwordInput.Select();
+        EventSystem.current.SetSelectedGameObject(passwordInput.gameObject);
+        yield return null;
+        passwordInput.MoveToEndOfLine(false, true);
+    }
+
     private void OnConfirmButtonClicked()
     {
         lastEnteredPassword = passwordInput.text;
         MainMenuRightSide.main.OpenGroup(MainMenuJoinServerPanel.NAME);
+        MainMenuJoinServerPanel.Instance.OnOpened();
     }
 
     private static void OnCancelClick()

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
@@ -138,7 +138,7 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
 
     public void OnOpened() => StartCoroutine(OpenedRoutine());
 
-    public IEnumerator OpenedRoutine()
+    private IEnumerator OpenedRoutine()
     {
         SelectFirstItem();
         yield return new WaitForEndOfFrame();

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
@@ -66,6 +66,8 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
         playerNameInputField.textComponent.GetComponent<RectTransform>().sizeDelta = new Vector2(-20, 42);
         playerNameInputField.characterLimit = 25; // See this.OnJoinClick()
         playerNameInputField.onFocusSelectAll = false;
+        playerNameInputField.onSubmit.AddListener(_ => OnJoinClick());
+        playerNameInputField.onSubmit.AddListener(_ => DeselectAllItems());
         playerNameInputField.ActivateInputField();
 
         //Prepares player color picker

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
@@ -134,7 +134,14 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
         colorPicker.SetHSB(hsb);
     }
 
-    public void OnOpened() => SelectFirstItem();
+    public void OnOpened() => StartCoroutine(OpenedRoutine());
+
+    public IEnumerator OpenedRoutine()
+    {
+        SelectFirstItem();
+        yield return new WaitForEndOfFrame();
+        playerNameInputField.MoveToEndOfLine(false, true);
+    }
 
     public bool OnButtonDown(GameInput.Button button)
     {

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
@@ -65,6 +65,7 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
         playerNameInputField.textComponent.fontSizeMax = 21;
         playerNameInputField.textComponent.GetComponent<RectTransform>().sizeDelta = new Vector2(-20, 42);
         playerNameInputField.characterLimit = 25; // See this.OnJoinClick()
+        playerNameInputField.onFocusSelectAll = false;
         playerNameInputField.ActivateInputField();
 
         //Prepares player color picker
@@ -132,6 +133,8 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
         playerNameInputField.text = playerName;
         colorPicker.SetHSB(hsb);
     }
+
+    public void OnOpened() => SelectFirstItem();
 
     public bool OnButtonDown(GameInput.Button button)
     {

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/MainMenuJoinServerPanel.cs
@@ -136,13 +136,15 @@ public class MainMenuJoinServerPanel : MonoBehaviour, uGUI_INavigableIconGrid, u
         colorPicker.SetHSB(hsb);
     }
 
-    public void OnOpened() => StartCoroutine(OpenedRoutine());
-
-    private IEnumerator OpenedRoutine()
+    public void FocusNameInputField()
     {
-        SelectFirstItem();
-        yield return new WaitForEndOfFrame();
-        playerNameInputField.MoveToEndOfLine(false, true);
+        StartCoroutine(Coroutine());
+        IEnumerator Coroutine()
+        {
+            SelectFirstItem();
+            yield return new WaitForEndOfFrame();
+            playerNameInputField.MoveToEndOfLine(false, true);
+        }
     }
 
     public bool OnButtonDown(GameInput.Button button)


### PR DESCRIPTION
- When the "join server" menu is opened, the player name input field is automatically focused with the cursor at the end
- Pressing enter inside the input field joins the server

I also want to look into a system that automatically deduplicates names for when I open two clients at once. I don't know the best way to do that though. Maybe the client could have the server check if their username is taken, and if it is, the server responds with an alternative username that the client could use.

Closes #2224
Closes #2225