### PR TITLE
Add null reference check when getting all player objects

### DIFF
--- a/NitroxClient/GameLogic/PlayerManager.cs
+++ b/NitroxClient/GameLogic/PlayerManager.cs
@@ -56,7 +56,10 @@ public class PlayerManager
                                                   .Select(player => player.Body)
                                                   .Where(body => body != null)
                                                   .ToSet();
-        remotePlayerObjects.Add(Player.mainObject);
+        if (Player.mainObject != null)
+        {
+            remotePlayerObjects.Add(Player.mainObject);    
+        }
         return remotePlayerObjects;
     }
 

--- a/NitroxClient/GameLogic/PlayerManager.cs
+++ b/NitroxClient/GameLogic/PlayerManager.cs
@@ -52,7 +52,10 @@ public class PlayerManager
 
     public HashSet<GameObject> GetAllPlayerObjects()
     {
-        HashSet<GameObject> remotePlayerObjects = GetAll().Select(player => player.Body).ToSet();
+        HashSet<GameObject> remotePlayerObjects = GetAll()
+                                                  .Select(player => player.Body)
+                                                  .Where(body => body != null)
+                                                  .ToSet();
         remotePlayerObjects.Add(Player.mainObject);
         return remotePlayerObjects;
     }


### PR DESCRIPTION
I was not able to reproduce the issue in question since this particular error seems to arise from a narrow race condition. However, it seems fairly straightforward to see where the issue occurs.

The `ChekItemsOnHashSet()` signature is defined as:

```cs
  private void ChekItemsOnHashSet(
    HashSet<GameObject> checkList,
    CyclopsSonarDisplay.EntityType entityType)
```

Given that `entityType` is always defined in `CyclopsSonarCreatureDetector_CheckForCreaturesInRange_Patch.Postfix`, it's clear that `checkList` is receiving a null value in its HashSet.

The HashSet passed by the `Postfix` is `Resolve<PlayerManager>().GetAllPlayerObjects()`:

```cs
__instance.ChekItemsOnHashSet(Resolve<PlayerManager>().GetAllPlayerObjects(), PLAYER_TYPE);
```

Previously, `GetAllPlayerObjects()` retrieved every player object under the assumption that every `player.Body` would not be null. However, under precise circumstances, it seems there is a small window of time where the `Body` GameObject is destroyed without being removed from `playersById`, leading to a race condition where `GetAll()` retrieves a null value:

```cs
    public void RemovePlayer(ushort playerId)
    {
        if (playersById.TryGetValue(playerId, out RemotePlayer player))
        {
            player.Destroy(); // This is where the race condition occurs.
            playersById.Remove(playerId); // There is a time gap between the above Destroy() and this Remove().
            OnRemove(playerId, player);
            DiscordClient.UpdatePartySize(GetTotalPlayerCount());
        }
    }
```

During this race condition, `GetAll()` will pull a GameObject where the `Body` has already been destroyed, but not removed from the Dictionary of `playersById`:

```cs
    public IEnumerable<RemotePlayer> GetAll()
    {
        return playersById.Values;
    }
```

This fix adds a check to filter out `GameObjects` that have already had their `Body` destroyed but have not yet been removed from the `playersById` dictionary.

Fixes #2360.