### PR TITLE
macOS fixes

### DIFF
--- a/Nitrox.Launcher/App.axaml
+++ b/Nitrox.Launcher/App.axaml
@@ -1,7 +1,8 @@
-<Application
-    x:Class="Nitrox.Launcher.App"
-    xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Application x:Class="Nitrox.Launcher.App"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Name="Nitrox">
+    
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -10,8 +11,17 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
+    
     <Application.Styles>
         <FluentTheme />
         <StyleInclude Source="/Models/Styles/Nitrox.axaml" />
     </Application.Styles>
+    
+    <!-- Menu that is used on macOS and some Linux distributions -->
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem Header="You are the best captain on this planet" />
+        </NativeMenu>
+    </NativeMenu.Menu>
+    
 </Application>

--- a/Nitrox.Launcher/Models/Behaviors/FocusOnViewShowBehavior.cs
+++ b/Nitrox.Launcher/Models/Behaviors/FocusOnViewShowBehavior.cs
@@ -7,11 +7,18 @@ namespace Nitrox.Launcher.Models.Behaviors;
 /// <summary>
 ///     Focuses the <see cref="Behavior.AssociatedObject" /> when its parent view is shown.
 /// </summary>
-public class SetFocusedOnViewShowBehavior : Behavior<Control>
+public class FocusOnViewShowBehavior : Behavior<Control>
 {
-    public SetFocusedOnViewShowBehavior()
+    protected override void OnAttached()
     {
-        WeakReferenceMessenger.Default.Register<ViewShownMessage>(this, (_, _) => Focus());
+        WeakReferenceMessenger.Default.Register<ViewShownMessage>(this, static (obj, _) => (obj as FocusOnViewShowBehavior)?.Focus());
+        base.OnAttached();
+    }
+
+    protected override void OnDetaching()
+    {
+        WeakReferenceMessenger.Default.UnregisterAll(this);
+        base.OnDetaching();
     }
 
     protected override void OnAttachedToVisualTree() => Focus();

--- a/Nitrox.Launcher/Models/Design/IRoutingScreen.cs
+++ b/Nitrox.Launcher/Models/Design/IRoutingScreen.cs
@@ -2,5 +2,5 @@ namespace Nitrox.Launcher.Models.Design;
 
 public interface IRoutingScreen
 {
-    public object ActiveViewModel { get; set; }
+    object ActiveViewModel { get; set; }
 }

--- a/Nitrox.Launcher/Models/Design/RoutingScreen.cs
+++ b/Nitrox.Launcher/Models/Design/RoutingScreen.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 
 namespace Nitrox.Launcher.Models.Design;
 
@@ -6,4 +8,13 @@ public partial class RoutingScreen : ObservableObject, IRoutingScreen
 {
     [ObservableProperty]
     private object activeViewModel;
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ActiveViewModel))
+        {
+            WeakReferenceMessenger.Default.Send(new ViewShownMessage(ActiveViewModel));
+        }
+        base.OnPropertyChanged(e);
+    }
 }

--- a/Nitrox.Launcher/Models/Extensions/ScreenExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/ScreenExtensions.cs
@@ -47,7 +47,6 @@ public static class ScreenExtensions
         }
         await contentLoadTask;
         screen.ActiveViewModel = routableViewModel;
-        WeakReferenceMessenger.Default.Send(new ViewShownMessage(routableViewModel));
     }
 
     public static async Task<bool> BackAsync(this IRoutingScreen screen)

--- a/Nitrox.Launcher/Models/Messages.cs
+++ b/Nitrox.Launcher/Models/Messages.cs
@@ -1,5 +1,4 @@
 using Nitrox.Launcher.Models.Design;
-using Nitrox.Launcher.ViewModels.Abstract;
 
 namespace Nitrox.Launcher.Models;
 
@@ -12,6 +11,6 @@ public record NotificationAddMessage(NotificationItem Item);
 
 public record NotificationCloseMessage(NotificationItem Item);
 
-public record ViewShownMessage(RoutableViewModelBase ViewModel);
+public record ViewShownMessage(object ViewModel);
 
 public record ServerStatusMessage(ServerEntry Server, bool IsOnline);

--- a/Nitrox.Launcher/ViewModels/EmbeddedServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/EmbeddedServerViewModel.cs
@@ -46,7 +46,7 @@ public partial class EmbeddedServerViewModel : RoutableViewModelBase
             {
                 return;
             }
-            if (!status.IsOnline)
+            if (!status.IsOnline && model.HostScreen.ActiveViewModel is EmbeddedServerViewModel)
             {
                 model.HostScreen.BackAsync().ConfigureAwait(false);
             }

--- a/Nitrox.Launcher/Views/CreateServerModal.axaml
+++ b/Nitrox.Launcher/Views/CreateServerModal.axaml
@@ -32,7 +32,7 @@
                         Text="{Binding Name, Converter={converters:TrimConverter}}"
                         Watermark="My server">
                         <Interaction.Behaviors>
-                            <behaviors:SetFocusedOnViewShowBehavior />
+                            <behaviors:FocusOnViewShowBehavior />
                         </Interaction.Behaviors>
                     </TextBox>
                 </StackPanel>

--- a/Nitrox.Launcher/Views/EmbeddedServerView.axaml
+++ b/Nitrox.Launcher/Views/EmbeddedServerView.axaml
@@ -109,7 +109,7 @@
                 Watermark="A server command here"
                 x:Name="ServerCommandTextBox">
                 <Interaction.Behaviors>
-                    <behaviors:SetFocusedOnViewShowBehavior />
+                    <behaviors:FocusOnViewShowBehavior />
                 </Interaction.Behaviors>
             </TextBox>
             <StackPanel

--- a/Nitrox.Launcher/Views/LaunchGameView.axaml
+++ b/Nitrox.Launcher/Views/LaunchGameView.axaml
@@ -73,7 +73,7 @@
                                         Command="{Binding StartMultiplayerCommand}"
                                         ToolTip.Tip="Launch Subnautica with multiplayer enabled">
                                         <Interaction.Behaviors>
-                                            <behaviors:SetFocusedOnViewShowBehavior />
+                                            <behaviors:FocusOnViewShowBehavior />
                                         </Interaction.Behaviors>
                                         <StackPanel>
                                             <TextBlock Text="PLAY" />

--- a/Nitrox.Launcher/Views/MainWindow.axaml
+++ b/Nitrox.Launcher/Views/MainWindow.axaml
@@ -52,14 +52,19 @@
                 <Setter Property="ToolTip.Placement" Value="Pointer" />
                 <Setter Property="Template">
                     <ControlTemplate>
-                        <Panel Background="{TemplateBinding Background}" HorizontalAlignment="Stretch">
-                            <StackPanel
-                                Margin="{TemplateBinding Padding}"
-                                Orientation="Horizontal"
-                                Spacing="10">
-                                <Image Source="{TemplateBinding Tag, Converter={converters:BitmapAssetValueConverter}}" />
-                                <TextBlock FontSize="{TemplateBinding FontSize}" Text="{TemplateBinding Content}" />
-                            </StackPanel>
+                        <Panel Background="{TemplateBinding Background}"
+                               HorizontalAlignment="Stretch">
+                            <Grid Margin="{TemplateBinding Padding}"
+                                  ColumnDefinitions="48,*">
+                                <Image Grid.Column="0"
+                                       Source="{TemplateBinding Tag, Converter={converters:BitmapAssetValueConverter}}"
+                                       Stretch="UniformToFill" />
+                                <TextBlock Grid.Column="1"
+                                           TextAlignment="Start"
+                                           VerticalAlignment="Center"
+                                           FontSize="{TemplateBinding FontSize}"
+                                           Text="{TemplateBinding Content}" />
+                            </Grid>
                         </Panel>
                     </ControlTemplate>
                 </Setter>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -405,27 +405,37 @@
             Grid.Row="2"
             Padding="25,17">
             <Grid
-                ColumnDefinitions="*,1*"
+                ColumnDefinitions="*,*"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <StackPanel
-                    Background="Transparent"
-                    Grid.Column="0"
-                    IsEnabled="{OnPlatform {Binding !ServerIsOnline},
-                                           macOS={x:False}}"
-                    ToolTip.ShowOnDisabled="True"
-                    ToolTip.Tip="{OnPlatform {x:Null},
-                                             macOS='External server console is not available for MacOS'}">
-                    <RadioButton
-                        Content="External"
-                        IsChecked="{Binding !ServerEmbedded}"
-                        ToolTip.ShowOnDisabled="False"
-                        ToolTip.Tip="Run server in external mode as a separate command line window" />
-                    <RadioButton
-                        Content="Embedded"
-                        IsChecked="{Binding ServerEmbedded}"
-                        ToolTip.ShowOnDisabled="False"
-                        ToolTip.Tip="Run server in embedded mode within the launcher UI" />
+                <StackPanel Grid.Column="0"
+                            IsEnabled="{Binding !ServerIsOnline}"
+                            Background="Transparent">
+                    <OnPlatform>
+                        <OnPlatform.Default>
+                            <StackPanel>
+                                <RadioButton Content="External"
+                                             GroupName="Choose runtime option"
+                                             IsChecked="{Binding !ServerEmbedded}"
+                                             ToolTip.ShowOnDisabled="True"
+                                             ToolTip.Tip="Run server in external mode as a separate command line window" />
+                            
+                                <RadioButton Content="Embedded"
+                                             GroupName="Choose runtime option"
+                                             IsChecked="{Binding ServerEmbedded}"
+                                             ToolTip.ShowOnDisabled="True"
+                                             ToolTip.Tip="Run server in embedded mode within the launcher UI" />
+                            </StackPanel>
+                        </OnPlatform.Default>
+                        
+                        <OnPlatform.macOS>
+                            <RadioButton Content="Embedded"
+                                         GroupName="Choose runtime option"
+                                         IsChecked="True"
+                                         ToolTip.ShowOnDisabled="True"
+                                         ToolTip.Tip="Run server in embedded mode within the launcher UI" />
+                        </OnPlatform.macOS>
+                    </OnPlatform>
                 </StackPanel>
 
                 <Panel Grid.Column="1" HorizontalAlignment="Stretch">

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -187,7 +187,7 @@
                             Text="{Binding ServerName, Converter={converters:TrimConverter}}"
                             Watermark="My server">
                             <Interaction.Behaviors>
-                                <behaviors:SetFocusedOnViewShowBehavior />
+                                <behaviors:FocusOnViewShowBehavior />
                             </Interaction.Behaviors>
                         </TextBox>
                     </StackPanel>


### PR DESCRIPTION
* Application name is overriden by informations we provide inside Info.plist upon macOS publish, but does not work inside IDE since this file does not exist
* Provide a basic native menu on macOS to avoid Avalonia emitting a default menu that displays a popup Nitrox is not aware and compatible of
* OnPlatform does not properly work with semi-binding, static providers, causing NRE on macOS