### PR TITLE
Prevent bench deconstruction while remote player sitting

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/BenchChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BenchChangedProcessor.cs
@@ -1,0 +1,60 @@
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class BenchChangedProcessor : ClientPacketProcessor<BenchChanged>
+{
+    private readonly PlayerManager remotePlayerManager;
+
+    public BenchChangedProcessor(PlayerManager remotePlayerManager)
+    {
+        this.remotePlayerManager = remotePlayerManager;
+    }
+
+    public override void Process(BenchChanged benchChanged)
+    {
+        if (!remotePlayerManager.TryFind(benchChanged.PlayerId, out RemotePlayer remotePlayer))
+        {
+            Log.Error($"Couldn't find {nameof(RemotePlayer)} for {benchChanged.PlayerId}");
+            return;
+        }
+        if (!NitroxEntity.TryGetObjectFrom(benchChanged.BenchId, out GameObject bench))
+        {
+            Log.Error($"Couldn't find GameObject for {benchChanged.BenchId}");
+            return;
+        }
+
+        remotePlayer.AnimationController["cinematics_enabled"] = benchChanged.ChangeState != BenchChanged.BenchChangeState.UNSET;
+        remotePlayer.AnimationController["bench_sit"] = benchChanged.ChangeState == BenchChanged.BenchChangeState.SITTING_DOWN;
+        remotePlayer.AnimationController["bench_stand_up"] = benchChanged.ChangeState == BenchChanged.BenchChangeState.STANDING_UP;
+
+        RemotePlayerBenchBlocker benchBlocker;
+        if (bench.GetComponent<Constructable>())
+        {
+            benchBlocker = bench.EnsureComponent<RemotePlayerBenchBlocker>();
+        }
+        else if (bench.transform.parent.GetComponent<Constructable>()) // For MultiplayerBenches
+        {
+            benchBlocker = bench.transform.parent.gameObject.EnsureComponent<RemotePlayerBenchBlocker>();
+        }
+        else
+        {
+            Log.Error($"Couldn't find Constructable component on {benchChanged.BenchId} or its parent");
+            return;
+        }
+
+        switch (benchChanged.ChangeState)
+        {
+            case BenchChanged.BenchChangeState.SITTING_DOWN:
+                benchBlocker.AddPlayerToBench(remotePlayer);
+                break;
+            case BenchChanged.BenchChangeState.UNSET:
+                benchBlocker.RemovePlayerFromBench(remotePlayer);
+                break;
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Bases/BuildUtils.cs
+++ b/NitroxClient/GameLogic/Bases/BuildUtils.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NitroxClient.GameLogic.Settings;
 using NitroxClient.GameLogic.Spawning.Bases;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.MonoBehaviours;
@@ -16,7 +17,7 @@ namespace NitroxClient.GameLogic.Bases;
 
 public static class BuildUtils
 {
-    public static bool TryGetIdentifier(BaseDeconstructable baseDeconstructable, out BuildPieceIdentifier identifier, BaseCell baseCell = null, Base.Face? baseFace = null)
+    public static bool TryGetIdentifier(BaseDeconstructable baseDeconstructable, out BuildPieceIdentifier identifier, BaseCell? baseCell = null, Base.Face? baseFace = null)
     {
         // It is unimaginable to have a BaseDeconstructable that is not child of a BaseCell
         if (!baseCell && !baseDeconstructable.TryGetComponentInParent(out baseCell, true))
@@ -31,7 +32,7 @@ public static class BuildUtils
 
     public static BuildPieceIdentifier GetIdentifier(BaseDeconstructable baseDeconstructable, BaseCell baseCell, Base.Face? baseFace = null)
     {
-        return new()
+        return new BuildPieceIdentifier
         {
             Recipe = baseDeconstructable.recipe.ToDto(),
             BaseFace = baseFace?.ToDto() ?? baseDeconstructable.face?.ToDto(),
@@ -73,7 +74,7 @@ public static class BuildUtils
                 }
                 break;
             case BaseAddMapRoomGhost:
-                face = new(GetMapRoomFunctionalityCell(baseGhost), 0);
+                face = new Base.Face(GetMapRoomFunctionalityCell(baseGhost), 0);
                 return true;
         }
 
@@ -88,7 +89,7 @@ public static class BuildUtils
     /// <returns>
     /// Whether or not the id was successfully transferred
     /// </returns>
-    public static bool TryTransferIdFromGhostToModule(BaseGhost baseGhost, NitroxId id, ConstructableBase constructableBase, out GameObject moduleObject)
+    public static bool TryTransferIdFromGhostToModule(BaseGhost baseGhost, NitroxId id, ConstructableBase constructableBase, out GameObject? moduleObject)
     {
         // 1. Find the face of the target piece
         Base.Face? face = null;
@@ -114,7 +115,7 @@ public static class BuildUtils
         // If the ghost is under a BaseDeconstructable(Clone), it may have an associated module
         else if (IsBaseDeconstructable(constructableBase))
         {
-            face = new(constructableBase.moduleFace.Value.cell + baseGhost.targetBase.GetAnchor(), constructableBase.moduleFace.Value.direction);
+            face = new Base.Face(constructableBase.moduleFace.Value.cell + baseGhost.targetBase.GetAnchor(), constructableBase.moduleFace.Value.direction);
         }
         else
         {
@@ -138,7 +139,7 @@ public static class BuildUtils
 
                 case TechType.BaseMapRoom:
                     // In the case the ghost is under a BaseDeconstructable, this is a good way to identify a MapRoom
-                    face = new(GetMapRoomFunctionalityCell(baseGhost), 0);
+                    face = new Base.Face(GetMapRoomFunctionalityCell(baseGhost), 0);
                     isMapRoomGhost = true;
                     break;
 
@@ -165,14 +166,8 @@ public static class BuildUtils
             if (mapRoomFunctionality)
             {
                 // As MapRooms can be built as the first piece of a base, we need to make sure that they receive a new id if they're not in a base
-                if (constructableBase.GetComponentInParent<Base>(true))
-                {
-                    NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, id);
-                }
-                else
-                {
-                    NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, id.Increment());
-                }
+                NitroxId nitroxId = constructableBase.GetComponentInParent<Base>(true) ? id : id.Increment();
+                NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, nitroxId);
                 moduleObject = mapRoomFunctionality.gameObject;
                 return true;
             }
@@ -287,7 +282,6 @@ public static class BuildUtils
                 {
                     continue;
                 }
-                MonoBehaviour moduleMB = baseModule as MonoBehaviour;
                 AddChild(InteriorPieceEntitySpawner.From(baseModule, entityMetadataManager));
             }
             else if (transform.TryGetComponent(out Constructable constructable))
@@ -309,8 +303,22 @@ public static class BuildUtils
         return childEntities;
     }
 
-    public static Component AliveOrNull(this IBaseModule baseModule)
+    public static Component? AliveOrNull(this IBaseModule baseModule)
     {
         return (baseModule as Component).AliveOrNull();
+    }
+
+    public static void DeconstructionAllowed(NitroxId baseId, ref bool result, ref string reason)
+    {
+        if (BuildingHandler.Main.BasesCooldown.ContainsKey(baseId))
+        {
+            result = false;
+            reason = Language.main.Get("Nitrox_ErrorRecentBuildUpdate");
+        }
+        else if (BuildingHandler.Main.EnsureTracker(baseId).IsDesynced() && NitroxPrefs.SafeBuilding.Value)
+        {
+            result = false;
+            reason = Language.main.Get("Nitrox_ErrorDesyncDetected");
+        }
     }
 }

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -136,6 +136,14 @@ public class LocalPlayer : ILocalNitroxPlayer
 
     public void BroadcastQuickSlotsBindingChanged(Optional<NitroxId>[] slotItemIds) => throttledPacketSender.SendThrottled(new PlayerQuickSlotsBindingChanged(slotItemIds), (packet) => 1);
 
+    public void BroadcastBenchChanged(NitroxId bench, BenchChanged.BenchChangeState changeState)
+    {
+        if (PlayerId.HasValue)
+        {
+            packetSender.Send(new BenchChanged(PlayerId.Value, bench, changeState));
+        }
+    }
+
     private GameObject CreateBodyPrototype()
     {
         GameObject prototype = Body;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -105,7 +105,7 @@ public class RemotePlayer : INitroxPlayer
         SetupSkyAppliers();
         SetupPlayerSounds();
         SetupMixins();
-        
+
         PlayerAnimation animation = PlayerContext.Animation;
         UpdateAnimationAndCollider((AnimChangeType)animation.Type, (AnimChangeState)animation.State);
 
@@ -373,11 +373,6 @@ public class RemotePlayer : INitroxPlayer
         {
             case AnimChangeType.UNDERWATER:
                 AnimationController["is_underwater"] = state != AnimChangeState.OFF;
-                break;
-            case AnimChangeType.BENCH:
-                AnimationController["cinematics_enabled"] = state != AnimChangeState.UNSET;
-                AnimationController["bench_sit"] = state == AnimChangeState.ON;
-                AnimationController["bench_stand_up"] = state == AnimChangeState.OFF;
                 break;
             case AnimChangeType.INFECTION_REVEAL:
                 AnimationController["player_infected"] = state != AnimChangeState.UNSET;

--- a/NitroxClient/MonoBehaviours/Overrides/MultiplayerBench.cs
+++ b/NitroxClient/MonoBehaviours/Overrides/MultiplayerBench.cs
@@ -2,70 +2,69 @@ using System;
 using NitroxClient.Unity.Helper;
 using UnityEngine;
 
-namespace NitroxClient.MonoBehaviours.Overrides
+namespace NitroxClient.MonoBehaviours.Overrides;
+
+public class MultiplayerBench : Bench
 {
-    public class MultiplayerBench : Bench
+    private Side side;
+
+    public static MultiplayerBench FromBench(Bench origin, GameObject target, Side side, GameObject animatorRoot)
     {
-        private Side side;
+        Animator animator = animatorRoot.GetComponent<Animator>();
+        Transform playerTarget = animatorRoot.transform.Find("root/cine_loc/player_target");
+        Transform playerOutTarget = animatorRoot.transform.Find("out_target");
 
-        public static MultiplayerBench FromBench(Bench origin, GameObject target, Side side, GameObject animatorRoot)
+        MultiplayerBench bench = target.AddComponent<MultiplayerBench>();
+        bench.frontObstacleCheck = origin.frontObstacleCheck;
+        bench.backObstacleCheck = origin.backObstacleCheck;
+        bench.frontAnimRotation = origin.frontAnimRotation;
+        bench.backAnimRotation = origin.backAnimRotation;
+        bench.checkDistance = origin.checkDistance;
+        bench.handText = origin.handText;
+        bench.triggerType = origin.triggerType;
+        bench.volumeTriggerType = origin.volumeTriggerType;
+        bench.standUpCinematicController = origin.standUpCinematicController;
+        bench.cinematicController = origin.cinematicController;
+
+        bench.onCinematicStart = new CinematicModeEvent();
+        bench.onCinematicEnd = new CinematicModeEvent();
+        bench.side = side;
+
+        bench.animator = animator;
+        bench.playerTarget = playerTarget;
+        bench.cinematicController.animatedTransform = playerTarget;
+        bench.cinematicController.animator = animator;
+        bench.cinematicController.informGameObject = target;
+        bench.standUpCinematicController.animatedTransform = playerTarget;
+        bench.standUpCinematicController.endTransform = playerOutTarget;
+        bench.standUpCinematicController.animator = animator;
+        bench.standUpCinematicController.informGameObject = target;
+
+        return bench;
+    }
+
+    public override void OnHandClick(GUIHand hand)
+    {
+        // Prevent users from sitting on a not fully-constructed bench
+        if (gameObject.TryGetComponentInParent(out Constructable constructable, true) && !constructable.constructed)
         {
-            Animator animator = animatorRoot.GetComponent<Animator>();
-            Transform playerTarget = animatorRoot.transform.Find("root/cine_loc/player_target");
-            Transform playerOutTarget = animatorRoot.transform.Find("out_target");
-
-            MultiplayerBench bench = target.AddComponent<MultiplayerBench>();
-            bench.frontObstacleCheck = origin.frontObstacleCheck;
-            bench.backObstacleCheck = origin.backObstacleCheck;
-            bench.frontAnimRotation = origin.frontAnimRotation;
-            bench.backAnimRotation = origin.backAnimRotation;
-            bench.checkDistance = origin.checkDistance;
-            bench.handText = origin.handText;
-            bench.triggerType = origin.triggerType;
-            bench.volumeTriggerType = origin.volumeTriggerType;
-            bench.standUpCinematicController = origin.standUpCinematicController;
-            bench.cinematicController = origin.cinematicController;
-
-            bench.onCinematicStart = new CinematicModeEvent();
-            bench.onCinematicEnd = new CinematicModeEvent();
-            bench.side = side;
-
-            bench.animator = animator;
-            bench.playerTarget = playerTarget;
-            bench.cinematicController.animatedTransform = playerTarget;
-            bench.cinematicController.animator = animator;
-            bench.cinematicController.informGameObject = target;
-            bench.standUpCinematicController.animatedTransform = playerTarget;
-            bench.standUpCinematicController.endTransform = playerOutTarget;
-            bench.standUpCinematicController.animator = animator;
-            bench.standUpCinematicController.informGameObject = target;
-
-            return bench;
+            return;
         }
-
-        public override void OnHandClick(GUIHand hand)
+        standUpCinematicController.transform.localPosition = side switch
         {
-            // Prevent users from sitting on a not fully-constructed bench
-            if (gameObject.TryGetComponentInParent(out Constructable constructable, true) && !constructable.constructed)
-            {
-                return;
-            }
-            standUpCinematicController.transform.localPosition = side switch
-            {
-                Side.LEFT => new Vector3(-0.75f, 0.082f, 0),
-                Side.CENTER => new Vector3(0, 0.082f, 0),
-                Side.RIGHT => new Vector3(0.75f, 0.082f, 0),
-                _ => throw new ArgumentOutOfRangeException()
-            };
+            Side.LEFT => new Vector3(-0.75f, 0.082f, 0),
+            Side.CENTER => new Vector3(0, 0.082f, 0),
+            Side.RIGHT => new Vector3(0.75f, 0.082f, 0),
+            _ => throw new ArgumentOutOfRangeException()
+        };
 
-            base.OnHandClick(hand);
-        }
+        base.OnHandClick(hand);
+    }
 
-        public enum Side
-        {
-            LEFT,
-            CENTER,
-            RIGHT
-        }
+    public enum Side
+    {
+        LEFT,
+        CENTER,
+        RIGHT
     }
 }

--- a/NitroxClient/MonoBehaviours/RemotePlayerBenchBlocker.cs
+++ b/NitroxClient/MonoBehaviours/RemotePlayerBenchBlocker.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using NitroxClient.GameLogic;
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours;
+
+public class RemotePlayerBenchBlocker : MonoBehaviour, IConstructable
+{
+    private readonly List<RemotePlayer> remoteSittingPlayer = [];
+
+    public void AddPlayerToBench(RemotePlayer remotePlayer) => remoteSittingPlayer.Add(remotePlayer);
+
+    public void RemovePlayerFromBench(RemotePlayer remotePlayer) => remoteSittingPlayer.Remove(remotePlayer);
+
+    public bool IsDeconstructionObstacle() => true;
+
+    public void OnConstructedChanged(bool constructed) {}
+
+    public bool CanDeconstruct(out string reason)
+    {
+        if(remoteSittingPlayer.Count != 0)
+        {
+            reason = Language.main.Get("Nitrox_RemotePlayerObstacle");
+            return false;
+        }
+        reason = string.Empty;
+        return true;
+    }
+}

--- a/NitroxModel/GameLogic/PlayerAnimation/AnimChangeType.cs
+++ b/NitroxModel/GameLogic/PlayerAnimation/AnimChangeType.cs
@@ -3,6 +3,5 @@ namespace NitroxModel.GameLogic.PlayerAnimation;
 public enum AnimChangeType
 {
     UNDERWATER,
-    BENCH,
-    INFECTION_REVEAL
+    INFECTION_REVEAL,
 }

--- a/NitroxModel/Packets/BenchChanged.cs
+++ b/NitroxModel/Packets/BenchChanged.cs
@@ -1,0 +1,26 @@
+using System;
+using NitroxModel.DataStructures;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class BenchChanged : Packet
+{
+    public ushort PlayerId { get; }
+    public NitroxId BenchId { get; }
+    public BenchChangeState ChangeState { get; }
+
+    public BenchChanged(ushort playerId, NitroxId benchId, BenchChangeState changeState)
+    {
+        PlayerId = playerId;
+        BenchId = benchId;
+        ChangeState = changeState;
+    }
+
+    public enum BenchChangeState
+    {
+        SITTING_DOWN,
+        STANDING_UP,
+        UNSET
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/BaseDeconstructable_DeconstructionAllowed_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseDeconstructable_DeconstructionAllowed_Patch.cs
@@ -1,6 +1,5 @@
 using NitroxClient.GameLogic.Bases;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Helper;
 using System.Reflection;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -15,6 +14,6 @@ public sealed partial class BaseDeconstructable_DeconstructionAllowed_Patch : Ni
         {
             return;
         }
-        Constructable_DeconstructionAllowed_Patch.DeconstructionAllowed(parentEntity.Id, ref __result, ref reason);
+        BuildUtils.DeconstructionAllowed(parentEntity.Id, ref __result, ref reason);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Bench_ExitSittingMode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Bench_ExitSittingMode_Patch.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.ChatUI;
 using NitroxModel.DataStructures;
-using NitroxModel.GameLogic.PlayerAnimation;
+using NitroxModel.Packets;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -29,14 +29,14 @@ public sealed partial class Bench_ExitSittingMode_Patch : NitroxPatch, IDynamicP
             // Request to be downgraded to a transient lock so we can still simulate the positioning.
             Resolve<SimulationOwnership>().RequestSimulationLock(id, SimulationLockType.TRANSIENT);
 
-            Resolve<LocalPlayer>().AnimationChange(AnimChangeType.BENCH, AnimChangeState.OFF);
-            __instance.StartCoroutine(ResetAnimationDelayed(__instance.standUpCinematicController.interpolationTimeOut));
+            Resolve<LocalPlayer>().BroadcastBenchChanged(id, BenchChanged.BenchChangeState.STANDING_UP);
+            __instance.StartCoroutine(ResetAnimationDelayed(id, __instance.standUpCinematicController.interpolationTimeOut));
         }
     }
 
-    private static IEnumerator ResetAnimationDelayed(float delay)
+    private static IEnumerator ResetAnimationDelayed(NitroxId benchId, float delay)
     {
         yield return new WaitForSeconds(delay);
-        Resolve<LocalPlayer>().AnimationChange(AnimChangeType.BENCH, AnimChangeState.UNSET);
+        Resolve<LocalPlayer>().BroadcastBenchChanged(benchId, BenchChanged.BenchChangeState.UNSET);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Bench_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Bench_OnHandClick_Patch.cs
@@ -3,7 +3,7 @@ using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.Simulation;
 using NitroxClient.MonoBehaviours.Gui.HUD;
 using NitroxModel.DataStructures;
-using NitroxModel.GameLogic.PlayerAnimation;
+using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -46,7 +46,7 @@ public sealed partial class Bench_OnHandClick_Patch : NitroxPatch, IDynamicPatch
         {
             skipPrefix = true;
             bench.OnHandClick(context.GuiHand);
-            Resolve<LocalPlayer>().AnimationChange(AnimChangeType.BENCH, AnimChangeState.ON);
+            Resolve<LocalPlayer>().BroadcastBenchChanged(id, BenchChanged.BenchChangeState.SITTING_DOWN);
             skipPrefix = false;
         }
         else

--- a/NitroxPatcher/Patches/Dynamic/Bench_OnPlayerDeath_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Bench_OnPlayerDeath_Patch.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using NitroxClient.GameLogic;
 using NitroxModel.DataStructures;
-using NitroxModel.GameLogic.PlayerAnimation;
+using NitroxModel.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -13,10 +13,10 @@ public sealed partial class Bench_OnPlayerDeath_Patch : NitroxPatch, IDynamicPat
     {
         if (__instance.TryGetIdOrWarn(out NitroxId id))
         {
+            Resolve<LocalPlayer>().BroadcastBenchChanged(id, BenchChanged.BenchChangeState.UNSET);
             // Request to be downgraded to a transient lock so we can still simulate the positioning.
             Resolve<SimulationOwnership>().RequestSimulationLock(id, SimulationLockType.TRANSIENT);
         }
 
-        Resolve<LocalPlayer>().AnimationChange(AnimChangeType.BENCH, AnimChangeState.UNSET);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/BuilderTool_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BuilderTool_Construct_Patch.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using NitroxClient.GameLogic.Bases;
 using NitroxClient.Helpers;
 using NitroxModel.DataStructures;
-using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -20,7 +19,7 @@ public sealed partial class BuilderTool_Construct_Patch : NitroxPatch, IDynamicP
         bool isAllowed = true;
         string message = string.Empty;
 
-        Constructable_DeconstructionAllowed_Patch.DeconstructionAllowed(parentId, ref isAllowed, ref message);
+        BuildUtils.DeconstructionAllowed(parentId, ref isAllowed, ref message);
         if (!isAllowed)
         {
             Log.InGame(message);

--- a/NitroxPatcher/Patches/Dynamic/Constructable_DeconstructionAllowed_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_DeconstructionAllowed_Patch.cs
@@ -1,10 +1,7 @@
 using System.Reflection;
 using NitroxClient.GameLogic.Bases;
-using NitroxClient.GameLogic.Settings;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.Unity.Helper;
-using NitroxModel.DataStructures;
-using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -21,20 +18,6 @@ public sealed partial class Constructable_DeconstructionAllowed_Patch : NitroxPa
         {
             return;
         }
-        DeconstructionAllowed(parentEntity.Id, ref __result, ref reason);
-    }
-
-    public static void DeconstructionAllowed(NitroxId baseId, ref bool __result, ref string reason)
-    {
-        if (BuildingHandler.Main.BasesCooldown.ContainsKey(baseId))
-        {
-            __result = false;
-            reason = Language.main.Get("Nitrox_ErrorRecentBuildUpdate");
-        }
-        else if (BuildingHandler.Main.EnsureTracker(baseId).IsDesynced() && NitroxPrefs.SafeBuilding.Value)
-        {
-            __result = false;
-            reason = Language.main.Get("Nitrox_ErrorDesyncDetected");
-        }
+        BuildUtils.DeconstructionAllowed(parentEntity.Id, ref __result, ref reason);
     }
 }


### PR DESCRIPTION
Adds `RemotePlayerBenchBlocker` to benches (and chairs) so sitting players block deconstruction.

Tested with two players (one sitting, one deconstructing).