### PR TITLE
Fix potential player freeze after initial sync

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/PlayerTeleportedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerTeleportedProcessor.cs
@@ -34,10 +34,6 @@ public class PlayerTeleportedProcessor : ClientPacketProcessor<PlayerTeleported>
         Player.main.cinematicModeActive = true;
         Player.main.WaitForTeleportation();
 
-        CoroutineHost.StartCoroutine(Terrain.WaitForWorldLoad().OnYieldError(e =>
-        {
-            Player.main.cinematicModeActive = false;
-            Log.Warn($"Something wrong happened while waiting for the terrain to load.\n{e}");
-        }));
+        CoroutineHost.StartCoroutine(Terrain.SafeWaitForWorldLoad());
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -53,7 +53,7 @@ public sealed class PlayerPositionInitialSyncProcessor : InitialSyncProcessor
         Optional<NitroxId> subRootId = packet.PlayerSubRootId;
         if (!subRootId.HasValue)
         {
-            yield return Terrain.WaitForWorldLoad();
+            yield return Terrain.SafeWaitForWorldLoad();
             Player.main.UpdateIsUnderwater();
 
             // Check if Player might fall through the map
@@ -70,7 +70,7 @@ public sealed class PlayerPositionInitialSyncProcessor : InitialSyncProcessor
         if (!sub.HasValue)
         {
             Log.Error($"Could not spawn player into subroot with id: {subRootId.Value}");
-            yield return Terrain.WaitForWorldLoad();
+            yield return Terrain.SafeWaitForWorldLoad();
             yield break;
         }
 

--- a/NitroxClient/GameLogic/Terrain.cs
+++ b/NitroxClient/GameLogic/Terrain.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using NitroxClient.Communication.Abstract;
+using NitroxClient.Unity.Helper;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using NitroxModel_Subnautica.DataStructures;
@@ -102,7 +103,16 @@ public class Terrain
         streamerV2.lowDetailOctreesStreamer.UpdateCenter(streamerV2.streamingCenter);
         streamerV2.clipmapStreamer.UpdateCenter(streamerV2.streamingCenter);
 
-        yield return new WaitUntil(() => LargeWorldStreamer.main.IsWorldSettled());
+        yield return new WaitUntil(LargeWorldStreamer.main.IsWorldSettled);
         Player.main.cinematicModeActive = false;
+    }
+
+    public static IEnumerator SafeWaitForWorldLoad()
+    {
+        yield return WaitForWorldLoad().OnYieldError(e =>
+        {
+            Player.main.cinematicModeActive = false;
+            Log.Warn($"Something wrong happened while waiting for the terrain to load.\n{e}");
+        });
     }
 }


### PR DESCRIPTION
Make it so all of the WaitForWorldLoad are actually backed up by an unfreeze if they fail.