### PR TITLE
Show RadminVPN IP in server console

### DIFF
--- a/NitroxModel/Helper/NatHelper.cs
+++ b/NitroxModel/Helper/NatHelper.cs
@@ -11,7 +11,7 @@ namespace NitroxModel.Helper;
 
 public static class NatHelper
 {
-    public static async Task<IPAddress> GetExternalIpAsync() => await MonoNatHelper.GetFirstAsync(static async device =>
+    public static async Task<IPAddress?> GetExternalIpAsync() => await MonoNatHelper.GetFirstAsync(static async device =>
     {
         try
         {
@@ -175,7 +175,7 @@ public static class NatHelper
                 return default;
             }
 
-            // Progressively handle devices until first not-null/false result or when discovery times out.
+            // Progressively handle devices until first not-null/true result or when discovery times out.
             ConcurrentDictionary<EndPoint, INatDevice> handledDevices = new();
             do
             {

--- a/NitroxModel/Helper/NetHelper.cs
+++ b/NitroxModel/Helper/NetHelper.cs
@@ -121,11 +121,11 @@ public static class NetHelper
         }
     }
 
-    public static IPAddress? GetHamachiIp()
+    public static IPAddress? GetVPNIp(string vpnNetworkName)
     {
         foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
         {
-            if (ni.Name != "Hamachi")
+            if (ni.Name != vpnNetworkName)
             {
                 continue;
             }
@@ -139,6 +139,16 @@ public static class NetHelper
             }
         }
         return null;
+    }
+
+    public static IPAddress? GetHamachiIp()
+    {
+        return GetVPNIp("Hamachi");
+    }
+
+    public static IPAddress? GetRadminIp()
+    {
+        return GetVPNIp("Radmin VPN");
     }
 
     private static bool? hasInternet;

--- a/NitroxModel/Helper/NetHelper.cs
+++ b/NitroxModel/Helper/NetHelper.cs
@@ -46,7 +46,7 @@ public static class NetHelper
                         .OrderBy(n => n.NetworkInterfaceType is NetworkInterfaceType.Ethernet ? 1 : 0)
                         .ThenBy(n => n.Name);
 
-    public static IPAddress GetLanIp()
+    public static IPAddress? GetLanIp()
     {
         lock (lanIpLock)
         {
@@ -73,7 +73,7 @@ public static class NetHelper
         return null;
     }
 
-    public static async Task<IPAddress> GetWanIpAsync()
+    public static async Task<IPAddress?> GetWanIpAsync()
     {
         lock (wanIpLock)
         {
@@ -121,11 +121,11 @@ public static class NetHelper
         }
     }
 
-    public static IPAddress? GetVPNIp(string vpnNetworkName)
+    public static IEnumerable<(IPAddress Address, string NetworkName)> GetVpnIps(params string[] vpnNetworkNames)
     {
         foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
         {
-            if (ni.Name != vpnNetworkName)
+            if (!vpnNetworkNames.Contains(ni.Name, StringComparer.Ordinal))
             {
                 continue;
             }
@@ -134,22 +134,16 @@ public static class NetHelper
             {
                 if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
                 {
-                    return ip.Address;
+                    yield return (ip.Address, ni.Name.Replace("VPN", "").Trim());
                 }
             }
         }
-        return null;
     }
 
-    public static IPAddress? GetHamachiIp()
-    {
-        return GetVPNIp("Hamachi");
-    }
-
-    public static IPAddress? GetRadminIp()
-    {
-        return GetVPNIp("Radmin VPN");
-    }
+    /// <summary>
+    ///     Gets supported VPN address if known by current machine.
+    /// </summary>
+    public static IEnumerable<(IPAddress Address, string NetworkName)> GetVpnIps() => GetVpnIps("Hamachi", "Radmin VPN");
 
     private static bool? hasInternet;
 

--- a/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
@@ -44,7 +44,7 @@ public class DiscordRequestIPProcessor : AuthenticatedPacketProcessor<DiscordReq
     }
 
     /// <summary>
-    /// Get the WAN IP address or the Hamachi IP address if the WAN IP address is not available.
+    /// Get the WAN IP address or the VPN IP address if the WAN IP address is not available.
     /// </summary>
     /// <returns>Found IP or blank string if none found</returns>
     private static async Task<string> GetIpAsync()

--- a/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
@@ -52,6 +52,7 @@ public class DiscordRequestIPProcessor : AuthenticatedPacketProcessor<DiscordReq
     {
         Task<IPAddress> wanIp = NetHelper.GetWanIpAsync();
         Task<IPAddress> hamachiIp = Task.Run(NetHelper.GetHamachiIp);
+        Task<IPAddress> radminIp = Task.Run(NetHelper.GetRadminIp);
         if (await wanIp != null)
         {
             return wanIp.Result.ToString();
@@ -61,6 +62,12 @@ public class DiscordRequestIPProcessor : AuthenticatedPacketProcessor<DiscordReq
         {
             return hamachiIp.Result.ToString();
         }
+
+        if (await radminIp != null)
+        {
+            return radminIp.Result.ToString();
+        }
+
         return "";
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/DiscordRequestIPProcessor.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using NitroxModel.Helper;
 using NitroxModel.Packets;
 using NitroxModel.Serialization;
 using NitroxServer.Communication.Packets.Processors.Abstract;
@@ -50,22 +49,15 @@ public class DiscordRequestIPProcessor : AuthenticatedPacketProcessor<DiscordReq
     /// <returns>Found IP or blank string if none found</returns>
     private static async Task<string> GetIpAsync()
     {
-        Task<IPAddress> wanIp = NetHelper.GetWanIpAsync();
-        Task<IPAddress> hamachiIp = Task.Run(NetHelper.GetHamachiIp);
-        Task<IPAddress> radminIp = Task.Run(NetHelper.GetRadminIp);
-        if (await wanIp != null)
+        Task<IPAddress> wanIpTask = NetHelper.GetWanIpAsync();
+        Task<IEnumerable<(IPAddress Address, string NetworkName)>> vpnIpsTask = Task.Run(NetHelper.GetVpnIps);
+        if (await wanIpTask is {} wanIp)
         {
-            return wanIp.Result.ToString();
+            return wanIp.ToString();
         }
-
-        if (await hamachiIp != null)
+        foreach ((IPAddress vpnAddress, string _) in await vpnIpsTask)
         {
-            return hamachiIp.Result.ToString();
-        }
-
-        if (await radminIp != null)
-        {
-            return radminIp.Result.ToString();
+            return vpnAddress.ToString();
         }
 
         return "";

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -279,6 +279,7 @@ public class Server
         Task<IPAddress> localIp = Task.Run(NetHelper.GetLanIp);
         Task<IPAddress> wanIp = NetHelper.GetWanIpAsync();
         Task<IPAddress> hamachiIp = Task.Run(NetHelper.GetHamachiIp);
+        Task<IPAddress> radminIp = Task.Run(NetHelper.GetRadminIp);
 
         List<string> options = ["127.0.0.1 - You (Local)"];
         if (await wanIp != null)
@@ -288,6 +289,10 @@ public class Server
         if (await hamachiIp != null)
         {
             options.Add($"{hamachiIp.Result} - Friends using Hamachi (VPN)");
+        }
+        if (await radminIp != null)
+        {
+            options.Add($"{radminIp.Result} - Friends using Radmin (VPN)");
         }
         // LAN IP could be null if all Ethernet/Wi-Fi interfaces are disabled.
         if (await localIp != null)

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -278,21 +278,16 @@ public class Server
     {
         Task<IPAddress> localIp = Task.Run(NetHelper.GetLanIp);
         Task<IPAddress> wanIp = NetHelper.GetWanIpAsync();
-        Task<IPAddress> hamachiIp = Task.Run(NetHelper.GetHamachiIp);
-        Task<IPAddress> radminIp = Task.Run(NetHelper.GetRadminIp);
+        Task<IEnumerable<(IPAddress Address, string NetworkName)>> vpnIps = Task.Run(NetHelper.GetVpnIps);
 
         List<string> options = ["127.0.0.1 - You (Local)"];
         if (await wanIp != null)
         {
             options.Add("{ip:l} - Friends on another internet network (Port Forwarding)");
         }
-        if (await hamachiIp != null)
+        foreach ((IPAddress? vpnAddress, string? vpnName) in await vpnIps)
         {
-            options.Add($"{hamachiIp.Result} - Friends using Hamachi (VPN)");
-        }
-        if (await radminIp != null)
-        {
-            options.Add($"{radminIp.Result} - Friends using Radmin (VPN)");
+            options.Add($"{vpnAddress} - Friends using {vpnName} (VPN)");
         }
         // LAN IP could be null if all Ethernet/Wi-Fi interfaces are disabled.
         if (await localIp != null)


### PR DESCRIPTION
This PR adds the RadminVPN IP to the server IP list if the app is running. Also refactored the function to make it easier to add other VPNs in the future should we decide to do so, assuming that getting their IPs work the same way as they do for Hamachi and Radmin.

Tested it out on my machine and it works, though I am not sure if there would be any issues if both Hamachi and Radmin are running at the same time as I don't have Hamachi installed (but I don't think this will be the case for most users).