### PR TITLE
Fix Linux build process

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,7 +17,7 @@
 
     <Target Name="_NitroxEmbedAssemblyInfo" AfterTargets="GetAssemblyAttributes" DependsOnTargets="PrepareForBuild;_CreateGitShortHashCacheFile">
         <PropertyGroup>
-            <_GitShortHash Condition="'$(_GitShortHash)' == '' AND Exists('$(_GitShortHashFilePath)')">$([System.IO.File]::ReadAllText('$(_GitShortHashFilePath)').Trim())</_GitShortHash>
+            <_GitShortHash Condition="'$(_GitShortHash)' == '' and Exists('$(_GitShortHashFilePath)')">$([System.IO.File]::ReadAllText('$(_GitShortHashFilePath)').Trim())</_GitShortHash>
         </PropertyGroup>
 
         <ItemGroup>
@@ -38,7 +38,7 @@
         <ItemGroup>
             <_AllHexAttributes Include="@(AssemblyAttribute)" Condition="$([System.String]::new('%(AssemblyAttribute._Parameter1)').EndsWith('Hash'))" />
         </ItemGroup>
-        <Error Condition="'%(_AllHexAttributes._Parameter2)' != '' AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(_AllHexAttributes._Parameter2)', '^[0-9a-fA-F]+$'))" Text="'Metadata attribute %(_AllHexAttributes._Parameter1) must be a suitable hexidecimal hash value but is '%(_AllHexAttributes._Parameter2)'" />
+        <Error Condition="'%(_AllHexAttributes._Parameter2)' != '' and !$([System.Text.RegularExpressions.Regex]::IsMatch('%(_AllHexAttributes._Parameter2)', '^[0-9a-fA-F]+$'))" Text="'Metadata attribute %(_AllHexAttributes._Parameter1) must be a suitable hexidecimal hash value but is '%(_AllHexAttributes._Parameter2)'" />
     </Target>
 
     <Target Name="FindGameAndIncludeReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(_NitroxDiscovery_TaskAssembly)' != '' and ('$(UnityModLibrary)' == 'true' or '$(TestLibrary)' == 'true')">

--- a/Nitrox.Launcher/Nitrox.Launcher.csproj
+++ b/Nitrox.Launcher/Nitrox.Launcher.csproj
@@ -26,11 +26,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+        <PackageReference Include="Avalonia" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
@@ -43,9 +43,9 @@
         </PackageReference>
         <PackageReference Include="dnlib" Version="4.4.0" />
         <PackageReference Include="LitJson" Version="0.19.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
-        <PackageReference Include="ServiceScan.SourceGenerator" Version="2.1.2">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+        <PackageReference Include="ServiceScan.SourceGenerator" Version="2.3.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -56,8 +56,8 @@
     </ItemGroup>
     
     <!-- Temp fix for Avalonia 11.3 bug: https://github.com/AvaloniaUI/Avalonia/discussions/18971#discussioncomment-13533852 -->
-    <ItemGroup>
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'" />
+    <ItemGroup Condition="$(_IsLinux) or $(_IsLinuxTarget)">
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/mono/SkiaSharp/issues/3117
Context workaround: https://github.com/AvaloniaUI/Avalonia/discussions/18971#discussioncomment-13533852

Currently we do make use of a workaround for a 11.3.x Avalonia bug that messed up with SkiaSharp versions for Linux : 
```xml
 <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'" />
```

However it does not apply when cross-compiling from Windows, this PR fix that.

```xml
Condition="$(_IsLinux) or $(_IsLinuxTarget)"
```

Instead of 

```xml
Condition="$([System.OperatingSystem]::IsLinux()))"
```
