### PR TITLE
Fix warpme command not sending escape pod changed packet

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/EscapePod_RespawnPlayer_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_RespawnPlayer_Patch.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using HarmonyLib;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.Util;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class EscapePod_RespawnPlayer_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((EscapePod t) => t.RespawnPlayer());
+
+    public static void Postfix(EscapePod __instance)
+    {
+        // LifePod.RespawnPlayer() runs both for player respawn (Player.MovePlayerToRespawnPoint()) and for warpme command
+        Optional<NitroxId> id = __instance.GetId();
+        Resolve<LocalPlayer>().BroadcastEscapePodChange(id);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_RespawnPlayer_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_RespawnPlayer_Patch.cs
@@ -13,7 +13,7 @@ public sealed partial class EscapePod_RespawnPlayer_Patch : NitroxPatch, IDynami
 
     public static void Postfix(EscapePod __instance)
     {
-        // LifePod.RespawnPlayer() runs both for player respawn (Player.MovePlayerToRespawnPoint()) and for warpme command
+        // EscapePod.RespawnPlayer() runs both for player respawn (Player.MovePlayerToRespawnPoint()) and for warpme command
         Optional<NitroxId> id = __instance.GetId();
         Resolve<LocalPlayer>().BroadcastEscapePodChange(id);
     }

--- a/NitroxPatcher/Patches/Dynamic/Player_MovePlayerToRespawnPoint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_MovePlayerToRespawnPoint_Patch.cs
@@ -23,6 +23,6 @@ public sealed partial class Player_MovePlayerToRespawnPoint_Patch : NitroxPatch,
 
         Resolve<LocalPlayer>().BroadcastSubrootChange(currentSubId);
         
-        // spawning in the escape pod is handled by EscapePod_RespawnPlayer_Patch for cross-functionality with the warpme command 
+        // BroadcastEscapePodChange() is handled by EscapePod_RespawnPlayer_Patch for cross-functionality with the warpme command 
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Player_MovePlayerToRespawnPoint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_MovePlayerToRespawnPoint_Patch.cs
@@ -21,13 +21,8 @@ public sealed partial class Player_MovePlayerToRespawnPoint_Patch : NitroxPatch,
             currentSubId = __instance.currentSub.GetId();
         }
 
-        Optional<NitroxId> currentEscapePodId = Optional.Empty;
-        if (__instance.currentEscapePod)
-        {
-            currentEscapePodId = __instance.currentEscapePod.GetId();
-        }
-
         Resolve<LocalPlayer>().BroadcastSubrootChange(currentSubId);
-        Resolve<LocalPlayer>().BroadcastEscapePodChange(currentEscapePodId);
+        
+        // spawning in the escape pod is handled by EscapePod_RespawnPlayer_Patch for cross-functionality with the warpme command 
     }
 }


### PR DESCRIPTION
Fixes issue #2238:

"warpme" command now correctly broadcasts the EscapePodChange packet when teleporting the player into the lifepod.
Adds patch (EscapePod_RespawnPlayer_Patch) to hook the function that respawns the player into the lifepod, either after a death or a "warpme".

Now-redundant code removed from Player_MovePlayerToRespawnPoint_Patch.