### PR TITLE
Fix global Seamoth light sound

### DIFF
--- a/NitroxServer/Communication/Packets/Processors/DefaultServerPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DefaultServerPacketProcessor.cs
@@ -27,7 +27,8 @@ public class DefaultServerPacketProcessor : AuthenticatedPacketProcessor<Packet>
         typeof(TorpedoTargetAcquired),
         typeof(StasisSphereShot),
         typeof(StasisSphereHit),
-        typeof(SeaTreaderChunkPickedUp)
+        typeof(SeaTreaderChunkPickedUp),
+        typeof(ToggleLights)
     };
 
     /// <summary>


### PR DESCRIPTION
The seamoth light sound played globally for all players. This PR should fix that issue, as can be heard in the video below:

https://github.com/user-attachments/assets/e3a8b5a8-7851-4e53-a80f-488575651162

Note: The Seamoth light on sound still plays globally when a player inserts a power cell into an unpowered Seamoth, but that issue is much less annoying to deal with than someone spamming the Seamoth lights.