### PR TITLE
Fix cyclops bridge and hull fragments not appearing

### DIFF
--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -430,9 +430,9 @@ public class WorldPersistenceTest
                                         break;
                                     case PlayerEntity when globalRootEntityAfter is PlayerEntity:
                                         break;
-                                    case VehicleEntity vehicleEntity when globalRootEntityAfter is VehicleEntity vehicleWorldEntityAfter:
-                                        Assert.AreEqual(vehicleEntity.SpawnerId, vehicleWorldEntityAfter.SpawnerId);
-                                        Assert.AreEqual(vehicleEntity.ConstructionTime, vehicleWorldEntityAfter.ConstructionTime);
+                                    case VehicleEntity vehicleEntity when globalRootEntityAfter is VehicleEntity vehicleEntityAfter:
+                                        Assert.AreEqual(vehicleEntity.SpawnerId, vehicleEntityAfter.SpawnerId);
+                                        Assert.AreEqual(vehicleEntity.ConstructionTime, vehicleEntityAfter.ConstructionTime);
                                         break;
                                     case RadiationLeakEntity radiationLeakEntity when globalRootEntityAfter is RadiationLeakEntity radiationLeakEntityAfter:
                                         Assert.AreEqual(radiationLeakEntity.ObjectIndex, radiationLeakEntityAfter.ObjectIndex);

--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -396,8 +396,8 @@ public class WorldPersistenceTest
                                     case BuildEntity buildEntity when globalRootEntityAfter is BuildEntity buildEntityAfter:
                                         Assert.AreEqual(buildEntity.BaseData, buildEntityAfter.BaseData);
                                         break;
-                                    case EscapePodWorldEntity escapePodWorldEntity when globalRootEntityAfter is EscapePodWorldEntity escapePodWorldEntityAfter:
-                                        Assert.IsTrue(escapePodWorldEntity.Players.SequenceEqual(escapePodWorldEntityAfter.Players));
+                                    case EscapePodEntity escapePodEntity when globalRootEntityAfter is EscapePodEntity escapePodEntityAfter:
+                                        Assert.IsTrue(escapePodEntity.Players.SequenceEqual(escapePodEntityAfter.Players));
                                         break;
                                     case InteriorPieceEntity interiorPieceEntity when globalRootEntityAfter is InteriorPieceEntity interiorPieceEntityAfter:
                                         Assert.AreEqual(interiorPieceEntity.BaseFace, interiorPieceEntityAfter.BaseFace);
@@ -430,9 +430,9 @@ public class WorldPersistenceTest
                                         break;
                                     case PlayerEntity when globalRootEntityAfter is PlayerEntity:
                                         break;
-                                    case VehicleWorldEntity vehicleWorldEntity when globalRootEntityAfter is VehicleWorldEntity vehicleWorldEntityAfter:
-                                        Assert.AreEqual(vehicleWorldEntity.SpawnerId, vehicleWorldEntityAfter.SpawnerId);
-                                        Assert.AreEqual(vehicleWorldEntity.ConstructionTime, vehicleWorldEntityAfter.ConstructionTime);
+                                    case VehicleEntity vehicleEntity when globalRootEntityAfter is VehicleEntity vehicleWorldEntityAfter:
+                                        Assert.AreEqual(vehicleEntity.SpawnerId, vehicleWorldEntityAfter.SpawnerId);
+                                        Assert.AreEqual(vehicleEntity.ConstructionTime, vehicleWorldEntityAfter.ConstructionTime);
                                         break;
                                     case RadiationLeakEntity radiationLeakEntity when globalRootEntityAfter is RadiationLeakEntity radiationLeakEntityAfter:
                                         Assert.AreEqual(radiationLeakEntity.ObjectIndex, radiationLeakEntityAfter.ObjectIndex);

--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -428,7 +428,7 @@ public class WorldPersistenceTest
                                         break;
                                     case PlanterEntity when globalRootEntityAfter is PlanterEntity:
                                         break;
-                                    case PlayerWorldEntity when globalRootEntityAfter is PlayerWorldEntity:
+                                    case PlayerEntity when globalRootEntityAfter is PlayerEntity:
                                         break;
                                     case VehicleWorldEntity vehicleWorldEntity when globalRootEntityAfter is VehicleWorldEntity vehicleWorldEntityAfter:
                                         Assert.AreEqual(vehicleWorldEntity.SpawnerId, vehicleWorldEntityAfter.SpawnerId);

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -127,7 +127,7 @@ public class BuildingResyncProcessor : ClientPacketProcessor<BuildingResync>
 
         yield return BuildEntitySpawner.SetupBase(buildEntity, @base, entities);
         yield return MoonpoolManager.RestoreMoonpools(buildEntity.ChildEntities.OfType<MoonpoolEntity>(), @base);
-        yield return entities.SpawnBatchAsync(buildEntity.ChildEntities.OfType<PlayerWorldEntity>().ToList<Entity>(), false, false);
+        yield return entities.SpawnBatchAsync(buildEntity.ChildEntities.OfType<PlayerEntity>().ToList<Entity>(), false, false);
 
         foreach (Entity childEntity in buildEntity.ChildEntities)
         {

--- a/NitroxClient/Communication/Packets/Processors/PlayerJoinedMultiplayerSessionProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerJoinedMultiplayerSessionProcessor.cs
@@ -25,7 +25,7 @@ public class PlayerJoinedMultiplayerSessionProcessor : ClientPacketProcessor<Pla
     private IEnumerator SpawnRemotePlayer(PlayerJoinedMultiplayerSession packet)
     {
         playerManager.Create(packet.PlayerContext);
-        yield return entities.SpawnEntityAsync(packet.PlayerWorldEntity, true, true);
+        yield return entities.SpawnEntityAsync(packet.PlayerEntity, true, true);
 
         Log.Info($"{packet.PlayerContext.PlayerName} joined the game");
         Log.InGame(Language.main.Get("Nitrox_PlayerJoined").Replace("{PLAYER}", packet.PlayerContext.PlayerName));

--- a/NitroxClient/Communication/Packets/Processors/SpawnEntitiesProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/SpawnEntitiesProcessor.cs
@@ -34,7 +34,8 @@ public class SpawnEntitiesProcessor : ClientPacketProcessor<SpawnEntities>
             }
 
             // Packet processing is done in the main thread so there's no issue calling this
-            entities.EnqueueEntitiesToSpawn(packet.Entities);
+            // We need a cold start so that all cleaned up entities (if force respawn is true) have time to be fully destroyed
+            entities.EnqueueEntitiesToSpawn(packet.Entities, packet.ForceRespawn);
         }
     }
 }

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -60,7 +60,7 @@ namespace NitroxClient.GameLogic
             entitySpawnersByType[typeof(PrefabPlaceholderEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(EscapePodEntity)] = new EscapePodEntitySpawner(localPlayer);
             entitySpawnersByType[typeof(PlayerEntity)] = new PlayerEntitySpawner(playerManager, localPlayer);
-            entitySpawnersByType[typeof(VehicleWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
+            entitySpawnersByType[typeof(VehicleEntity)] = new VehicleEntitySpawner();
             entitySpawnersByType[typeof(SerializedWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(GlobalRootEntity)] = new GlobalRootEntitySpawner();
             entitySpawnersByType[typeof(BaseLeakEntity)] = new BaseLeakEntitySpawner(liveMixinManager);

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -121,7 +121,7 @@ namespace NitroxClient.GameLogic
         {
             if (coldStart)
             {
-                yield return null;
+                yield return null; // Skips a frame
             }
 
             // The coroutine waits a frame after SpawnBatchAsync finishes, and another entity may be enqueued then, so a loop is needed

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -59,7 +59,7 @@ namespace NitroxClient.GameLogic
             entitySpawnersByType[typeof(PlaceholderGroupWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(PrefabPlaceholderEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(EscapePodEntity)] = new EscapePodEntitySpawner(localPlayer);
-            entitySpawnersByType[typeof(PlayerWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
+            entitySpawnersByType[typeof(PlayerEntity)] = new PlayerEntitySpawner(playerManager, localPlayer);
             entitySpawnersByType[typeof(VehicleWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(SerializedWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(GlobalRootEntity)] = new GlobalRootEntitySpawner();

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -117,8 +117,13 @@ namespace NitroxClient.GameLogic
             packetSender.Send(new EntitySpawnedByClient(entity, requireRespawn));
         }
 
-        private IEnumerator SpawnNewEntities()
+        private IEnumerator SpawnNewEntities(bool coldStart = false)
         {
+            if (coldStart)
+            {
+                yield return null;
+            }
+
             // The coroutine waits a frame after SpawnBatchAsync finishes, and another entity may be enqueued then, so a loop is needed
             while (EntitiesToSpawn.Count > 0)
             {
@@ -132,13 +137,13 @@ namespace NitroxClient.GameLogic
             simulationOwnership.ClearNewerSimulations();
         }
 
-        public void EnqueueEntitiesToSpawn(List<Entity> entitiesToEnqueue)
+        public void EnqueueEntitiesToSpawn(List<Entity> entitiesToEnqueue, bool coldStart = false)
         {
             EntitiesToSpawn.InsertRange(0, entitiesToEnqueue);
             if (!spawningEntities)
             {
                 spawningEntities = true;
-                CoroutineHost.StartCoroutine(SpawnNewEntities());
+                CoroutineHost.StartCoroutine(SpawnNewEntities(coldStart));
             }
         }
 

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -58,7 +58,7 @@ namespace NitroxClient.GameLogic
             entitySpawnersByType[typeof(WorldEntity)] = new WorldEntitySpawner(entityMetadataManager, playerManager, localPlayer, this, simulationOwnership);
             entitySpawnersByType[typeof(PlaceholderGroupWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(PrefabPlaceholderEntity)] = entitySpawnersByType[typeof(WorldEntity)];
-            entitySpawnersByType[typeof(EscapePodWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
+            entitySpawnersByType[typeof(EscapePodEntity)] = new EscapePodEntitySpawner(localPlayer);
             entitySpawnersByType[typeof(PlayerWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(VehicleWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];
             entitySpawnersByType[typeof(SerializedWorldEntity)] = entitySpawnersByType[typeof(WorldEntity)];

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -101,6 +101,7 @@ public class Items
         NitroxId id = NitroxEntity.GetIdOrGenerateNew(gameObject);
         Optional<EntityMetadata> metadata = entityMetadataManager.Extract(gameObject);
         string classId = gameObject.GetComponent<PrefabIdentifier>().ClassId;
+        int level = gameObject.TryGetComponent(out LargeWorldEntity largeWorldEntity) ? (int)largeWorldEntity.cellLevel : 0;
 
         WorldEntity droppedItem;
         List<Entity> childrenEntities = GetPrefabChildren(gameObject, id, entityMetadataManager).ToList();
@@ -111,7 +112,7 @@ public class Items
         {
             // We cast it to an entity type that is always seeable by clients
             // therefore, the packet will be redirected to everyone
-            droppedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), 0, classId, true, id, techType.Value.ToDto(), metadata.OrNull(), parentId, childrenEntities);
+            droppedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.Value.ToDto(), metadata.OrNull(), parentId, childrenEntities);
         }
         else if (gameObject.TryGetComponent(out OxygenPipe oxygenPipe))
         {
@@ -136,13 +137,13 @@ public class Items
             oxygenPipe.rootPipeUID = rootPipeId.ToString();
             oxygenPipe.parentPipeUID = parentPipeId.ToString();
 
-            droppedItem = new OxygenPipeEntity(gameObject.transform.ToWorldDto(), 0, classId, false, id, techType.Value.ToDto(), metadata.OrNull(), null,
-                                              childrenEntities, rootPipeId, parentPipeId, parentConnection.GetAttachPoint().ToDto());
+            droppedItem = new OxygenPipeEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.Value.ToDto(), metadata.OrNull(), null,
+                                              childrenEntities, parentPipeId, rootPipeId, parentConnection.GetAttachPoint().ToDto());
         }
         else
         {
             // Generic case
-            droppedItem = new(gameObject.transform.ToWorldDto(), 0, classId, false, id, techType.Value.ToDto(), metadata.OrNull(), null, childrenEntities);
+            droppedItem = new(gameObject.transform.ToWorldDto(), level, classId, false, id, techType.Value.ToDto(), metadata.OrNull(), null, childrenEntities);
         }
 
         if (packetSender.Send(new EntitySpawnedByClient(droppedItem, true)))
@@ -161,6 +162,7 @@ public class Items
         NitroxId id = NitroxEntity.GetIdOrGenerateNew(gameObject);
         Optional<EntityMetadata> metadata = entityMetadataManager.Extract(gameObject);
         string classId = gameObject.GetComponent<PrefabIdentifier>().ClassId;
+        int level = gameObject.TryGetComponent(out LargeWorldEntity largeWorldEntity) ? (int)largeWorldEntity.cellLevel : 0;
 
         List<Entity> childrenEntities = GetPrefabChildren(gameObject, id, entityMetadataManager).ToList();
         WorldEntity placedItem;
@@ -171,14 +173,14 @@ public class Items
         switch (gameObject.AliveOrNull())
         {
             case not null when IsGlobalRootObject(gameObject):
-                placedItem = new GlobalRootEntity(gameObject.transform.ToWorldDto(), 0, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
+                placedItem = new GlobalRootEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
                 break;
             case not null when Player.main.AliveOrNull()?.GetCurrentSub().AliveOrNull()?.TryGetNitroxId(out NitroxId parentId) == true:
-                placedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), 0, classId, true, id, techType.ToDto(), metadata.OrNull(), parentId, childrenEntities);
+                placedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), parentId, childrenEntities);
                 break;
             default:
                 // If the object is not under a SubRoot nor in GlobalRoot, it'll be under a CellRoot but we still want to remember its state
-                placedItem = new PlacedWorldEntity(gameObject.transform.ToWorldDto(), 0, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
+                placedItem = new PlacedWorldEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
                 break;
         }
 

--- a/NitroxClient/GameLogic/MobileVehicleBay.cs
+++ b/NitroxClient/GameLogic/MobileVehicleBay.cs
@@ -40,7 +40,7 @@ public class MobileVehicleBay
 
         NitroxId constructedObjectId = NitroxEntity.GenerateNewId(constructedObject);
 
-        VehicleWorldEntity vehicleEntity = Vehicles.BuildVehicleWorldEntity(constructedObject, constructedObjectId, techType, constructorId);
+        VehicleEntity vehicleEntity = Vehicles.BuildVehicleEntity(constructedObject, constructedObjectId, techType, constructorId);
 
         packetSender.Send(new EntitySpawnedByClient(vehicleEntity));
         // TODO: Fix remote players treating the SimulationOwnership change on the vehicle (they can't find it) even tho they're still in the

--- a/NitroxClient/GameLogic/NitroxConsole.cs
+++ b/NitroxClient/GameLogic/NitroxConsole.cs
@@ -51,7 +51,7 @@ namespace NitroxClient.GameLogic
         {
             NitroxId id = NitroxEntity.GetIdOrGenerateNew(gameObject);
 
-            VehicleWorldEntity vehicleEntity = Vehicles.BuildVehicleWorldEntity(gameObject, id, techType);
+            VehicleEntity vehicleEntity = Vehicles.BuildVehicleEntity(gameObject, id, techType);
             
             packetSender.Send(new EntitySpawnedByClient(vehicleEntity));
 

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -82,6 +82,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
     public static BuildEntity From(Base targetBase, EntityMetadataManager entityMetadataManager)
     {
         BuildEntity buildEntity = BuildEntity.MakeEmpty();
+        buildEntity.Level = (int)LargeWorldEntity.CellLevel.Global;
         if (targetBase.TryGetNitroxId(out NitroxId baseId))
         {
             buildEntity.Id = baseId;

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -50,7 +50,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
 #if DEBUG
         Log.Verbose($"Took {stopwatch.ElapsedMilliseconds}ms to create the Base");
 #endif
-        yield return entities.SpawnBatchAsync(entity.ChildEntities.OfType<PlayerWorldEntity>().ToList<Entity>());
+        yield return entities.SpawnBatchAsync(entity.ChildEntities.OfType<PlayerEntity>().ToList<Entity>());
         yield return MoonpoolManager.RestoreMoonpools(entity.ChildEntities.OfType<MoonpoolEntity>(), @base);
 
         TaskResult<Optional<GameObject>> childResult = new();

--- a/NitroxClient/GameLogic/Spawning/Bases/GhostEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/GhostEntitySpawner.cs
@@ -34,6 +34,7 @@ public class GhostEntitySpawner : EntitySpawner<GhostEntity>
     public static GhostEntity From(ConstructableBase constructableBase)
     {
         GhostEntity ghost = GhostEntity.MakeEmpty();
+        ghost.Level = (int)LargeWorldEntity.CellLevel.Global;
         ModuleEntitySpawner.FillObject(ghost, constructableBase);
 
         if (constructableBase.moduleFace.HasValue)

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -117,6 +117,8 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
     public static InteriorPieceEntity From(IBaseModule module, EntityMetadataManager entityMetadataManager)
     {
         InteriorPieceEntity interiorPiece = InteriorPieceEntity.MakeEmpty();
+        interiorPiece.Level = (int)LargeWorldEntity.CellLevel.Global;
+
         GameObject gameObject = (module as Component).gameObject;
         if (gameObject && gameObject.TryGetComponent(out PrefabIdentifier identifier))
         {

--- a/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
@@ -153,6 +153,7 @@ public class ModuleEntitySpawner : EntitySpawner<ModuleEntity>
     public static ModuleEntity From(Constructable constructable)
     {
         ModuleEntity module = ModuleEntity.MakeEmpty();
+        module.Level = (int)LargeWorldEntity.CellLevel.Global;
         FillObject(module, constructable);
         return module;
     }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/DefaultWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/DefaultWorldEntitySpawner.cs
@@ -44,13 +44,19 @@ public class DefaultWorldEntitySpawner : IWorldEntitySpawner, IWorldEntitySyncSp
             Items.TryGetParentWaterPark(parent.Value.transform.parent, out parentWaterPark);
         }
 
+        LargeWorldEntity largeWorldEntity = gameObject.GetComponent<LargeWorldEntity>();
+        if (largeWorldEntity)
+        {
+            largeWorldEntity.cellLevel = (LargeWorldEntity.CellLevel)entity.Level;
+        }
+
         if (!parentWaterPark)
         {
             if (parent.HasValue && !parent.Value.GetComponent<LargeWorldEntityCell>())
             {
                 LargeWorldEntity.Register(gameObject); // This calls SetActive on the GameObject
             }
-            else if (gameObject.GetComponent<LargeWorldEntity>() && !gameObject.transform.parent && cellRoot.liveRoot)
+            else if (largeWorldEntity && !gameObject.transform.parent && cellRoot.liveRoot)
             {
                 gameObject.transform.SetParent(cellRoot.liveRoot.transform, true);
                 LargeWorldEntity.Register(gameObject);

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
@@ -24,7 +24,6 @@ public class WorldEntitySpawnerResolver
     public WorldEntitySpawnerResolver(EntityMetadataManager entityMetadataManager, PlayerManager playerManager, LocalPlayer localPlayer, Entities entities, SimulationOwnership simulationOwnership)
     {
         customSpawnersByTechType[TechType.Crash] = new CrashEntitySpawner();
-        customSpawnersByTechType[TechType.EscapePod] = new EscapePodWorldEntitySpawner(localPlayer);
         customSpawnersByTechType[TechType.Creepvine] = new CreepvineEntitySpawner(defaultEntitySpawner);
 
         vehicleWorldEntitySpawner = new VehicleWorldEntitySpawner(entities);

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
@@ -12,7 +12,6 @@ public class WorldEntitySpawnerResolver
 
     private readonly PrefabPlaceholderEntitySpawner prefabPlaceholderEntitySpawner;
     private readonly PlaceholderGroupWorldEntitySpawner placeholderGroupWorldEntitySpawner;
-    private readonly PlayerWorldEntitySpawner playerWorldEntitySpawner;
     private readonly SerializedWorldEntitySpawner serializedWorldEntitySpawner;
     private readonly GeyserWorldEntitySpawner geyserWorldEntitySpawner;
     private readonly ReefbackEntitySpawner reefbackEntitySpawner;
@@ -29,7 +28,6 @@ public class WorldEntitySpawnerResolver
         vehicleWorldEntitySpawner = new VehicleWorldEntitySpawner(entities);
         prefabPlaceholderEntitySpawner = new PrefabPlaceholderEntitySpawner(defaultEntitySpawner);
         placeholderGroupWorldEntitySpawner = new PlaceholderGroupWorldEntitySpawner(entities, this, defaultEntitySpawner, entityMetadataManager, prefabPlaceholderEntitySpawner);
-        playerWorldEntitySpawner = new PlayerWorldEntitySpawner(playerManager, localPlayer);
         serializedWorldEntitySpawner = new SerializedWorldEntitySpawner();
         geyserWorldEntitySpawner = new GeyserWorldEntitySpawner(entities);
         reefbackChildEntitySpawner = new ReefbackChildEntitySpawner();
@@ -45,8 +43,6 @@ public class WorldEntitySpawnerResolver
                 return prefabPlaceholderEntitySpawner;
             case PlaceholderGroupWorldEntity:
                 return placeholderGroupWorldEntitySpawner;
-            case PlayerWorldEntity:
-                return playerWorldEntitySpawner;
             case VehicleWorldEntity:
                 return vehicleWorldEntitySpawner;
             case SerializedWorldEntity:

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
@@ -8,7 +8,6 @@ namespace NitroxClient.GameLogic.Spawning.WorldEntities;
 public class WorldEntitySpawnerResolver
 {
     private readonly DefaultWorldEntitySpawner defaultEntitySpawner = new();
-    private readonly VehicleWorldEntitySpawner vehicleWorldEntitySpawner;
 
     private readonly PrefabPlaceholderEntitySpawner prefabPlaceholderEntitySpawner;
     private readonly PlaceholderGroupWorldEntitySpawner placeholderGroupWorldEntitySpawner;
@@ -25,7 +24,6 @@ public class WorldEntitySpawnerResolver
         customSpawnersByTechType[TechType.Crash] = new CrashEntitySpawner();
         customSpawnersByTechType[TechType.Creepvine] = new CreepvineEntitySpawner(defaultEntitySpawner);
 
-        vehicleWorldEntitySpawner = new VehicleWorldEntitySpawner(entities);
         prefabPlaceholderEntitySpawner = new PrefabPlaceholderEntitySpawner(defaultEntitySpawner);
         placeholderGroupWorldEntitySpawner = new PlaceholderGroupWorldEntitySpawner(entities, this, defaultEntitySpawner, entityMetadataManager, prefabPlaceholderEntitySpawner);
         serializedWorldEntitySpawner = new SerializedWorldEntitySpawner();
@@ -43,8 +41,6 @@ public class WorldEntitySpawnerResolver
                 return prefabPlaceholderEntitySpawner;
             case PlaceholderGroupWorldEntity:
                 return placeholderGroupWorldEntitySpawner;
-            case VehicleWorldEntity:
-                return vehicleWorldEntitySpawner;
             case SerializedWorldEntity:
                 return serializedWorldEntitySpawner;
             case GeyserWorldEntity:

--- a/NitroxClient/GameLogic/Spawning/WorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntitySpawner.cs
@@ -30,15 +30,15 @@ public class WorldEntitySpawner : SyncEntitySpawner<WorldEntity>
 
     protected override IEnumerator SpawnAsync(WorldEntity entity, TaskResult<Optional<GameObject>> result)
     {
-        bool found = TryFindAwakeParentCell(entity, out EntityCell parentCell);
-        if (found)
+        bool foundParentCell = TryFindAwakeParentCell(entity, out EntityCell parentCell);
+        if (foundParentCell)
         {
             parentCell.EnsureRoot();
         }
         Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
 
         // No place to spawn the entity
-        if (!found && !parent.HasValue)
+        if (!foundParentCell && !parent.HasValue)
         {
             return null;
         }
@@ -62,15 +62,15 @@ public class WorldEntitySpawner : SyncEntitySpawner<WorldEntity>
 
     protected override bool SpawnSync(WorldEntity entity, TaskResult<Optional<GameObject>> result)
     {
-        bool found = TryFindAwakeParentCell(entity, out EntityCell parentCell);
-        if (found)
+        bool foundParentCell = TryFindAwakeParentCell(entity, out EntityCell parentCell);
+        if (foundParentCell)
         {
             parentCell.EnsureRoot();
         }
         Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
 
         // No place to spawn the entity
-        if (!found && !parent.HasValue)
+        if (!foundParentCell && !parent.HasValue)
         {
             return true;
         }

--- a/NitroxClient/GameLogic/Spawning/WorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntitySpawner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
@@ -31,24 +30,28 @@ public class WorldEntitySpawner : SyncEntitySpawner<WorldEntity>
 
     protected override IEnumerator SpawnAsync(WorldEntity entity, TaskResult<Optional<GameObject>> result)
     {
-        EntityCell cellRoot = EnsureCell(entity);
-        if (cellRoot == null)
+        bool found = TryFindAwakeParentCell(entity, out EntityCell parentCell);
+        if (found)
         {
-            // Error logging is done in EnsureCell
+            parentCell.EnsureRoot();
+        }
+        Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
+
+        // No place to spawn the entity
+        if (!found && !parent.HasValue)
+        {
             return null;
         }
-
-        Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
 
         IWorldEntitySpawner entitySpawner = worldEntitySpawnResolver.ResolveEntitySpawner(entity);
 
         if (entitySpawner is IWorldEntitySyncSpawner syncSpawner &&
-            syncSpawner.SpawnSync(entity, parent, cellRoot, result))
+            syncSpawner.SpawnSync(entity, parent, parentCell, result))
         {
             return null;
         }
 
-        return entitySpawner.SpawnAsync(entity, parent, cellRoot, result);
+        return entitySpawner.SpawnAsync(entity, parent, parentCell, result);
     }
 
     protected override bool SpawnsOwnChildren(WorldEntity entity)
@@ -59,17 +62,39 @@ public class WorldEntitySpawner : SyncEntitySpawner<WorldEntity>
 
     protected override bool SpawnSync(WorldEntity entity, TaskResult<Optional<GameObject>> result)
     {
-        EntityCell cellRoot = EnsureCell(entity);
-        if (cellRoot == null)
+        bool found = TryFindAwakeParentCell(entity, out EntityCell parentCell);
+        if (found)
         {
-            // Error logging is done in EnsureCell
+            parentCell.EnsureRoot();
+        }
+        Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
+
+        // No place to spawn the entity
+        if (!found && !parent.HasValue)
+        {
             return true;
         }
 
-        Optional<GameObject> parent = (entity.ParentId != null) ? NitroxEntity.GetObjectFrom(entity.ParentId) : Optional.Empty;
         IWorldEntitySpawner entitySpawner = worldEntitySpawnResolver.ResolveEntitySpawner(entity);
 
-        return entitySpawner is IWorldEntitySyncSpawner syncSpawner && syncSpawner.SpawnSync(entity, parent, cellRoot, result);
+        return entitySpawner is IWorldEntitySyncSpawner syncSpawner && syncSpawner.SpawnSync(entity, parent, parentCell, result);
+    }
+
+    public bool TryFindAwakeParentCell(WorldEntity entity, out EntityCell parentCell)
+    {
+        Int3 batchId = entity.AbsoluteEntityCell.BatchId.ToUnity();
+        Int3 cellId = entity.AbsoluteEntityCell.CellId.ToUnity();
+
+        if (batchCellsById.TryGetValue(batchId, out BatchCells batchCells))
+        {
+            parentCell = batchCells.Get(cellId, entity.Level);
+            // in both states, the cell is awake
+            return parentCell != null &&
+                   (parentCell.state == EntityCell.State.IsAwake || parentCell.state == EntityCell.State.QueuedForSleep);
+        }
+
+        parentCell = null;
+        return false;
     }
 
     public EntityCell EnsureCell(WorldEntity entity)

--- a/NitroxClient/GameLogic/Terrain.cs
+++ b/NitroxClient/GameLogic/Terrain.cs
@@ -34,6 +34,7 @@ public class Terrain
 
         if (!visibleCells.Contains(cell))
         {
+            removedCells.Remove(cell);
             visibleCells.Add(cell);
             addedCells.Add(cell);
             cellsPendingSync = true;

--- a/NitroxClient/GameLogic/Vehicles.cs
+++ b/NitroxClient/GameLogic/Vehicles.cs
@@ -165,9 +165,9 @@ public class Vehicles
         }
     }
 
-    public static VehicleWorldEntity BuildVehicleWorldEntity(GameObject constructedObject, NitroxId constructedObjectId, TechType techType, NitroxId constructorId = null)
+    public static VehicleEntity BuildVehicleEntity(GameObject constructedObject, NitroxId constructedObjectId, TechType techType, NitroxId constructorId = null)
     {
-        VehicleWorldEntity vehicleEntity = new(constructorId, DayNightCycle.main.timePassedAsFloat, constructedObject.transform.ToLocalDto(), string.Empty, false, constructedObjectId, techType.ToDto(), null);
+        VehicleEntity vehicleEntity = new(constructorId, DayNightCycle.main.timePassedAsFloat, constructedObject.transform.ToLocalDto(), string.Empty, false, constructedObjectId, techType.ToDto(), null);
         VehicleChildEntityHelper.PopulateChildren(constructedObjectId, constructedObject.GetFullHierarchyPath(), vehicleEntity.ChildEntities, constructedObject);
         return vehicleEntity;
     }

--- a/NitroxClient/MonoBehaviours/MoonpoolManager.cs
+++ b/NitroxClient/MonoBehaviours/MoonpoolManager.cs
@@ -123,7 +123,7 @@ public class MoonpoolManager : MonoBehaviour
     {
         foreach (MoonpoolEntity moonpoolEntity in moonpoolsByCell.Values)
         {
-            VehicleWorldEntity moonpoolVehicleEntity = moonpoolEntity.ChildEntities.OfType<VehicleWorldEntity>().FirstOrFallback(null);
+            VehicleEntity moonpoolVehicleEntity = moonpoolEntity.ChildEntities.OfType<VehicleEntity>().FirstOrFallback(null);
             if (moonpoolVehicleEntity != null)
             {
                 yield return entities.SpawnEntityAsync(moonpoolVehicleEntity);

--- a/NitroxModel/DataStructures/GameLogic/Entities/EscapePodWorldEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/EscapePodWorldEntity.cs
@@ -9,18 +9,18 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 
 [Serializable]
 [DataContract]
-public class EscapePodWorldEntity : GlobalRootEntity
+public class EscapePodEntity : GlobalRootEntity
 {
     [DataMember(Order = 1)]
     public List<ushort> Players { get; set; } = [];
 
     [IgnoreConstructor]
-    protected EscapePodWorldEntity()
+    protected EscapePodEntity()
     {
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public EscapePodWorldEntity(NitroxVector3 position, NitroxId id, EntityMetadata metadata)
+    public EscapePodEntity(NitroxVector3 position, NitroxId id, EntityMetadata metadata)
     {
         Transform = new NitroxTransform(position, NitroxQuaternion.Identity, NitroxVector3.One);
         Id = id;
@@ -33,7 +33,7 @@ public class EscapePodWorldEntity : GlobalRootEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public EscapePodWorldEntity(List<ushort> players, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public EscapePodEntity(List<ushort> players, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         Players = players;
@@ -41,6 +41,6 @@ public class EscapePodWorldEntity : GlobalRootEntity
 
     public override string ToString()
     {
-        return $"[EscapePodWorldEntity Players: [{string.Join(", ", Players)}] {base.ToString()}]";
+        return $"[EscapePodEntity Players: [{string.Join(", ", Players)}] {base.ToString()}]";
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -17,7 +17,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 [ProtoInclude(54, typeof(ModuleEntity))]
 [ProtoInclude(55, typeof(MoonpoolEntity))]
 [ProtoInclude(56, typeof(PlanterEntity))]
-[ProtoInclude(57, typeof(PlayerWorldEntity))]
+[ProtoInclude(57, typeof(PlayerEntity))]
 [ProtoInclude(58, typeof(VehicleWorldEntity))]
 [ProtoInclude(59, typeof(RadiationLeakEntity))]
 public class GlobalRootEntity : WorldEntity

--- a/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -22,6 +22,9 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 [ProtoInclude(59, typeof(RadiationLeakEntity))]
 public class GlobalRootEntity : WorldEntity
 {
+    [IgnoreDataMember]
+    public const int GLOBAL_ROOT_LEVEL = 100;
+
     [IgnoreConstructor]
     protected GlobalRootEntity()
     {

--- a/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -18,7 +18,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 [ProtoInclude(55, typeof(MoonpoolEntity))]
 [ProtoInclude(56, typeof(PlanterEntity))]
 [ProtoInclude(57, typeof(PlayerEntity))]
-[ProtoInclude(58, typeof(VehicleWorldEntity))]
+[ProtoInclude(58, typeof(VehicleEntity))]
 [ProtoInclude(59, typeof(RadiationLeakEntity))]
 public class GlobalRootEntity : WorldEntity
 {

--- a/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -11,7 +11,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 
 [Serializable, DataContract]
 [ProtoInclude(50, typeof(BuildEntity))]
-[ProtoInclude(51, typeof(EscapePodWorldEntity))]
+[ProtoInclude(51, typeof(EscapePodEntity))]
 [ProtoInclude(52, typeof(InteriorPieceEntity))]
 [ProtoInclude(53, typeof(MapRoomEntity))]
 [ProtoInclude(54, typeof(ModuleEntity))]

--- a/NitroxModel/DataStructures/GameLogic/Entities/OxygenPipeEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/OxygenPipeEntity.cs
@@ -33,4 +33,9 @@ public class OxygenPipeEntity : WorldEntity
         RootPipeId = rootPipeId;
         ParentPosition = parentPosition;
     }
+
+    public override string ToString()
+    {
+        return $"[{nameof(OxygenPipeEntity)} ParentPipeId: {ParentPipeId}, RootPipeId: {RootPipeId}, ParentPosition: {ParentPosition} {base.ToString()}]";
+    }
 }

--- a/NitroxModel/DataStructures/GameLogic/Entities/PlayerEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/PlayerEntity.cs
@@ -9,10 +9,10 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 
 [Serializable]
 [DataContract]
-public class PlayerWorldEntity : GlobalRootEntity
+public class PlayerEntity : GlobalRootEntity
 {
     [IgnoreConstructor]
-    protected PlayerWorldEntity()
+    protected PlayerEntity()
     {
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
@@ -21,7 +21,7 @@ public class PlayerWorldEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public PlayerWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public PlayerEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities) {}
 
     public override string ToString()

--- a/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
@@ -23,8 +23,9 @@ public class VehicleEntity : GlobalRootEntity
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
+    // 100 is GlobalRoot level
     public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata) :
-        base(transform, 0, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
+        base(transform, 100, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
     {
         SpawnerId = spawnerId;
         ConstructionTime = constructionTime;

--- a/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
@@ -9,7 +9,7 @@ namespace NitroxModel.DataStructures.GameLogic.Entities;
 
 [Serializable]
 [DataContract]
-public class VehicleWorldEntity : GlobalRootEntity
+public class VehicleEntity : GlobalRootEntity
 {
     [DataMember(Order = 1)]
     public NitroxId SpawnerId { get; set; }
@@ -18,12 +18,12 @@ public class VehicleWorldEntity : GlobalRootEntity
     public float ConstructionTime { get; set; }
 
     [IgnoreConstructor]
-    protected VehicleWorldEntity()
+    protected VehicleEntity()
     {
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public VehicleWorldEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata) :
+    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata) :
         base(transform, 0, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
     {
         SpawnerId = spawnerId;
@@ -31,7 +31,7 @@ public class VehicleWorldEntity : GlobalRootEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public VehicleWorldEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         SpawnerId = spawnerId;

--- a/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
+++ b/NitroxModel/DataStructures/GameLogic/Entities/VehicleEntity.cs
@@ -23,9 +23,8 @@ public class VehicleEntity : GlobalRootEntity
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    // 100 is GlobalRoot level
     public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata) :
-        base(transform, 100, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
+        base(transform, GLOBAL_ROOT_LEVEL, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
     {
         SpawnerId = spawnerId;
         ConstructionTime = constructionTime;

--- a/NitroxModel/Packets/PlayerJoinedMultiplayerSession.cs
+++ b/NitroxModel/Packets/PlayerJoinedMultiplayerSession.cs
@@ -11,12 +11,12 @@ public class PlayerJoinedMultiplayerSession : Packet
 {
     public PlayerContext PlayerContext { get; }
     public Optional<NitroxId> SubRootId { get; }
-    public PlayerWorldEntity PlayerWorldEntity { get; }
+    public PlayerEntity PlayerEntity { get; }
 
-    public PlayerJoinedMultiplayerSession(PlayerContext playerContext, Optional<NitroxId> subRootId, PlayerWorldEntity playerWorldEntity)
+    public PlayerJoinedMultiplayerSession(PlayerContext playerContext, Optional<NitroxId> subRootId, PlayerEntity playerEntity)
     {
         PlayerContext = playerContext;
         SubRootId = subRootId;
-        PlayerWorldEntity = playerWorldEntity;
+        PlayerEntity = playerEntity;
     }
 }

--- a/NitroxModel/Packets/SpawnEntities.cs
+++ b/NitroxModel/Packets/SpawnEntities.cs
@@ -13,10 +13,10 @@ namespace NitroxModel.Packets
 
         public bool ForceRespawn { get; }
 
-        public SpawnEntities(List<Entity> entities)
+        public SpawnEntities(List<Entity> entities, bool forceRespawn = false)
         {
             Entities = entities;
-            ForceRespawn = false;
+            ForceRespawn = forceRespawn;
         }
 
         public SpawnEntities(Entity entity, SimulatedEntity simulatedEntity = null, bool forceRespawn = false)

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using NitroxClient.GameLogic.Spawning.WorldEntities;
+using NitroxClient.GameLogic.Spawning;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -10,6 +10,6 @@ public sealed partial class EscapePod_Awake_Patch : NitroxPatch, IDynamicPatch
 
     public static bool Prefix(EscapePod __instance)
     {
-        return !EscapePodWorldEntitySpawner.SuppressEscapePodAwakeMethod;
+        return !EscapePodEntitySpawner.SuppressEscapePodAwakeMethod;
     }
 }

--- a/NitroxServer-Subnautica/GameLogic/Entities/SimulationWhitelist.cs
+++ b/NitroxServer-Subnautica/GameLogic/Entities/SimulationWhitelist.cs
@@ -67,7 +67,8 @@ public class SimulationWhitelist : ISimulationWhitelist
         TechType.RockPuncher.ToDto(),
         TechType.Peeper.ToDto(),
         TechType.Jumper.ToDto(),
-        TechType.Constructor.ToDto()
+        TechType.Constructor.ToDto(),
+        TechType.PipeSurfaceFloater.ToDto(),
     };
 
     /// <inheritdoc cref="ISimulationWhitelist.UtilityWhitelist" />

--- a/NitroxServer/Communication/Packets/Processors/CellVisibilityChangedProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/CellVisibilityChangedProcessor.cs
@@ -47,7 +47,7 @@ public class CellVisibilityChangedProcessor : AuthenticatedPacketProcessor<CellV
 
         if (totalEntities.Count > 0)
         {
-            SpawnEntities batchEntities = new(totalEntities);
+            SpawnEntities batchEntities = new(totalEntities, true);
             player.SendPacket(batchEntities);
         }
     }

--- a/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/EntityDestroyedPacketProcessor.cs
@@ -1,6 +1,5 @@
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.GameLogic.Entities;
-using NitroxModel.DataStructures.Util;
 using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
@@ -27,9 +26,9 @@ public class EntityDestroyedPacketProcessor : AuthenticatedPacketProcessor<Entit
 
         if (worldEntityManager.TryDestroyEntity(packet.Id, out Entity entity))
         {
-            if (entity is VehicleWorldEntity vehicleWorldEntity)
+            if (entity is VehicleEntity vehicleEntity)
             {
-                worldEntityManager.MovePlayerChildrenToRoot(vehicleWorldEntity);
+                worldEntityManager.MovePlayerChildrenToRoot(vehicleEntity);
             }
 
             foreach (Player player in playerManager.GetConnectedPlayers())

--- a/NitroxServer/Communication/Packets/Processors/PlayerInCyclopsMovementProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerInCyclopsMovementProcessor.cs
@@ -19,18 +19,18 @@ public class PlayerInCyclopsMovementProcessor : AuthenticatedPacketProcessor<Pla
 
     public override void Process(PlayerInCyclopsMovement packet, Player player)
     {
-        if (entityRegistry.TryGetEntityById(player.PlayerContext.PlayerNitroxId, out PlayerWorldEntity playerWorldEntity))
+        if (entityRegistry.TryGetEntityById(player.PlayerContext.PlayerNitroxId, out PlayerEntity playerEntity))
         {
-            playerWorldEntity.Transform.LocalPosition = packet.LocalPosition;
-            playerWorldEntity.Transform.LocalRotation = packet.LocalRotation;
+            playerEntity.Transform.LocalPosition = packet.LocalPosition;
+            playerEntity.Transform.LocalRotation = packet.LocalRotation;
 
-            player.Position = playerWorldEntity.Transform.Position;
-            player.Rotation = playerWorldEntity.Transform.Rotation;
+            player.Position = playerEntity.Transform.Position;
+            player.Rotation = playerEntity.Transform.Rotation;
             playerManager.SendPacketToOtherPlayers(packet, player);
         }
         else
         {
-            Log.ErrorOnce($"{nameof(PlayerWorldEntity)} couldn't be found for player {player.Name}. It is adviced the player reconnects before losing too much progression.");
+            Log.ErrorOnce($"{nameof(PlayerEntity)} couldn't be found for player {player.Name}. It is adviced the player reconnects before losing too much progression.");
         }
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -105,19 +105,19 @@ namespace NitroxServer.Communication.Packets.Processors
                                                       .Select(p => p.PlayerContext);
         }
 
-        private PlayerWorldEntity SetupPlayerEntity(Player player)
+        private PlayerEntity SetupPlayerEntity(Player player)
         {
             NitroxTransform transform = new(player.Position, player.Rotation, NitroxVector3.One);
 
-            PlayerWorldEntity playerEntity = new PlayerWorldEntity(transform, 0, null, false, player.GameObjectId, NitroxTechType.None, null, null, new List<Entity>());
+            PlayerEntity playerEntity = new PlayerEntity(transform, 0, null, false, player.GameObjectId, NitroxTechType.None, null, null, new List<Entity>());
             entityRegistry.AddOrUpdate(playerEntity);
             world.WorldEntityManager.TrackEntityInTheWorld(playerEntity);
             return playerEntity;
         }
 
-        private PlayerWorldEntity RespawnExistingEntity(Player player)
+        private PlayerEntity RespawnExistingEntity(Player player)
         {
-            if (entityRegistry.TryGetEntityById(player.PlayerContext.PlayerNitroxId, out PlayerWorldEntity playerWorldEntity))
+            if (entityRegistry.TryGetEntityById(player.PlayerContext.PlayerNitroxId, out PlayerEntity playerWorldEntity))
             {
                 return playerWorldEntity;
             }

--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -43,7 +43,7 @@ namespace NitroxServer.Communication.Packets.Processors
         public override void Process(PlayerJoiningMultiplayerSession packet, INitroxConnection connection)
         {
             Player player = playerManager.PlayerConnected(connection, packet.ReservationKey, out bool wasBrandNewPlayer);
-            NitroxId assignedEscapePodId = world.EscapePodManager.AssignPlayerToEscapePod(player.Id, out Optional<EscapePodWorldEntity> newlyCreatedEscapePod);
+            NitroxId assignedEscapePodId = world.EscapePodManager.AssignPlayerToEscapePod(player.Id, out Optional<EscapePodEntity> newlyCreatedEscapePod);
 
             if (wasBrandNewPlayer)
             {

--- a/NitroxServer/Communication/Packets/Processors/PlayerMovementProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerMovementProcessor.cs
@@ -21,7 +21,7 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(PlayerMovement packet, Player player)
         {
-            Optional<PlayerWorldEntity> playerEntity = entityRegistry.GetEntityById<PlayerWorldEntity>(player.PlayerContext.PlayerNitroxId);
+            Optional<PlayerEntity> playerEntity = entityRegistry.GetEntityById<PlayerEntity>(player.PlayerContext.PlayerNitroxId);
 
             if (playerEntity.HasValue)
             {

--- a/NitroxServer/GameLogic/Bases/BuildingManager.cs
+++ b/NitroxServer/GameLogic/Bases/BuildingManager.cs
@@ -80,7 +80,7 @@ public class BuildingManager
             Log.Error($"Trying to add a module to a build that isn't registered (ParentId: {moduleEntity.ParentId})");
             return false;
         }
-        if (parentEntity is not BuildEntity && parentEntity is not VehicleWorldEntity)
+        if (parentEntity is not BuildEntity && parentEntity is not VehicleEntity)
         {
             Log.Error($"Trying to add a module to an entity that is not a building/vehicle (ParentId: {moduleEntity.ParentId})");
             return false;

--- a/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
@@ -110,6 +110,15 @@ public class WorldEntityManager
                 return false;
             }
 
+            // Return early because a GlobalRootEntity doesn't have an AbsoluteEntityCell, thus it would throw an exception
+            if (worldEntity is GlobalRootEntity)
+            {
+                worldEntity.Transform.Position = position;
+                worldEntity.Transform.Rotation = rotation;
+                newCell = null;
+                return true;
+            }
+
             AbsoluteEntityCell oldCell = worldEntity.AbsoluteEntityCell;
 
             worldEntity.Transform.Position = position;

--- a/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
+++ b/NitroxServer/GameLogic/Entities/WorldEntityManager.cs
@@ -148,8 +148,8 @@ public class WorldEntityManager
 
     public void MovePlayerChildrenToRoot(GlobalRootEntity globalRootEntity)
     {
-        List<PlayerWorldEntity> playerEntities = FindPlayerEntitiesInChildren(globalRootEntity);
-        foreach (PlayerWorldEntity childPlayerEntity in playerEntities)
+        List<PlayerEntity> playerEntities = FindPlayerEntitiesInChildren(globalRootEntity);
+        foreach (PlayerEntity childPlayerEntity in playerEntities)
         {
             // Reparent the entity on top of GlobalRoot
             globalRootEntity.ChildEntities.Remove(childPlayerEntity);
@@ -357,9 +357,9 @@ public class WorldEntityManager
     /// <summary>
     /// Iterative breadth-first search which gets all children player entities in <paramref name="parentEntity"/>'s hierarchy.
     /// </summary>
-    private List<PlayerWorldEntity> FindPlayerEntitiesInChildren(Entity parentEntity)
+    private List<PlayerEntity> FindPlayerEntitiesInChildren(Entity parentEntity)
     {
-        List<PlayerWorldEntity> playerWorldEntities = [];
+        List<PlayerEntity> playerEntities = [];
         List<Entity> entitiesToSearch = [parentEntity];
 
         while (entitiesToSearch.Count > 0)
@@ -367,15 +367,15 @@ public class WorldEntityManager
             Entity currentEntity = entitiesToSearch[^1];
             entitiesToSearch.RemoveAt(entitiesToSearch.Count - 1);
 
-            if (currentEntity is PlayerWorldEntity playerWorldEntity)
+            if (currentEntity is PlayerEntity playerEntity)
             {
-                playerWorldEntities.Add(playerWorldEntity);
+                playerEntities.Add(playerEntity);
             }
             else
             {
                 entitiesToSearch.InsertRange(0, currentEntity.ChildEntities);
             }
         }
-        return playerWorldEntities;
+        return playerEntities;
     }
 }

--- a/NitroxServer/GameLogic/EscapePodManager.cs
+++ b/NitroxServer/GameLogic/EscapePodManager.cs
@@ -15,8 +15,8 @@ public class EscapePodManager
     private const int PLAYERS_PER_ESCAPEPOD = 50;
 
     private readonly EntityRegistry entityRegistry;
-    private readonly ThreadSafeDictionary<ushort, EscapePodWorldEntity> escapePodsByPlayerId = new();
-    private EscapePodWorldEntity podForNextPlayer;
+    private readonly ThreadSafeDictionary<ushort, EscapePodEntity> escapePodsByPlayerId = new();
+    private EscapePodEntity podForNextPlayer;
     private readonly string seed;
 
     private readonly RandomStartGenerator randomStart;
@@ -27,17 +27,17 @@ public class EscapePodManager
         this.randomStart = randomStart;
         this.entityRegistry = entityRegistry;
 
-        List<EscapePodWorldEntity> escapePods = entityRegistry.GetEntities<EscapePodWorldEntity>();
+        List<EscapePodEntity> escapePods = entityRegistry.GetEntities<EscapePodEntity>();
 
         InitializePodForNextPlayer(escapePods);
         InitializeEscapePodsByPlayerId(escapePods);
     }
 
-    public NitroxId AssignPlayerToEscapePod(ushort playerId, out Optional<EscapePodWorldEntity> newlyCreatedPod)
+    public NitroxId AssignPlayerToEscapePod(ushort playerId, out Optional<EscapePodEntity> newlyCreatedPod)
     {
         newlyCreatedPod = Optional.Empty;
 
-        if (escapePodsByPlayerId.TryGetValue(playerId, out EscapePodWorldEntity podEntity))
+        if (escapePodsByPlayerId.TryGetValue(playerId, out EscapePodEntity podEntity))
         {
             return podEntity.Id;
         }
@@ -54,9 +54,9 @@ public class EscapePodManager
         return podForNextPlayer.Id;
     }
 
-    private EscapePodWorldEntity CreateNewEscapePod()
+    private EscapePodEntity CreateNewEscapePod()
     {
-        EscapePodWorldEntity escapePod = new(GetStartPosition(), new NitroxId(), new EscapePodMetadata(false, false));
+        EscapePodEntity escapePod = new(GetStartPosition(), new NitroxId(), new EscapePodMetadata(false, false));
 
         escapePod.ChildEntities.Add(new PrefabChildEntity(new NitroxId(), "5c06baec-0539-4f26-817d-78443548cc52", new NitroxTechType("Radio"), 0, null, escapePod.Id));
         escapePod.ChildEntities.Add(new PrefabChildEntity(new NitroxId(), "c0175cf7-0b6a-4a1d-938f-dad0dbb6fa06", new NitroxTechType("MedicalCabinet"), 0, null, escapePod.Id));
@@ -70,7 +70,7 @@ public class EscapePodManager
 
     private NitroxVector3 GetStartPosition()
     {
-        List<EscapePodWorldEntity> escapePods = entityRegistry.GetEntities<EscapePodWorldEntity>();
+        List<EscapePodEntity> escapePods = entityRegistry.GetEntities<EscapePodEntity>();
 
         Random rnd = new(seed.GetHashCode());
         NitroxVector3 position = randomStart.GenerateRandomStartPosition(rnd);
@@ -80,7 +80,7 @@ public class EscapePodManager
             return position;
         }
 
-        foreach (EscapePodWorldEntity escapePodModel in escapePods)
+        foreach (EscapePodEntity escapePodModel in escapePods)
         {
             if (position == NitroxVector3.Zero)
             {
@@ -122,9 +122,9 @@ public class EscapePodManager
         return new NitroxVector3(lastEscapePodPosition.X + x, 0, lastEscapePodPosition.Z + z);
     }
 
-    private void InitializePodForNextPlayer(List<EscapePodWorldEntity> escapePods)
+    private void InitializePodForNextPlayer(List<EscapePodEntity> escapePods)
     {
-        foreach (EscapePodWorldEntity pod in escapePods)
+        foreach (EscapePodEntity pod in escapePods)
         {
             if (!IsPodFull(pod))
             {
@@ -136,10 +136,10 @@ public class EscapePodManager
         podForNextPlayer = CreateNewEscapePod();
     }
 
-    private void InitializeEscapePodsByPlayerId(List<EscapePodWorldEntity> escapePods)
+    private void InitializeEscapePodsByPlayerId(List<EscapePodEntity> escapePods)
     {
         escapePodsByPlayerId.Clear();
-        foreach (EscapePodWorldEntity pod in escapePods)
+        foreach (EscapePodEntity pod in escapePods)
         {
             foreach (ushort playerId in pod.Players)
             {
@@ -148,7 +148,7 @@ public class EscapePodManager
         }
     }
 
-    private static bool IsPodFull(EscapePodWorldEntity pod)
+    private static bool IsPodFull(EscapePodEntity pod)
     {
         return pod.Players.Count >= PLAYERS_PER_ESCAPEPOD;
     }

--- a/NitroxServer/Player.cs
+++ b/NitroxServer/Player.cs
@@ -40,7 +40,7 @@ namespace NitroxServer
         public ThreadSafeDictionary<string, NitroxId> EquippedItems { get; set ;}
         public ThreadSafeSet<NitroxId> OutOfCellVisibleEntities { get; set; } = [];
 
-        public PlayerWorldEntity Entity { get; set; }
+        public PlayerEntity Entity { get; set; }
 
         public Player(ushort id, string name, bool isPermaDeath, PlayerContext playerContext, INitroxConnection connection,
                       NitroxVector3 position, NitroxQuaternion rotation, NitroxId playerId, Optional<NitroxId> subRootId, Perms perms, PlayerStatsData stats, NitroxGameMode gameMode,


### PR DESCRIPTION
Can be reviewed commit by commit for ease of read

## Refactoring
Three entity types were refactored, thus killing all previous savefiles (except if you build a python script to rename those in your EntityData and GlobalRootData files):
- PlayerWorldEntity -> PlayerEntity
- VehicleWorldEntity -> VehicleEntity
- EscapePodWorldEntity -> EscapePodEntity

## Why ?
WorldEntity is special type of entities which can be spawned and move in the world
the type is inherited by GlobalRootEntity which doesn't use the cell system
thus, it must be clear which entities built uppon WorldEntity and GlobalRootEntity

Also it was the occasion to make actual entity spawners for those entities instead of using the WorldEntitySpawner which is not suited for those as they don't need cells

## Cell level fix
I've found that world entities never had their cell level applied to their GameObject, so they'd spawn and then be moved to the wrong cell (which is bad), and then, you'd never be able to find them in the right cell because you'd be loading/unloading the actualy cell when going around.

## Cold start fix
I've just thought about it quickly and it seems reasonable to add one frame to wait for cleaned up entities to actually be destroyed before spawning their replacement. And this improves a lot the logging which is no longer spammed by "unregistering id" stuff.

## Occasional stuff
I came across oxygen pipes while fixing cell level so I just made a quick fix for it (and also added a relevant movement whitelist entry)

## Potentially breaking change
I set world entities to no longer spawn when they don't have a parent or when the cell they're supposed to spawn in is no longer loaded. Thus we need some testing to find out if this broke some spawning stuff here and there.