### PR TITLE
Fix standalone moonpools not being registered on remote clients

### DIFF
--- a/NitroxClient/GameLogic/Bases/BuildingHandler.cs
+++ b/NitroxClient/GameLogic/Bases/BuildingHandler.cs
@@ -173,6 +173,17 @@ public partial class BuildingHandler : MonoBehaviour
         BaseGhost baseGhost = constructableBase.model.GetComponent<BaseGhost>();
         constructableBase.SetState(true, true);
         NitroxEntity.SetNewId(baseGhost.targetBase.gameObject, placeBase.FormerGhostId);
+
+        // Specific case : just a moonpool built as a base
+        if (constructableBase.techType == TechType.BaseMoonpool)
+        {
+            // For a new base, the moonpool will be the only cell which is 0, 0, 0
+            Int3 absoluteCell = new(0, 0, 0);
+            // Deterministic id, see MoonpoolManager.LateAssignNitroxEntity
+            NitroxId moonpoolId = placeBase.FormerGhostId.Increment();
+            baseGhost.targetBase.gameObject.EnsureComponent<MoonpoolManager>().RegisterMoonpool(absoluteCell, moonpoolId);
+        }
+
         BasesCooldown[placeBase.FormerGhostId] = DateTimeOffset.UtcNow;
     }
 

--- a/NitroxClient/MonoBehaviours/MoonpoolManager.cs
+++ b/NitroxClient/MonoBehaviours/MoonpoolManager.cs
@@ -51,10 +51,13 @@ public class MoonpoolManager : MonoBehaviour
     public void LateAssignNitroxEntity(NitroxId baseId)
     {
         this.baseId = baseId;
+        NitroxId nextId = baseId.Increment(); // To be recognizable, we need it to be deterministic
         foreach (MoonpoolEntity moonpoolEntity in moonpoolsByCell.Values)
         {
             moonpoolEntity.ParentId = baseId;
-            moonpoolEntity.Id = new(); // Generate a new id in case
+            moonpoolEntity.Id = nextId;
+            
+            nextId = nextId.Increment();
         }
     }
 
@@ -84,7 +87,11 @@ public class MoonpoolManager : MonoBehaviour
 
     public Optional<GameObject> RegisterMoonpool(Transform constructableTransform, NitroxId moonpoolId)
     {
-        Int3 absoluteCell = Absolute(constructableTransform.position);
+        return RegisterMoonpool(Absolute(constructableTransform.position), moonpoolId);
+    }
+
+    public Optional<GameObject> RegisterMoonpool(Int3 absoluteCell, NitroxId moonpoolId)
+    {
         moonpoolsByCell[absoluteCell] = new(moonpoolId, baseId, absoluteCell.ToDto());
         TaskResult<Optional<GameObject>> resultObject = new();
         AssignNitroxEntityToMoonpool(absoluteCell, moonpoolId, resultObject);


### PR DESCRIPTION
This way is more natural and fitting to the system than #2331 because the only issue was that when you built a moonpool on its own, remote players would never go through the code that creates the MoonpoolManager although it was created by every other way to have this standalone moonpool (when joining a world or when placing it on local client).

Important note: for bases composed of a standalone moonpool, the first id after the base id will be reserved for the said standalone moonpool