### PR TITLE
Implement proper multiplayer cleanup on post-credits sequence

### DIFF
--- a/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
@@ -86,7 +86,7 @@ public class LiteNetLibClient : IClient
     public void Stop()
     {
         IsConnected = false;
-        client.Stop();
+        client.Stop(true);
     }
 
     /// <summary>

--- a/NitroxClient/MonoBehaviours/Cyclops/VirtualCyclops.cs
+++ b/NitroxClient/MonoBehaviours/Cyclops/VirtualCyclops.cs
@@ -36,8 +36,11 @@ public class VirtualCyclops : MonoBehaviour
 
     public static void Dispose()
     {
-        Destroy(Instance.gameObject);
-        Instance = null;
+        if (Instance != null)
+        {
+            Destroy(Instance.gameObject);
+            Instance = null;
+        }
         Multiplayer.OnAfterMultiplayerEnd -= Dispose;
     }
 

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/ServerJoin/JoinServerBackend.cs
@@ -170,17 +170,21 @@ public static class JoinServerBackend
         {
             return;
         }
-
-        if (multiplayerSession.CurrentState.CurrentStage != MultiplayerSessionConnectionStage.DISCONNECTED)
+        
+        if (multiplayerSession != null)
         {
-            multiplayerSession.Disconnect();
+            multiplayerSession.ConnectionStateChanged -= SessionConnectionStateChangedHandler;
         }
-        multiplayerSession.ConnectionStateChanged -= SessionConnectionStateChangedHandler;
-
+    
         Multiplayer.Main.StopCurrentSession();
-        NitroxServiceLocator.EndCurrentLifetimeScope(); //Always do this last.
+        NitroxServiceLocator.EndCurrentLifetimeScope();
 
         Object.Destroy(multiplayerClient);
         multiplayerClient = null;
+
+        if (MainMenuServerListPanel.Main != null)
+        {
+            MainMenuServerListPanel.Main.RefreshServerEntries();
+        }
     }
 }

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -186,6 +186,19 @@ namespace NitroxClient.MonoBehaviours
             SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
             OnAfterMultiplayerEnd?.Invoke();
         }
+        
+        public void OnDestroy()
+        {
+            if (multiplayerSession != null && multiplayerSession.CurrentState.CurrentStage != MultiplayerSessionConnectionStage.DISCONNECTED)
+            {
+                multiplayerSession.Disconnect();
+            }
+
+            if (Main == this)
+            {
+                Main = null;
+            }
+        }
 
         private static void SetLoadingComplete()
         {

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -226,7 +226,6 @@ namespace NitroxClient.MonoBehaviours
                 // If we just disconnected from a multiplayer session, then we need to kill the connection here.
                 // Maybe a better place for this, but here works in a pinch.
                 JoinServerBackend.StopMultiplayerClient();
-                SceneCleaner.Open();
             }
         }
     }

--- a/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGame_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IngameMenu_QuitGame_Patch.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using NitroxModel.Helper;
-using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -10,8 +9,6 @@ public sealed partial class IngameMenu_QuitGame_Patch : NitroxPatch, IDynamicPat
 
     public static bool Prefix()
     {
-        // TODO: Remove this patch after fixing that no MP resources are left on disconnect. So that we can return to main menu.
-        Application.Quit();
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
The disconnect sequence following the launch of the rocket, including the cleanup process, failed to properly handle multiplayer sessions. This lead to several bugs, including:

- XMenu recursive loops resulting in "screen flickering" after the credits
- NullReferenceExceptions on dispose of Cyclops, preventing rejoining
- Servers hosting a zombie player post-credits, preventing rejoining
- The "Quit" would forcefully exit the application instead of returning to the main menu

This PR attempts to implement a graceful cleanup of multiplayer sessions following the credits sequence.

A couple of notes:

- The rocket launch appears to still be bugged, and this PR was tested using a separate fix (see original issue).
- The server listing after the credits sequence still appears to delist the non-LAN server and does not refresh the server list upon returning to the main menu. Restarting the server also doesn't seem to refresh the server listing. As a workaround, servers can be manually re-added and joined via IP address.

Fixes #2356.