### PR TITLE
Change OptionsView "Save File Location" to "Nitrox Logs Location"

### DIFF
--- a/Nitrox.Launcher/ViewModels/Designer/DesignOptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/Designer/DesignOptionsViewModel.cs
@@ -13,6 +13,6 @@ internal class DesignOptionsViewModel : OptionsViewModel
             Platform = Platform.STEAM
         };
         LaunchArgs = "-vrmode none";
-        SavesFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox\saves";
+        LogsFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox\Logs";
     }
 }

--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -30,7 +30,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
     private string launchArgs;
 
     [ObservableProperty]
-    private string savesFolderDir;
+    private string logsFolderDir;
 
     [ObservableProperty]
     private KnownGame selectedGame;
@@ -58,7 +58,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
         {
             SelectedGame = new() { PathToGame = NitroxUser.GamePath, Platform = NitroxUser.GamePlatform?.Platform ?? Platform.NONE };
             LaunchArgs = keyValueStore.GetSubnauticaLaunchArguments(DefaultLaunchArg);
-            SavesFolderDir = keyValueStore.GetSavesFolderDir();
+            LogsFolderDir = NitroxModel.Logger.Log.LogDirectory;
             LightModeEnabled = keyValueStore.GetIsLightModeEnabled();
             AllowMultipleGameInstances = keyValueStore.GetIsMultipleGameInstancesAllowed();
             IsInReleaseMode = NitroxEnvironment.IsReleaseMode;
@@ -149,11 +149,11 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
     }
 
     [RelayCommand]
-    private void OpenSavesFolder()
+    private void OpenLogsFolder()
     {
         Process.Start(new ProcessStartInfo
         {
-            FileName = SavesFolderDir,
+            FileName = LogsFolderDir,
             Verb = "open",
             UseShellExecute = true
         })?.Dispose();

--- a/Nitrox.Launcher/Views/OptionsView.axaml
+++ b/Nitrox.Launcher/Views/OptionsView.axaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    d:DesignHeight="500"
+    d:DesignHeight="1000"
     d:DesignWidth="1000"
     mc:Ignorable="d"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -211,11 +211,11 @@
                 <TextBlock
                     FontSize="20"
                     FontWeight="Bold"
-                    Text="Save File Location" />
+                    Text="Nitrox Logs Location" />
                 <TextBlock
                     FontSize="12"
                     HorizontalAlignment="Left"
-                    Text="This is the location where your Nitrox server save files are stored" />
+                    Text="This is the location where your Nitrox logs are stored" />
 
                 <Border
                     Background="{DynamicResource BrandPanelBackground}"
@@ -226,11 +226,11 @@
                             FontSize="15"
                             Foreground="{DynamicResource BrandBlack}"
                             Opacity="0.75"
-                            Text="{Binding SavesFolderDir}"
+                            Text="{Binding LogsFolderDir}"
                             VerticalAlignment="Center" />
                         <Button
                             Classes="primary"
-                            Command="{Binding OpenSavesFolderCommand}"
+                            Command="{Binding OpenLogsFolderCommand}"
                             Content="Open"
                             Grid.Column="1"
                             HorizontalAlignment="Right"


### PR DESCRIPTION
This PR changes the open folder button in OptionsView to open the Nitrox logs folder instead.

I think this is better since ServersView already has buttons to open save folder locations, and users may need to see their log files (in case we ask for it in the Discord help channel) so making a button dedicated to it in OptionsView would make it easier for them to get to it.

<img width="1191" height="711" alt="image" src="https://github.com/user-attachments/assets/676dbeda-fd02-467b-b794-4711bd0adbae" />
