### PR TITLE
Support port checkers

### DIFF
--- a/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton<CommunityView>();
         collection.AddSingleton<UpdatesView>();
         collection.AddSingleton<EmbeddedServerView>();
+        collection.AddSingleton<TroubleshootingView>();
 
         // ViewModels
         collection.AddTransient<MainWindowViewModel>();
@@ -56,6 +57,7 @@ public static class ServiceCollectionExtensions
         collection.AddTransient<CommunityViewModel>();
         collection.AddTransient<UpdatesViewModel>();
         collection.AddTransient<EmbeddedServerViewModel>();
+        collection.AddTransient<TroubleshootingViewModel>();
 
         return collection;
     }

--- a/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
@@ -28,6 +28,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly UpdatesViewModel updatesViewModel;
     private readonly IDialogService dialogService;
     private readonly ServerService serverService;
+    private readonly TroubleshootingViewModel troubleshootingViewModel;
 
     [ObservableProperty]
     private bool updateAvailableOrUnofficial;
@@ -53,7 +54,8 @@ public partial class MainWindowViewModel : ViewModelBase
         UpdatesViewModel updatesViewModel,
         OptionsViewModel optionsViewModel,
         IDialogService dialogService,
-        ServerService serverService
+        ServerService serverService,
+        TroubleshootingViewModel troubleshootingViewModel
     )
     {
         this.launchGameViewModel = launchGameViewModel;
@@ -65,6 +67,7 @@ public partial class MainWindowViewModel : ViewModelBase
         this.routingScreen = routingScreen;
         this.dialogService = dialogService;
         this.serverService = serverService;
+        this.troubleshootingViewModel = troubleshootingViewModel;
 
         this.RegisterMessageListener<ViewShownMessage, MainWindowViewModel>(static (message, vm) => vm.ActiveViewModel = message.ViewModel);
         this.RegisterMessageListener<NotificationAddMessage, MainWindowViewModel>(static async (message, vm) =>
@@ -139,6 +142,12 @@ public partial class MainWindowViewModel : ViewModelBase
     public async Task OpenOptionsViewAsync()
     {
         await RoutingScreen.ShowAsync(optionsViewModel);
+    }
+
+    [RelayCommand(AllowConcurrentExecutions = false)]
+    public async Task OpenTroubleshootingViewAsync()
+    {
+        await RoutingScreen.ShowAsync(troubleshootingViewModel);
     }
 
     [RelayCommand]

--- a/Nitrox.Launcher/ViewModels/TroubleshootingViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/TroubleshootingViewModel.cs
@@ -1,0 +1,16 @@
+using Nitrox.Launcher.ViewModels.Abstract;
+using NitroxModel.Helper;
+
+namespace Nitrox.Launcher.ViewModels;
+public partial class TroubleshootingViewModel : RoutableViewModelBase
+{
+    private readonly IKeyValueStore keyValueStore;
+
+    public TroubleshootingViewModel()
+    {
+    }
+    public TroubleshootingViewModel(IKeyValueStore keyValueStore)
+    {
+        this.keyValueStore = keyValueStore;
+    }
+}

--- a/Nitrox.Launcher/ViewModels/TroubleshootingViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/TroubleshootingViewModel.cs
@@ -4,13 +4,8 @@ using NitroxModel.Helper;
 namespace Nitrox.Launcher.ViewModels;
 public partial class TroubleshootingViewModel : RoutableViewModelBase
 {
-    private readonly IKeyValueStore keyValueStore;
 
     public TroubleshootingViewModel()
     {
-    }
-    public TroubleshootingViewModel(IKeyValueStore keyValueStore)
-    {
-        this.keyValueStore = keyValueStore;
     }
 }

--- a/Nitrox.Launcher/Views/MainWindow.axaml
+++ b/Nitrox.Launcher/Views/MainWindow.axaml
@@ -266,6 +266,21 @@
                                     </Binding>
                                 </RadioButton.IsChecked>
                             </RadioButton>
+                          <RadioButton
+                            Command="{Binding OpenTroubleshootingViewCommand}"
+                            Content="Troubleshooting"
+                            Tag="/Assets/Images/tabs-icons/options.png"
+                            ToolTip.Tip="Find solutions to issues with Nitrox">
+                            <RadioButton.IsChecked>
+                              <Binding Path="ActiveViewModel" Converter="{converters:IsTypeConverter}" Mode="OneWay">
+                                <Binding.ConverterParameter>
+                                  <generic:List x:TypeArguments="system:Type">
+                                    <x:Type TypeName="vm:TroubleshootingViewModel" />
+                                  </generic:List>
+                                </Binding.ConverterParameter>
+                              </Binding>
+                            </RadioButton.IsChecked>
+                          </RadioButton>
                         </StackPanel>
                     </Panel>
                 </Grid>
@@ -340,6 +355,9 @@
                         <DataTemplate x:DataType="vm:OptionsViewModel">
                             <views:OptionsView />
                         </DataTemplate>
+                      <DataTemplate x:DataType="vm:TroubleshootingViewModel">
+                        <views:TroubleshootingView />
+                      </DataTemplate>
                         <!--  Fallback view. This DataTemplate must be kept at the bottom.  -->
                         <DataTemplate x:DataType="system:Object">
                             <TextBlock>

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml
@@ -10,14 +10,53 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Nitrox.Launcher.ViewModels"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <Grid ColumnDefinitions="Auto, Auto" RowDefinitions="Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
-  <TextBlock Text="Enable port checking" FontSize="20" Grid.Column="0" Grid.Row="0"/>
-  <CheckBox
-        Classes="switch"
-        Checked="EnablePortChecking"
-        Unchecked="DisablePortChecking"
-        Grid.Column="1"
-        Margin="30,0,0,0"
-        Grid.Row="0"/>
+  <StackPanel>
+  <TextBlock
+  Text="Troubleshooting"
+  Margin="100,0,0,0"
+  FontSize="48"
+  Grid.Row="0"
+  Grid.Column="0"/>
+  <Grid
+    ColumnDefinitions="Auto,Auto,Auto"
+    RowDefinitions="Auto, Auto"
+    HorizontalAlignment="Center"
+    Margin="0,50,0,0">
+  <TextBlock
+    Text="Enable port checking"
+    FontSize="20"
+    Grid.Column="0"
+    Grid.Row="0"/>
+    <Button
+      Name="PortForwardCheckButton"
+      Content="Start"
+      Click="OnPortForwardClick"
+      Margin="30,0,0,0"
+      Grid.Row="0"
+      Grid.Column="1"
+      Classes="primary"/>
+    <TextBlock
+      Text="Status:"
+      FontSize="16"
+      Grid.Column="0"
+      Grid.Row="1"
+      Margin="0,25,0,0"/>
+    <Ellipse
+      Name="PortForwardStatusCircle"
+      Width="25"
+      Height="25"
+      Fill="DarkGray"
+      Grid.Column="1"
+      Grid.Row="1"
+      Margin="0,25,0,0"/>
+    <TextBlock
+      Name="PortForwardStatusText"
+      Text="Not started"
+      FontSize="16"
+      Foreground="DarkGray"
+      Grid.Column="2"
+      Grid.Row="1"
+      Margin="0,25,0,0"/>
   </Grid>
+  </StackPanel>
 </UserControl>

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml
@@ -10,6 +10,14 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Nitrox.Launcher.ViewModels"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-    <TextBlock Text="Hello, World!" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="24"/>
+  <Grid ColumnDefinitions="Auto, Auto" RowDefinitions="Auto" HorizontalAlignment="Center" VerticalAlignment="Center">
+  <TextBlock Text="Enable port checking" FontSize="20" Grid.Column="0" Grid.Row="0"/>
+  <CheckBox
+        Classes="switch"
+        Checked="EnablePortChecking"
+        Unchecked="DisablePortChecking"
+        Grid.Column="1"
+        Margin="30,0,0,0"
+        Grid.Row="0"/>
+  </Grid>
 </UserControl>

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    d:DesignWidth="1000"
+    mc:Ignorable="d"
+    x:Class="Nitrox.Launcher.Views.TroubleshootingView"
+    x:DataType="vm:TroubleshootingViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:converters="clr-namespace:Nitrox.Launcher.Models.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:Nitrox.Launcher.ViewModels"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <TextBlock Text="Hello, World!" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="24"/>
+</UserControl>

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
@@ -1,4 +1,13 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
 using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
 using NitroxModel.Logger;
@@ -7,18 +16,88 @@ namespace Nitrox.Launcher.Views;
 
 public partial class TroubleshootingView : RoutableViewBase<TroubleshootingViewModel>
 {
+    private UdpClient server;
+    private static readonly IPEndPoint port = new(IPAddress.Any, 11000);
+    private CancellationTokenSource canceller = new();
+    private readonly Button portForwardCheckBtn;
+    private readonly TextBlock portForwardStatusText;
+    private readonly Ellipse portForwardStatusCircle;
+    private static readonly IBrush yellowBrush = new SolidColorBrush(Colors.Yellow);
+    private static readonly IBrush redBrush = new SolidColorBrush(Colors.Red);
+    private static readonly IBrush greenBrush = new SolidColorBrush(Colors.Green);
+
     public TroubleshootingView()
     {
         InitializeComponent();
+        portForwardCheckBtn = this.FindControl<Button>("PortForwardCheckButton");
+        portForwardStatusText = this.FindControl<TextBlock>("PortForwardStatusText");
+        portForwardStatusCircle = this.FindControl<Ellipse>("PortForwardStatusCircle");
+    }
+
+    private void CleanupServer()
+    {
+        server?.Dispose();
+        server = null;
     }
 
     public void EnablePortChecking(object? sender, RoutedEventArgs e)
     {
-        
+        server = new UdpClient(port);
+        Task.Run(() =>
+        {
+            // WTF: this isn't running after it is cancelled once.
+            IPEndPoint clientEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            try
+            {
+                byte[] bytesin = server.Receive(ref clientEndpoint);
+            }
+            catch (Exception) {
+                Dispatcher.UIThread.Post(() => {
+                    portForwardCheckBtn.Classes.Clear();
+                    portForwardCheckBtn.Classes.Add("primary");
+                    portForwardCheckBtn.Content = "Start";
+                    portForwardStatusText.Text = "Failed";
+                    portForwardStatusText.Foreground = redBrush;
+                    portForwardStatusCircle.Fill = redBrush;
+                });
+                CleanupServer();
+                return; 
+            }
+            CleanupServer();
+            Dispatcher.UIThread.Post(() =>
+            {
+                portForwardCheckBtn.Classes.Clear();
+                portForwardCheckBtn.Classes.Add("primary");
+                portForwardCheckBtn.Content = "Start";
+                portForwardStatusCircle.Fill = greenBrush;
+                portForwardStatusText.Text = "Succeeded";
+                portForwardStatusText.Foreground = greenBrush;
+            });
+        }, canceller.Token);
     }
 
-    public void DisablePortChecking(object? sender, RoutedEventArgs e)
+    public void CancelPortChecking(object? sender, RoutedEventArgs e)
     {
-        
+        canceller.Cancel();
+        CleanupServer();
+        canceller = new CancellationTokenSource();
+    }
+
+    public void OnPortForwardClick(object? sender, RoutedEventArgs e)
+    {
+        if (server == null)
+        {
+            portForwardCheckBtn.Classes.Clear();
+            portForwardCheckBtn.Classes.Add("abort");
+            portForwardCheckBtn.Content = "Stop";
+            portForwardStatusText.Text = "Running...";
+            portForwardStatusText.Foreground = yellowBrush;
+            portForwardStatusCircle.Fill = yellowBrush;
+            EnablePortChecking(sender, e);
+        }
+        else
+        {
+            CancelPortChecking(sender, e);
+        }
     }
 }

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
@@ -1,0 +1,12 @@
+using Nitrox.Launcher.ViewModels;
+using Nitrox.Launcher.Views.Abstract;
+
+namespace Nitrox.Launcher.Views;
+
+public partial class TroubleshootingView : RoutableViewBase<TroubleshootingViewModel>
+{
+    public TroubleshootingView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
+++ b/Nitrox.Launcher/Views/TroubleshootingView.axaml.cs
@@ -1,5 +1,7 @@
+using Avalonia.Interactivity;
 using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
+using NitroxModel.Logger;
 
 namespace Nitrox.Launcher.Views;
 
@@ -8,5 +10,15 @@ public partial class TroubleshootingView : RoutableViewBase<TroubleshootingViewM
     public TroubleshootingView()
     {
         InitializeComponent();
+    }
+
+    public void EnablePortChecking(object? sender, RoutedEventArgs e)
+    {
+        
+    }
+
+    public void DisablePortChecking(object? sender, RoutedEventArgs e)
+    {
+        
     }
 }


### PR DESCRIPTION
- [x] Usable troubleshooting view
- [ ] UX assets for aforementioned view(just an icon needed for the view RadioButton I think)
- [x] Make the port checker actually work
- [ ] Disable the port checker when game or a server is launched
Idea is that players can enable this and then go to an online port checker site and it will be able to tell them if they set up port forwarding correctly. 

## Closes
- Closes #2160