### PR TITLE
Fix fruit plants not growing when first built

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/FruitPlant_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FruitPlant_Update_Patch.cs
@@ -35,12 +35,12 @@ public sealed partial class FruitPlant_Update_Patch : NitroxPatch, IDynamicPatch
         // If the NitroxEntity is on the distant Plantable object (e.g. fruit tree in a plant pot)
         if (PickPrefab_SetPickedUp_Patch.TryGetPlantable(__instance, out Plantable plantable) &&
             plantable.TryGetNitroxId(out entityId) &&
-            plantable.currentPlanter && plantable.currentPlanter.TryGetNitroxId(out NitroxId planterId))
+            Planter_ResetStorage_Patch.TryGetOwnerNitroxId(plantable.currentPlanter, out NitroxId ownerNitroxId))
         {
             __state = (__instance.timeNextFruit, entityId, plantable);
             // In this precise case, we look for ownership over the planter and not the plant
             // This simplifies a lot simulation ownership distribution
-            return Resolve<SimulationOwnership>().HasAnyLockType(planterId);
+            return Resolve<SimulationOwnership>().HasAnyLockType(ownerNitroxId);
         }
 
         __state = (__instance.timeNextFruit, null, null);

--- a/NitroxPatcher/Patches/Dynamic/Planter_AddItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Planter_AddItem_Patch.cs
@@ -19,10 +19,11 @@ public sealed partial class Planter_AddItem_Patch : NitroxPatch, IDynamicPatch
         }
 
         // When the planter accepts the new incoming seed, we want to send out metadata about what time the seed was planted.
-        if (plantable.TryGetNitroxId(out NitroxId id) &&
-            Resolve<SimulationOwnership>().HasAnyLockType(id))
+        if (plantable.TryGetNitroxId(out NitroxId plantableId) &&
+            Planter_ResetStorage_Patch.TryGetOwnerNitroxId(__instance, out NitroxId ownerNitroxId) &&
+            Resolve<SimulationOwnership>().HasAnyLockType(ownerNitroxId))
         {
-            Resolve<Entities>().EntityMetadataChanged(plantable, id);
+            Resolve<Entities>().EntityMetadataChanged(plantable, plantableId);
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Planter_ResetStorage_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Planter_ResetStorage_Patch.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic;
+using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 using NitroxModel.Packets;
@@ -24,12 +25,54 @@ public sealed partial class Planter_ResetStorage_Patch : NitroxPatch, IDynamicPa
 
         // This is called from WaterPark.Update so we have no proper way of suppressing it.
         // Thus we restrict to simulation ownership
-        if (!__instance.TryGetIdOrWarn(out NitroxId planterId) ||
-            !Resolve<SimulationOwnership>().HasAnyLockType(planterId))
+        if (__instance.TryGetIdOrWarn(out NitroxId planterId) &&
+            TryGetOwnerNitroxId(__instance, out NitroxId ownerNitroxId) &&
+            Resolve<SimulationOwnership>().HasAnyLockType(ownerNitroxId))
         {
-            return;
+            Resolve<IPacketSender>().Send(new ClearPlanter(planterId));
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> with <paramref name="ownerNitroxId"/> being the NitroxId of the entity responsible for the planter if it can be found.
+    /// Else returns <c>false</c>.
+    /// </summary>
+    public static bool TryGetOwnerNitroxId(Planter planter, out NitroxId ownerNitroxId)
+    {
+        if (!planter)
+        {
+            Log.WarnOnce("Tried getting owner NitroxId of null planter");
+            ownerNitroxId = null;
+            return false;
         }
 
-        Resolve<IPacketSender>().Send(new ClearPlanter(planterId));
+        // Multiple cases:
+        // 1. outdoor planter, it is responsible for itself
+        if (!planter.isIndoor)
+        {
+            return planter.TryGetNitroxId(out ownerNitroxId);
+        }
+
+        switch (planter.environment)
+        {
+            // 2. indoor planter, not in waterpark, the base is responsible
+            case Planter.PlantEnvironment.Air:
+                if (planter.TryGetComponentInParent(out Base parentBase))
+                {
+                    return parentBase.TryGetNitroxId(out ownerNitroxId);
+                }
+                break;
+
+            // 3. indoor planter, in waterpark, the water park is responsible
+            case Planter.PlantEnvironment.Water:
+                if (planter.TryGetComponentInParent(out WaterPark waterPark))
+                {
+                    return waterPark.TryGetNitroxId(out ownerNitroxId);
+                }
+                break;
+        }
+
+        ownerNitroxId = null;
+        return false;
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/EntitySpawnedByClientProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/EntitySpawnedByClientProcessor.cs
@@ -35,14 +35,14 @@ namespace NitroxServer.Communication.Packets.Processors
             if (entity is WorldEntity worldEntity)
             {
                 worldEntityManager.TrackEntityInTheWorld(worldEntity);
+            }
 
-                if (packet.RequireSimulation)
-                {
-                    simulatedEntity = entitySimulation.AssignNewEntityToPlayer(entity, playerWhoSpawned);
+            if (packet.RequireSimulation)
+            {
+                simulatedEntity = entitySimulation.AssignNewEntityToPlayer(entity, playerWhoSpawned);
 
-                    SimulationOwnershipChange ownershipChangePacket = new SimulationOwnershipChange(simulatedEntity);
-                    playerManager.SendPacketToAllPlayers(ownershipChangePacket);
-                }
+                SimulationOwnershipChange ownershipChangePacket = new SimulationOwnershipChange(simulatedEntity);
+                playerManager.SendPacketToAllPlayers(ownershipChangePacket);
             }
 
             SpawnEntities spawnEntities = new(entity, simulatedEntity, packet.RequireRespawn);


### PR DESCRIPTION
TL;DR: it's a simulation issue

What it used to be: check if planter has simulation ownership at all times. Although planter's simulation was not attributed by default

Now what it'll be

Indoors planters:
- if directly built into a base, when checking for simulating player, the check is done on the base entity
- if it's a waterpark's planter, check is done on the water park entity

Outdoor planters: the planter has proper simulation for itself

Also changed some simulation assignment logic to not restrict simulation to world entities


Fixes #2415 