### PR TITLE
Fix cyclops docking sound being global

### DIFF
--- a/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
+++ b/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
@@ -732,8 +732,8 @@ event:/sub/cyclops/climb_front_down;true;false;20
 event:/sub/cyclops/climb_front_up;true;false;20
 event:/sub/cyclops/control_room_ambience;false;false;0
 event:/sub/cyclops/creature_attack_sfx;false;false;0
-event:/sub/cyclops/cyclops_door_close;true;true;false;20
-event:/sub/cyclops/cyclops_door_open;true;true;false;20
+event:/sub/cyclops/cyclops_door_close;true;false;20
+event:/sub/cyclops/cyclops_door_open;true;false;20
 event:/sub/cyclops/cyclops_helm door_close;true;false;20
 event:/sub/cyclops/cyclops_helm_door_open;true;false;20
 event:/sub/cyclops/cyclops_loop_epic_fast;false;false;90

--- a/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
+++ b/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
@@ -732,8 +732,8 @@ event:/sub/cyclops/climb_front_down;true;false;20
 event:/sub/cyclops/climb_front_up;true;false;20
 event:/sub/cyclops/control_room_ambience;false;false;0
 event:/sub/cyclops/creature_attack_sfx;false;false;0
-event:/sub/cyclops/cyclops_door_close;true;true;20
-event:/sub/cyclops/cyclops_door_open;true;true;20
+event:/sub/cyclops/cyclops_door_close;true;true;false;20
+event:/sub/cyclops/cyclops_door_open;true;true;false;20
 event:/sub/cyclops/cyclops_helm door_close;true;false;20
 event:/sub/cyclops/cyclops_helm_door_open;true;false;20
 event:/sub/cyclops/cyclops_loop_epic_fast;false;false;90


### PR DESCRIPTION
Make the sounds of the door to the docked sub in the cyclops not global, pretty sure this was the sound it was talking about