### PR TITLE
Fix SeaTreader_SetNextPathPoint not emitting metadata changes

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/SeaTreader_SetNextPathPoint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaTreader_SetNextPathPoint_Patch.cs
@@ -11,7 +11,7 @@ public sealed partial class SeaTreader_SetNextPathPoint_Patch : NitroxPatch, IDy
 {
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((SeaTreader t) => t.SetNextPathPoint());
 
-    public static void Prefix(SeaTreader __instance)
+    public static void Postfix(SeaTreader __instance)
     {
         if (__instance.TryGetNitroxId(out NitroxId creatureId) &&
             Resolve<SimulationOwnership>().HasAnyLockType(creatureId))


### PR DESCRIPTION
Since some internal metadata of the SeaTreader are modified inside the method, we should extract and send metadata changes after this method is called

![image](https://github.com/user-attachments/assets/c2d6d01b-1b4b-4a2a-a466-22f044365c70)
