### PR TITLE
Destroy time capsules server-side when opened

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/TimeCapsule_Open_Patch.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxModel.DataStructures;
+using NitroxModel.Helper;
+using NitroxModel.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class TimeCapsule_Open_Patch : NitroxPatch, IDynamicPatch
+{
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((TimeCapsule t) => t.Open());
+
+    public static void Prefix(TimeCapsule __instance)
+    {
+        if (__instance.TryGetIdOrWarn(out NitroxId id))
+        {
+            Resolve<IPacketSender>().Send(new EntityDestroyed(id));
+        }
+    }
+}


### PR DESCRIPTION
Adds a patch to send an `EntityDestroyed` packet when the player opens a time capsule. This removes the entity from the server's registry, so it won't reappear when that player or another player reenters the area.

The change to `EntityDestroyedPacketProcessor` in #2368 is not necessary, since time capsules are spawned by the server and not by the client. The client does not need to receive `EntityDestroyed` packets for entities it can't see, since the server will omit that entity from `SpawnEntities` if they load that cell, meaning the entity will not respawn. (Confirmed with testing)

Fixes #2357 