### PR TITLE
Decouple pawn cleanup logic from RemotePlayer

### DIFF
--- a/NitroxClient/GameLogic/CyclopsPawn.cs
+++ b/NitroxClient/GameLogic/CyclopsPawn.cs
@@ -104,6 +104,13 @@ public class CyclopsPawn
 
     public void MaintainPosition()
     {
+        if (RealObject == null)
+        {
+            Log.Warn($"CyclopsPawn for player '{player.PlayerName}' has a null RealObject. Unregistering stale pawn.");
+            Unregister();
+            return;
+        }
+        
         RealObject.transform.localPosition = Handle.transform.localPosition;
         RealObject.transform.rotation = realCyclopsTransform.rotation;
         if (!isLocalPlayer)

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -107,12 +107,6 @@ public class RemotePlayer : INitroxPlayer
         vitals = playerVitalsManager.CreateOrFindForPlayer(this);
         RefreshVitalsVisibility();
 
-        PlayerDisconnectEvent.AddHandler(Body, _ =>
-        {
-            Pawn?.Unregister();
-            Pawn = null;
-        });
-
         PlayerDeathEvent.AddHandler(Body, _ =>
         {
             ResetStates();

--- a/NitroxClient/MonoBehaviours/Cyclops/NitroxCyclops.cs
+++ b/NitroxClient/MonoBehaviours/Cyclops/NitroxCyclops.cs
@@ -110,6 +110,7 @@ public class NitroxCyclops : MonoBehaviour
     /// </summary>
     public void OnPlayerEnter(RemotePlayer remotePlayer)
     {
+        remotePlayer.PlayerDisconnectEvent.AddHandler(this, OnPlayerExit);
         remotePlayer.Pawn = AddPawnForPlayer(remotePlayer);
     }
 
@@ -118,6 +119,7 @@ public class NitroxCyclops : MonoBehaviour
     /// </summary>
     public void OnPlayerExit(RemotePlayer remotePlayer)
     {
+        remotePlayer.PlayerDisconnectEvent.RemoveHandler(this, OnPlayerExit);
         RemovePawnForPlayer(remotePlayer);
         remotePlayer.Pawn = null;
     }


### PR DESCRIPTION
As an initial note, I was unable to replicate this after about an hour of testing, so this is mostly speculation.

Currently, `InitializeGameObject` also adds a handler to `Body` for pawn cleanups with regards to the Cyclops:

```cs
PlayerDisconnectEvent.AddHandler(Body, _ =>
{
    Pawn?.Unregister();
    Pawn = null;
});
```

In normal circumstances, this would `Unregister()` the `GameObject` through `CyclopsPawn.cs`. However, there seems to be a race condition that can trigger a `NullReferenceException`.

In the event the `Body` is destroyed before the `PlayerDisconnectEvent` triggers, then the handler will never fire, and `Pawn?.Unregister()` is never called.

What this means is there is now a stale `CyclopsPawn` instance because it's never removed.

The `NullReferenceException` stems from `MaintainPosition()` in `CyclopsPawn.cs`, specifically the reference to `RealObject`. Notably, `RealObject` is set to `remotePlayer.Body`.

```cs
else if (player is RemotePlayer remotePlayer)
{
    RealObject = remotePlayer.Body;
    MaintainPredicate = () => !remotePlayer.PilotingChair;
}
```

And where RealObject, the null `Body`, is referenced:

```cs
public void MaintainPosition()
{
    RealObject.transform.localPosition = Handle.transform.localPosition; // This is where the NRE occurs.
    RealObject.transform.rotation = realCyclopsTransform.rotation;
    if (!isLocalPlayer)
    {
        RealObject.transform.localRotation = Handle.transform.localRotation;
    }
}
```

The fix decouples the handler logic from the `Body` and migrates it to the `Cyclops` instance. It also adds an additional defensive null check during `MaintainPosition()` to unregister stale pawns.

(Probably) Fixes #2372.