### PR TITLE
Add Sync for Stalker Teeth Drop

### DIFF
--- a/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
+++ b/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
@@ -123,7 +123,7 @@ event:/creature/tred/stomp;false;false;0
 event:/creature/trident/bite;false;false;0
 event:/creature/trident/charge;false;false;0
 event:/creature/trident/roar;false;false;0
-event:/creature/trident/tooth_break;false;false;0
+event:/creature/trident/tooth_break;true;true;15
 event:/creature/trident/wound;false;false;0
 event:/creature/warper/idle;false;false;0
 event:/creature/warper/portal_close;false;false;0

--- a/NitroxPatcher/Patches/Dynamic/Stalker_CheckLoseTooth_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Stalker_CheckLoseTooth_Patch.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 using UnityEngine;
 
@@ -8,22 +10,55 @@ public sealed partial class Stalker_CheckLoseTooth_Patch : NitroxPatch, IDynamic
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Stalker t) => t.CheckLoseTooth(default(GameObject)));
 
-    //GetComponent<HardnessMixin> was returning null for everything instead of a HardnessMixin with a hardness value. Since this component
-    //isn't used for anything else than the stalker teeth drop, we hard-code the values and bingo.
+    // HardnessMixin seems to be a bit buggy (ie: undefined values for some scraps, which is a vanilla bug), so we'll just hard-code the values for now.
+    // Note that HardnessMixin is only used by Stalkers
     public static bool Prefix(Stalker __instance, GameObject target)
     {
-        float dropProbability = 0f;
+        if (!__instance.TryGetNitroxId(out NitroxId creatureId)
+            && !Resolve<SimulationOwnership>().HasAnyLockType(creatureId))
+        {
+            return false;
+        }
+
+
         TechType techType = CraftData.GetTechType(target);
 
-        if (techType == TechType.ScrapMetal)
+        float dropProbability = techType switch
         {
-            dropProbability = 0.15f; // 15% probability
+            TechType.ScrapMetal => 0.25f, // https://subnautica.fandom.com/wiki/Metal_Salvage_(Subnautica)
+            TechType.MapRoomCamera => 0.25f,
+            TechType.Titanium or TechType.Silver or TechType.Gold or TechType.Kyanite or TechType.Copper or TechType.Nickel => 0.15f,
+            _ => 0f,
+        };
+
+        if (dropProbability == 0)
+        {
+            return false;
         }
 
-        if (UnityEngine.Random.value < dropProbability)
+        // Random.value returns a random float within[0.0..1.0] (range is inclusive)
+        if (Random.value < dropProbability && Random.value < 0.5f)
         {
-            __instance.LoseTooth();
+            // Code from Stalker.LoseTooth() to avoid having another patch
+
+            GameObject toothGameObject = Object.Instantiate(__instance.toothPrefab);
+            toothGameObject.transform.position = __instance.loseToothDropLocation.transform.position;
+            toothGameObject.transform.rotation = __instance.loseToothDropLocation.transform.rotation;
+
+            if (toothGameObject.activeSelf && __instance.isActiveAndEnabled)
+            {
+                foreach (Collider collider in toothGameObject.GetComponentsInChildren<Collider>())
+                {
+                    Physics.IgnoreCollision(__instance.stalkerBodyCollider, collider);
+                }
+            }
+
+            Utils.PlayFMODAsset(__instance.loseToothSound, toothGameObject.transform, 20f);
+            LargeWorldEntity.Register(toothGameObject);
+
+            Resolve<Items>().Dropped(toothGameObject);
         }
+
         return false;
     }
 }


### PR DESCRIPTION
Closes #2243 

I've extracted the #2255  commit to allow at least this synchronization for 1.8, which seems to be an important part of Gameplay for crafting and base building.

I've included a correction to the code that handles probabilities, I've extracted from the wiki some components that seem to influence the drop of a Stalker tooth, I've restricted myself to metals/minerals for the moment.

Note: The DropTooth code has been copied directly into the patch to avoid having to introduce a new patch for this method, which is only called by the method we're already patching