### PR TITLE
Moved Screenshots Path to Nitrox AppData

### DIFF
--- a/Nitrox.Launcher/Models/HttpDelegatingHandlers/FileCacheDelegatingHandler.cs
+++ b/Nitrox.Launcher/Models/HttpDelegatingHandlers/FileCacheDelegatingHandler.cs
@@ -53,6 +53,6 @@ internal sealed class FileCacheDelegatingHandler : DelegatingHandler
         {
             throw new Exception($"{nameof(request.RequestUri)} must not be null");
         }
-        return Path.Combine(NitroxUser.AppDataPath, "Cache", $"nitrox_{string.Join('_', $"{uri.Host}{uri.LocalPath}".ReplaceInvalidFileNameCharacters('_').Split('_').Select(s => s[0]))}_{Convert.ToHexStringLower(uri.ToString().AsMd5Hash())}.cache");
+        return Path.Combine(NitroxUser.CachePath, $"nitrox_{string.Join('_', $"{uri.Host}{uri.LocalPath}".ReplaceInvalidFileNameCharacters('_').Split('_').Select(s => s[0]))}_{Convert.ToHexStringLower(uri.ToString().AsMd5Hash())}.cache");
     }
 }

--- a/Nitrox.Launcher/Models/Utils/Hashing.cs
+++ b/Nitrox.Launcher/Models/Utils/Hashing.cs
@@ -69,6 +69,6 @@ public static class Hashing
     private static string GetSha256CacheFilePath(string targetFilePath)
     {
         string filePathMd5 = Convert.ToHexStringLower(MD5.HashData(Encoding.UTF8.GetBytes(targetFilePath)));
-        return Path.Combine(NitroxUser.AppDataPath, "Cache", Path.ChangeExtension(filePathMd5, "sha256"));
+        return Path.Combine(NitroxUser.CachePath, Path.ChangeExtension(filePathMd5, "sha256"));
     }
 }

--- a/Nitrox.Shared.targets
+++ b/Nitrox.Shared.targets
@@ -109,7 +109,7 @@
         <Message Importance="High"
                  Text="Running NitroxClean on $(MSBuildProjectName)" />
 
-         <RemoveDir Directories="$(TargetDir)\$(_NitroxOutputFolder);$(TargetDir)\$(_NitroxResourcesFolder);$(TargetDir)\runtimes;$(TargetDir)\screenshots"
+         <RemoveDir Directories="$(TargetDir)\$(_NitroxOutputFolder);$(TargetDir)\$(_NitroxResourcesFolder);$(TargetDir)\runtimes"
                     ContinueOnError="WarnAndContinue" />
     </Target>
 

--- a/NitroxModel/Helper/NitroxUser.cs
+++ b/NitroxModel/Helper/NitroxUser.cs
@@ -92,6 +92,8 @@ public static class NitroxUser
         }
     }
 
+    public static string CachePath => Path.Combine(AppDataPath, "cache");
+
     /// <summary>
     ///     Tries to get the launcher path that was previously saved by other Nitrox code.
     /// </summary>

--- a/NitroxModel/Logger/Log.cs
+++ b/NitroxModel/Logger/Log.cs
@@ -88,7 +88,7 @@ namespace NitroxModel.Logger
             }
         }
 
-        public static string LogDirectory { get; } = Path.GetFullPath(Path.Combine(NitroxUser.AppDataPath ?? "", "Logs"));
+        public static string LogDirectory { get; } = Path.GetFullPath(Path.Combine(NitroxUser.AppDataPath ?? "", "logs"));
 
         public static string GetMostRecentLogFile() => new DirectoryInfo(LogDirectory).GetFiles().OrderByDescending(f => f.CreationTimeUtc).FirstOrDefault()?.FullName; // TODO: Filter by servername ( .Where(f => f.Name.Contains($"[{SaveName}]")) )
 

--- a/NitroxPatcher/Patches/Persistent/ScreenshotManager_Initialise.Path.cs
+++ b/NitroxPatcher/Patches/Persistent/ScreenshotManager_Initialise.Path.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using System.Reflection;
 using NitroxModel.Helper;
 
@@ -10,7 +11,7 @@ namespace NitroxPatcher.Patches.Persistent
 
         public static void Prefix(ScreenshotManager __instance, ref string _savePath)
         {
-            _savePath = Path.GetFullPath(NitroxUser.LauncherPath ?? ".");
+            _savePath = Path.GetFullPath(NitroxUser.AppDataPath ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
         }
     }
 }

--- a/NitroxServer-Subnautica/Resources/Parsers/PrefabPlaceholderGroupsParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/PrefabPlaceholderGroupsParser.cs
@@ -61,7 +61,7 @@ public class PrefabPlaceholderGroupsParser : IDisposable
         // Loading all prefabs by their classId and file paths (first the path to the prefab then the dependencies)
         LoadAddressableCatalog(prefabDatabase);
 
-        string nitroxCachePath = Path.Combine(NitroxUser.AppDataPath, "Cache");
+        string nitroxCachePath = NitroxUser.CachePath;
         Directory.CreateDirectory(nitroxCachePath);
 
         Dictionary<string, PrefabPlaceholdersGroupAsset> prefabPlaceholdersGroupPaths = null;


### PR DESCRIPTION
<img width="783" height="347" alt="image" src="https://github.com/user-attachments/assets/271b688e-ddfd-4cdd-b331-483a5746f83d" />

Currently the folder look like this

"screenshots" is hardcoded inside Subnautica's code and would required multiple transpilers to get rid of. Since "saves" is already in lower, I decided to lowered the 2 others as well