### PR TITLE
Removed UpdateForPlayer log spam

### DIFF
--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/PlayerMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/PlayerMetadataProcessor.cs
@@ -38,7 +38,7 @@ public class PlayerMetadataProcessor : EntityMetadataProcessor<PlayerMetadata>
         }
     }
 
-    private void UpdateForLocalPlayer(PlayerMetadata metadata)
+    private static void UpdateForLocalPlayer(PlayerMetadata metadata)
     {
         ItemsContainer currentItems = Inventory.Get().container;
         Equipment equipment = Inventory.main.equipment;
@@ -66,9 +66,8 @@ public class PlayerMetadataProcessor : EntityMetadataProcessor<PlayerMetadata>
         }
     }
 
-    private void UpdateForRemotePlayer(GameObject gameObject, PlayerMetadata metadata)
+    private static void UpdateForRemotePlayer(GameObject gameObject, PlayerMetadata metadata)
     {
-        Log.Info("Calling UpdateForRemotePlayer");
         RemotePlayerIdentifier remotePlayerId = gameObject.RequireComponent<RemotePlayerIdentifier>();
 
         List<TechType> equippedTechTypes = metadata.EquippedItems.Select(x => x.TechType.ToUnity()).ToList();


### PR DESCRIPTION
While testing #2359, I noticed that there is a log that is often spam : 

<img width="729" height="605" alt="image" src="https://github.com/user-attachments/assets/c49539a2-451f-4440-a7ff-883d2e721366" />

Which doesn't give any useful infos