### PR TITLE
Temporarily disable PlayerCinematicController patches

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_OnPlayerCinematicModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_OnPlayerCinematicModeEnd_Patch.cs
@@ -1,3 +1,6 @@
+// Disabled because these patches cause certain animations to break (such as https://github.com/SubnauticaNitrox/Nitrox/issues/2287)
+// TODO: reenable after the 1.8 release and fix animations
+#if false
 using System.Reflection;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.PlayerLogic;
@@ -29,3 +32,4 @@ public sealed partial class PlayerCinematicController_OnPlayerCinematicModeEnd_P
         Resolve<PlayerCinematics>().EndCinematicMode(Resolve<IMultiplayerSession>().Reservation.PlayerId, entity.Id, identifier, __instance.playerViewAnimationName);
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_StartCinematicMode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_StartCinematicMode_Patch.cs
@@ -1,3 +1,6 @@
+// Disabled because these patches cause certain animations to break (such as https://github.com/SubnauticaNitrox/Nitrox/issues/2287)
+// TODO: reenable after the 1.8 release and fix animations
+#if false
 using System.Reflection;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.PlayerLogic;
@@ -37,3 +40,4 @@ public sealed partial class PlayerCinematicController_StartCinematicMode_Patch :
         Resolve<PlayerCinematics>().StartCinematicMode(Resolve<IMultiplayerSession>().Reservation.PlayerId, entity.Id, identifier, __instance.playerViewAnimationName);
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PlayerCinematicController_Start_Patch.cs
@@ -1,3 +1,6 @@
+// Disabled because these patches cause certain animations to break (such as https://github.com/SubnauticaNitrox/Nitrox/issues/2287)
+// TODO: reenable after the 1.8 release and fix animations
+#if false
 using System.Reflection;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.CinematicController;
@@ -26,3 +29,4 @@ public sealed partial class PlayerCinematicController_Start_Patch : NitroxPatch,
         entity.gameObject.EnsureComponent<MultiplayerCinematicReference>().AddController(__instance);
     }
 }
+#endif


### PR DESCRIPTION
With the ongoing attempt to sync player animations, several interactions are broken. We decided to temporarily disable these changes for the upcoming 1.8 release and spend more time finding a proper fix once the update is out.

Fixes #2287 