### PR TITLE
Fixes #2318, battery/power cell in chargers disappearing on resync

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -123,7 +123,7 @@ public class BuildingResyncProcessor : ClientPacketProcessor<BuildingResync>
         Log.Info($"[Base RESYNC] Overwriting base with id {buildEntity.Id}");
         ClearBaseChildren(@base);
         // Frame to let all children be deleted properly
-        yield return null;
+        yield return Yielders.WaitForEndOfFrame;
 
         yield return BuildEntitySpawner.SetupBase(buildEntity, @base, entities);
         yield return MoonpoolManager.RestoreMoonpools(buildEntity.ChildEntities.OfType<MoonpoolEntity>(), @base);

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -122,6 +122,9 @@ public class BuildingResyncProcessor : ClientPacketProcessor<BuildingResync>
     {
         Log.Info($"[Base RESYNC] Overwriting base with id {buildEntity.Id}");
         ClearBaseChildren(@base);
+        // Frame to let all children be deleted properly
+        yield return null;
+
         yield return BuildEntitySpawner.SetupBase(buildEntity, @base, entities);
         yield return MoonpoolManager.RestoreMoonpools(buildEntity.ChildEntities.OfType<MoonpoolEntity>(), @base);
         yield return entities.SpawnBatchAsync(buildEntity.ChildEntities.OfType<PlayerWorldEntity>().ToList<Entity>(), false, false);

--- a/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
@@ -43,14 +43,19 @@ public class ModuleEntitySpawner : EntitySpawner<ModuleEntity>
             yield break;
         }
         GameObject moduleObject = result.Get().Value;
+        
         Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(moduleObject);
-        if (!opContainer.HasValue)
+        if (opContainer.HasValue)
         {
-            yield break;
+            yield return entities.SpawnBatchAsync(entity.ChildEntities.OfType<InventoryItemEntity>().ToList<Entity>(), true);
         }
 
-        yield return entities.SpawnBatchAsync(entity.ChildEntities.OfType<InventoryItemEntity>().ToList<Entity>(), true);
-
+        Optional<Equipment> opEquipment = EquipmentHelper.FindEquipmentComponent(moduleObject);
+        if (opEquipment.HasValue)
+        {
+            yield return entities.SpawnBatchAsync(entity.ChildEntities.OfType<InstalledModuleEntity>().ToList<Entity>(), true);
+        }
+        
         if (moduleObject.TryGetComponent(out PowerSource powerSource))
         {
             // TODO: Have synced/restored power

--- a/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
@@ -80,7 +80,16 @@ public class InstalledModuleEntitySpawner : SyncEntitySpawner<InstalledModuleEnt
         Pickupable pickupable = gameObject.RequireComponent<Pickupable>();
         pickupable.Initialize();
 
-        InventoryItem inventoryItem = new(pickupable);
-        equipment.AddItem(entity.Slot, inventoryItem, true);
+        InventoryItem inventoryItem = new(pickupable)
+        {
+            container = equipment
+        };
+        inventoryItem.item.Reparent(equipment.tr);
+
+        equipment.equipment[entity.Slot] = inventoryItem;
+
+        equipment.UpdateCount(pickupable.GetTechType(), true);
+        Equipment.SendEquipmentEvent(pickupable, 0, parentObject, entity.Slot);
+        equipment.NotifyEquip(entity.Slot, inventoryItem);
     }
 }

--- a/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InstalledModuleEntitySpawner.cs
@@ -80,16 +80,7 @@ public class InstalledModuleEntitySpawner : SyncEntitySpawner<InstalledModuleEnt
         Pickupable pickupable = gameObject.RequireComponent<Pickupable>();
         pickupable.Initialize();
 
-        InventoryItem inventoryItem = new(pickupable)
-        {
-            container = equipment
-        };
-        inventoryItem.item.Reparent(equipment.tr);
-
-        equipment.equipment[entity.Slot] = inventoryItem;
-
-        equipment.UpdateCount(pickupable.GetTechType(), true);
-        Equipment.SendEquipmentEvent(pickupable, 0, parentObject, entity.Slot);
-        equipment.NotifyEquip(entity.Slot, inventoryItem);
+        InventoryItem inventoryItem = new(pickupable);
+        equipment.AddItem(entity.Slot, inventoryItem, true);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_OnDestroy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_OnDestroy_Patch.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using NitroxClient.GameLogic.Bases;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class Pickupable_OnDestroy_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Pickupable t) => t.OnDestroy());
+
+    public static bool Prefix(Pickupable __instance)
+    {
+        // stops Pickupable.OnDestroy from triggering the OnDestroy function if BuildingHandler is Resyncing
+        // this stops the IItemsContainer.RemoveItem() method from being called which broadcasts a packet in some implementations 
+        if (BuildingHandler.Main.Resyncing)
+        {
+            __instance.isDestroyed = true;
+            return false;
+        }
+
+        return true;
+    }
+    
+}

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_OnDestroy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_OnDestroy_Patch.cs
@@ -10,7 +10,7 @@ public sealed partial class Pickupable_OnDestroy_Patch : NitroxPatch, IDynamicPa
 
     public static bool Prefix(Pickupable __instance)
     {
-        // stops Pickupable.OnDestroy from triggering the OnDestroy function if BuildingHandler is Resyncing
+        // Stops Pickupable.OnDestroy from triggering the OnDestroy function if BuildingHandler is Resyncing
         // this stops the IItemsContainer.RemoveItem() method from being called which broadcasts a packet in some implementations 
         if (BuildingHandler.Main.Resyncing)
         {
@@ -20,5 +20,4 @@ public sealed partial class Pickupable_OnDestroy_Patch : NitroxPatch, IDynamicPa
 
         return true;
     }
-    
 }


### PR DESCRIPTION
Fixes issue #2318 where batteries and power cells would disappear after rejoining the game or using the building resync feature.

`ModuleEntitySpawner` now spawns `InstalledModuleEntity` child entities as well as `InventoryItemEntity`. Previously batteries/powercells would not be spawned because of this.

~When the charger was restored in preparation for the resync it would broadcast `ModuleRemoved` for each battery and cause them to be lost. `InstalledModuleEntitySpawner` now uses the `Equipment.AddItem()` method instead of inlining the same steps, which broadcasts `ModuleAdded`.~
