### PR TITLE
Various Nitrox Launcher Improvements

### DIFF
--- a/Nitrox.Launcher/Models/Design/BackupItem.cs
+++ b/Nitrox.Launcher/Models/Design/BackupItem.cs
@@ -2,4 +2,4 @@
 
 namespace Nitrox.Launcher.Models.Design;
 
-public record BackupItem(DateTime BackupDate, string BackupFileName);
+public record BackupItem(string BackupName, string BackupFilePath);

--- a/Nitrox.Launcher/Models/Validators/BackupAttribute.cs
+++ b/Nitrox.Launcher/Models/Validators/BackupAttribute.cs
@@ -16,11 +16,11 @@ public sealed class BackupAttribute : TypedValidationAttribute<BackupItem>
         {
             return new ValidationResult($"{context.DisplayName} must not be null.");
         }
-        if (value.BackupFileName == null || value.BackupFileName.AsSpan().Trim().IsEmpty)
+        if (value.BackupFilePath == null || value.BackupFilePath.AsSpan().Trim().IsEmpty)
         {
             return new ValidationResult($"{context.DisplayName} must have a backup path assigned");
         }
-        if (!File.Exists(value.BackupFileName))
+        if (!File.Exists(value.BackupFilePath))
         {
             return new ValidationResult($"{context.DisplayName} must point to a valid file.");
         }

--- a/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
@@ -63,6 +63,14 @@ public partial class BackupRestoreViewModel : ModalViewModelBase
 
                          string dateTimePart = fileName["Backup - ".Length..];
                          return DateTime.TryParseExact(dateTimePart, WorldPersistence.BACKUP_DATE_TIME_FORMAT, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+                     })
+                     .OrderByDescending(file =>
+                     {
+                         string fileName = Path.GetFileNameWithoutExtension(file);
+                         string dateTimePart = fileName["Backup - ".Length..];
+                         return DateTime.TryParseExact(dateTimePart, WorldPersistence.BACKUP_DATE_TIME_FORMAT, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime parsedDate)
+                             ? parsedDate
+                             : File.GetCreationTime(file);
                      });
 
         if (saveDirectory == null)
@@ -75,13 +83,16 @@ public partial class BackupRestoreViewModel : ModalViewModelBase
             yield break;
         }
 
+        int i = 0;
         foreach (string backupPath in GetBackupFilePaths(backupDir))
         {
             if (!DateTime.TryParseExact(Path.GetFileNameWithoutExtension(backupPath)["Backup - ".Length..], WorldPersistence.BACKUP_DATE_TIME_FORMAT, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime backupDate))
             {
                 backupDate = File.GetCreationTime(backupPath);
             }
-            yield return new BackupItem(backupDate, backupPath);
+            i++;
+            string backupName = $"[b]Backup {i})[/b]\t{backupDate}";
+            yield return new BackupItem(backupName, backupPath);
         }
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -319,6 +319,7 @@ public partial class ManageServerViewModel : RoutableViewModelBase
             model.Title = $"Server '{ServerName}' config editor";
             model.FieldAcceptFilter = p => !advancedSettingsDeniedFields.Any(v => p.Name.Contains(v, StringComparison.OrdinalIgnoreCase));
             model.OwnerObject = Config.Load(SaveFolderDirectory);
+            model.DisableButtons = Server.IsOnline;
         });
         if (result && result.OwnerObject is Config config)
         {

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -40,45 +40,45 @@ public partial class ManageServerViewModel : RoutableViewModelBase
     private readonly ServerService serverService;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private bool serverAllowCommands;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private bool serverAllowLanDiscovery;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private bool serverAutoPortForward;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [Range(10, 86400, ErrorMessage = "Value must be between 10s and 24 hours (86400s).")]
     private int serverAutoSaveInterval;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private Perms serverDefaultPlayerPerm;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private NitroxGameMode serverGameMode;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private Bitmap serverIcon;
 
     private string serverIconDir;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [Range(1, 1000)]
     [NotifyDataErrorInfo]
     private int serverMaxPlayers;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [Required]
     [FileName]
@@ -87,21 +87,21 @@ public partial class ManageServerViewModel : RoutableViewModelBase
     private string serverName;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private string serverPassword;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     private int serverPlayers;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [Range(ushort.MinValue, ushort.MaxValue)]
     private int serverPort;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(StartServerCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [NitroxWorldSeed]
     private string serverSeed;
@@ -252,6 +252,7 @@ public partial class ManageServerViewModel : RoutableViewModelBase
         BackCommand.NotifyCanExecuteChanged();
         StartServerCommand.NotifyCanExecuteChanged();
         UndoCommand.NotifyCanExecuteChanged();
+        RestoreBackupCommand.NotifyCanExecuteChanged();
         SaveCommand.NotifyCanExecuteChanged();
     }
 
@@ -337,7 +338,7 @@ public partial class ManageServerViewModel : RoutableViewModelBase
             UseShellExecute = true
         })?.Dispose();
 
-    [RelayCommand(CanExecute = nameof(CanRestoreBackupAndDeleteServer))]
+    [RelayCommand(CanExecute = nameof(CanRestoreBackup))]
     private async Task RestoreBackup()
     {
         BackupRestoreViewModel result = await dialogService.ShowAsync<BackupRestoreViewModel>(model =>
@@ -368,13 +369,15 @@ public partial class ManageServerViewModel : RoutableViewModelBase
         }
     }
 
-    [RelayCommand(CanExecute = nameof(CanRestoreBackupAndDeleteServer))]
+    private bool CanRestoreBackup() => !ServerIsOnline && !HasChanges();
+
+    [RelayCommand(CanExecute = nameof(CanDeleteServer))]
     private async Task DeleteServerAsync()
     {
         await CoreDeleteServerAsync();
     }
 
-    [RelayCommand(CanExecute = nameof(CanRestoreBackupAndDeleteServer))]
+    [RelayCommand(CanExecute = nameof(CanDeleteServer))]
     private async Task ForceDeleteServerAsync()
     {
         await CoreDeleteServerAsync(true);
@@ -407,7 +410,7 @@ public partial class ManageServerViewModel : RoutableViewModelBase
         }
     }
 
-    private bool CanRestoreBackupAndDeleteServer() => !ServerIsOnline;
+    private bool CanDeleteServer() => !ServerIsOnline;
 
     partial void OnServerEmbeddedChanged(bool value)
     {

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -349,7 +349,7 @@ public partial class ManageServerViewModel : RoutableViewModelBase
 
         if (result)
         {
-            string backupFile = result.SelectedBackup.BackupFileName;
+            string backupFile = result.SelectedBackup.BackupFilePath;
             try
             {
                 if (!File.Exists(backupFile))

--- a/Nitrox.Launcher/ViewModels/ObjectPropertyEditorViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ObjectPropertyEditorViewModel.cs
@@ -35,6 +35,8 @@ public partial class ObjectPropertyEditorViewModel : ModalViewModelBase
     /// </summary>
     public Func<PropertyInfo, bool> FieldAcceptFilter { get; set; } = _ => true;
 
+    public bool DisableButtons { get; set; }
+
     public ObjectPropertyEditorViewModel() : this(null)
     {
     }

--- a/Nitrox.Launcher/Views/BackupRestoreModal.axaml
+++ b/Nitrox.Launcher/Views/BackupRestoreModal.axaml
@@ -62,10 +62,7 @@
                     </ListBox.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <StackPanel Orientation="Horizontal" ToolTip.Tip="{Binding BackupFileName}">
-                                <TextBlock Text="Backup " />
-                                <TextBlock Text="{Binding BackupDate}" />
-                            </StackPanel>
+                            <controls:RichTextBlock Text="{Binding BackupName}" ToolTip.Tip="{Binding BackupFilePath}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ListBox>

--- a/Nitrox.Launcher/Views/DialogBoxModal.axaml
+++ b/Nitrox.Launcher/Views/DialogBoxModal.axaml
@@ -1,5 +1,6 @@
 <Window
     CanResize="False"
+    MaxHeight="1080"
     MaxWidth="1000"
     MinWidth="400"
     SizeToContent="WidthAndHeight"

--- a/Nitrox.Launcher/Views/ObjectPropertyEditorModal.axaml
+++ b/Nitrox.Launcher/Views/ObjectPropertyEditorModal.axaml
@@ -58,7 +58,8 @@
                                         <StackPanel Classes="form" DataContext="{Binding $parent[ContentPresenter].Parent.((design:EditorField)DataContext)}">
                                             <TextBlock Text="{Binding PropertyInfo.Name}" />
                                             <TextBlock Text="{Binding Description}" />
-                                            <TextBox Text="{Binding Value, Mode=TwoWay}" />
+                                            <TextBox Text="{Binding Value, Mode=TwoWay}"
+                                                     IsEnabled="{Binding !$parent[ItemsControl].((vm:ObjectPropertyEditorViewModel)DataContext).DisableButtons}" />
                                         </StackPanel>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type system:Boolean}">
@@ -68,28 +69,32 @@
                                             <CheckBox
                                                 Classes="switch"
                                                 HorizontalAlignment="Left"
-                                                IsChecked="{Binding Value}" />
+                                                IsChecked="{Binding Value}"
+                                                IsEnabled="{Binding !$parent[ItemsControl].((vm:ObjectPropertyEditorViewModel)DataContext).DisableButtons}" />
                                         </StackPanel>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type system:Int32}">
                                         <StackPanel Classes="form" DataContext="{Binding $parent[ContentPresenter].Parent.((design:EditorField)DataContext)}">
                                             <TextBlock Text="{Binding PropertyInfo.Name}" />
                                             <TextBlock Text="{Binding Description}" />
-                                            <NumericUpDown Value="{Binding Value, Mode=TwoWay}" />
+                                            <NumericUpDown Value="{Binding Value, Mode=TwoWay}"
+                                                           IsEnabled="{Binding !$parent[ItemsControl].((vm:ObjectPropertyEditorViewModel)DataContext).DisableButtons}" />
                                         </StackPanel>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type system:Single}">
                                         <StackPanel Classes="form" DataContext="{Binding $parent[ContentPresenter].Parent.((design:EditorField)DataContext)}">
                                             <TextBlock Text="{Binding PropertyInfo.Name}" />
                                             <TextBlock Text="{Binding Description}" />
-                                            <NumericUpDown Value="{Binding Value, Mode=TwoWay}" />
+                                            <NumericUpDown Value="{Binding Value, Mode=TwoWay}"
+                                                           IsEnabled="{Binding !$parent[ItemsControl].((vm:ObjectPropertyEditorViewModel)DataContext).DisableButtons}" />
                                         </StackPanel>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type system:Object}">
                                         <StackPanel Classes="form" DataContext="{Binding $parent[ContentPresenter].Parent.((design:EditorField)DataContext)}">
                                             <TextBlock Text="{Binding PropertyInfo.Name}" />
                                             <TextBlock Text="{Binding Description}" />
-                                            <ComboBox ItemsSource="{Binding PossibleValues}" SelectedValue="{Binding Value}">
+                                            <ComboBox ItemsSource="{Binding PossibleValues}" SelectedValue="{Binding Value}"
+                                                      IsEnabled="{Binding !$parent[ItemsControl].((vm:ObjectPropertyEditorViewModel)DataContext).DisableButtons}">
                                                 <ComboBox.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Text="{Binding Converter={converters:ToStringConverter}}" />
@@ -118,7 +123,8 @@
                     Command="{Binding SaveCommand}"
                     Content="Save"
                     HorizontalAlignment="Right"
-                    HotKey="Enter" />
+                    HotKey="Enter"
+                    IsEnabled="{Binding !DisableButtons}" />
             </Panel>
         </Border>
 


### PR DESCRIPTION
The goal of this PR is to further polish the Nitrox launcher before the next release. Some of the below TODOs may be pushed for a future release.

**TODO:**
- [x] Make Server Imbed/external radio buttons automatically save and apply its setting instead of requiring user input to save.
- [x] Starting an external server from ManageServerView doesn't disable advanced settings buttons (needs to be disabled).
- [x] Disable "Restore Backup" button when changes are made to ManageServerView settings.
- [x] Improvements to Restore Backup window (better naming, reversing list order so that it's descending by dates).
- [ ] Add a Dialog Box for running a second server on the same port as the first (ask to change port of second server).
- [ ] Fix server crashing not allowing server to be stopped when imbedded (10 second timeout w/ dialog box asking if user wants to force shutdown the server).
- [ ] Add launcher feature to find external servers that are already running and set those as running (send input to/read output from the pipe for imbedded servers).
- [ ] Implement autocomplete for commands in EmbeddedServerView.
- [ ] Implement Light Mode?
- [ ] Fix multi-line selection in ImbeddedServerView (I'm already several hours into this one to no avail).

Feel free to make any more suggestions for Launcher Improvements that could be included in this PR.