### PR TITLE
Added auto registration of Views, ViewModels and Dialogs for launcher

### DIFF
--- a/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
@@ -3,13 +3,14 @@ using HanumanInstitute.MvvmDialogs.Avalonia;
 using Microsoft.Extensions.DependencyInjection;
 using Nitrox.Launcher.Models.Design;
 using Nitrox.Launcher.Models.Services;
-using Nitrox.Launcher.ViewModels;
-using Nitrox.Launcher.Views;
+using Nitrox.Launcher.ViewModels.Abstract;
+using Nitrox.Launcher.Views.Abstract;
 using NitroxModel.Helper;
+using ServiceScan.SourceGenerator;
 
 namespace Nitrox.Launcher.Models.Extensions;
 
-public static class ServiceCollectionExtensions
+public static partial class ServiceCollectionExtensions
 {
     public static IServiceCollection AddAppServices(this IServiceCollection collection)
     {
@@ -25,38 +26,20 @@ public static class ServiceCollectionExtensions
         // Domain services
         collection.AddSingleton(_ => KeyValueStore.Instance);
         collection.AddSingleton<ServerService>();
-        
-        // Dialog ViewModels and Dialog Views
-        collection.AddTransient<CreateServerViewModel>();
-        collection.AddTransient<CreateServerModal>();
-        collection.AddTransient<BackupRestoreViewModel>();
-        collection.AddTransient<BackupRestoreModal>();
-        collection.AddTransient<ObjectPropertyEditorViewModel>();
-        collection.AddTransient<ObjectPropertyEditorModal>();
-        collection.AddTransient<DialogBoxViewModel>();
-        collection.AddTransient<DialogBoxModal>();
 
-        // Views
-        collection.AddSingleton<LaunchGameView>();
-        collection.AddSingleton<OptionsView>();
-        collection.AddSingleton<ServersView>();
-        collection.AddSingleton<ManageServerView>();
-        collection.AddSingleton<BlogView>();
-        collection.AddSingleton<CommunityView>();
-        collection.AddSingleton<UpdatesView>();
-        collection.AddSingleton<EmbeddedServerView>();
-
-        // ViewModels
-        collection.AddTransient<MainWindowViewModel>();
-        collection.AddTransient<LaunchGameViewModel>();
-        collection.AddTransient<OptionsViewModel>();
-        collection.AddTransient<ServersViewModel>();
-        collection.AddTransient<ManageServerViewModel>();
-        collection.AddTransient<BlogViewModel>();
-        collection.AddTransient<CommunityViewModel>();
-        collection.AddTransient<UpdatesViewModel>();
-        collection.AddTransient<EmbeddedServerViewModel>();
-
-        return collection;
+        return collection
+               .AddDialogs()
+               .AddViews()
+               .AddViewModels();
     }
+
+    [GenerateServiceRegistrations(AssignableTo = typeof(ModalViewModelBase), AsSelf = true)]
+    [GenerateServiceRegistrations(AssignableTo = typeof(ModalBase), AsSelf = true)]
+    private static partial IServiceCollection AddDialogs(this IServiceCollection services);
+
+    [GenerateServiceRegistrations(AssignableTo = typeof(RoutableViewBase<>), AsSelf = true, Lifetime = ServiceLifetime.Singleton)]
+    private static partial IServiceCollection AddViews(this IServiceCollection services);
+
+    [GenerateServiceRegistrations(AssignableTo = typeof(ViewModelBase), AsSelf = true)]
+    private static partial IServiceCollection AddViewModels(this IServiceCollection services);
 }

--- a/Nitrox.Launcher/Nitrox.Launcher.csproj
+++ b/Nitrox.Launcher/Nitrox.Launcher.csproj
@@ -42,6 +42,10 @@
         <PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia" Version="2.1.0" />
         <PackageReference Include="LitJson" Version="0.19.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="ServiceScan.SourceGenerator" Version="2.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Nitrox.Launcher/ViewModels/Abstract/ViewModelBase.cs
+++ b/Nitrox.Launcher/ViewModels/Abstract/ViewModelBase.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using System.Diagnostics;
+using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Nitrox.Launcher.Models;
@@ -9,8 +11,38 @@ public abstract class ViewModelBase : ObservableValidator, IMessageReceiver
 {
     protected Window MainWindow => AppViewLocator.MainWindow;
 
-    public virtual void Dispose()
+    protected ViewModelBase()
     {
-        WeakReferenceMessenger.Default.UnregisterAll(this);
+        ThrowIfViewModelCtorWasEmptyWhileNonEmptyExists();
+    }
+
+    public virtual void Dispose() => WeakReferenceMessenger.Default.UnregisterAll(this);
+
+    /// <summary>
+    ///     This will check that DI did not call the empty ViewModel constructor if dependencies for another constructor aren't met.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private static void ThrowIfViewModelCtorWasEmptyWhileNonEmptyExists()
+    {
+        if (Design.IsDesignMode)
+        {
+            return;
+        }
+        foreach (StackFrame stackFrame in new StackTrace(2, false).GetFrames())
+        {
+            if (stackFrame.GetMethod() is not { IsConstructor: true } method)
+            {
+                continue;
+            }
+            if (method.DeclaringType is not { IsAbstract: false } declaringType)
+            {
+                continue;
+            }
+            if (method.GetParameters().Length > 0 || declaringType.GetConstructors().Length == 1)
+            {
+                break;
+            }
+            throw new Exception($"Empty ViewModel constructor of '{declaringType.Name}' should only be used in design mode! Check that the DI-container has all the dependencies to call a different constructor.");
+        }
     }
 }


### PR DESCRIPTION
Added error if empty ViewModel constructor is called while a non-empty exists. This meant that the DI container couldn't resolve all the constructor parameters.