### PR TITLE
Send EntityDestroyed packet on time capsule destruction to server

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
@@ -12,7 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic;
 /// </summary>
 public sealed partial class TimeCapsule_Open_Patch : NitroxPatch, IDynamicPatch
 {
-    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((TimeCapsule t) => t.Open());
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((TimeCapsule t) => t.Open());
     
     public static void Postfix(TimeCapsule __instance)
     {
@@ -21,7 +21,7 @@ public sealed partial class TimeCapsule_Open_Patch : NitroxPatch, IDynamicPatch
             return;
         }
         
-        var packet = new EntityDestroyed(timeCapsuleId);
+        EntityDestroyed packet = new(timeCapsuleId);
         Resolve<IPacketSender>().Send(packet);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
@@ -1,0 +1,27 @@
+﻿using NitroxModel.Packets;
+using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Ensures that when a player opens a time capsule, it is permanently destroyed on the server,
+/// preventing it from respawning.
+/// </summary>
+public sealed partial class TimeCapsule_Open_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((TimeCapsule t) => t.Open());
+    
+    public static void Postfix(TimeCapsule __instance)
+    {
+        if (!__instance.TryGetIdOrWarn(out NitroxId timeCapsuleId))
+        {
+            return;
+        }
+        
+        var packet = new EntityDestroyed(timeCapsuleId);
+        Resolve<IPacketSender>().Send(packet);
+    }
+}

--- a/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
@@ -32,14 +32,7 @@ public class EntityDestroyedPacketProcessor : AuthenticatedPacketProcessor<Entit
                 worldEntityManager.MovePlayerChildrenToRoot(vehicleWorldEntity);
             }
 
-            foreach (Player player in playerManager.GetConnectedPlayers())
-            {
-                bool isOtherPlayer = player != destroyingPlayer;
-                if (isOtherPlayer && player.CanSee(entity))
-                {
-                    player.SendPacket(packet);
-                }
-            }
+            playerManager.SendPacketToOtherPlayers(packet, destroyingPlayer);
         }
     }
 }


### PR DESCRIPTION
Certain resources, e.g. flares, notify the server via an `EntityDestroyed` packet once the resource is destroyed. Time capsules lacked an `EntityDestroyed` broadcast, resulting in clients seeing respawning capsules from the `BatchEntitySpawner`. 

This fix adds a patch which sends the `EntityDestroyed` packet to the server when a client opens a time capsule.

Fixes #2357.