### PR TITLE
Fix water park fishes having a global root cell level

### DIFF
--- a/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
@@ -55,7 +55,7 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
             // WaterParks have a child named "items_root" where the fish are put
             if (parentTransform.TryGetComponent(out WaterPark waterPark))
             {
-                SetupObjectInWaterPark(gameObject, waterPark);
+                SetupObjectInWaterPark(gameObject, largeWorldEntity, waterPark);
 
                 // TODO: When metadata is reworked (it'll be possible to give different metadatas to the same entity)
                 // this will no longer be needed because the entity metadata will set this to false accordingly
@@ -79,8 +79,12 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
         }
     }
 
-    public static void SetupObjectInWaterPark(GameObject gameObject, WaterPark waterPark)
+    public static void SetupObjectInWaterPark(GameObject gameObject, LargeWorldEntity largeWorldEntity, WaterPark waterPark)
     {
+        // Fishes in water parks are GlobalRootEntities on server-side but client-side needs them at a regular cell level (not GlobalRoot)
+        // initialCellLevel refers to the prefab's cell level which is the value we'll use
+        largeWorldEntity.cellLevel = largeWorldEntity.initialCellLevel;
+
         gameObject.transform.SetParent(waterPark.itemsRoot, false);
         using (PacketSuppressor<EntityMetadataUpdate>.Suppress())
         {


### PR DESCRIPTION
Title says it all

My fix applies another step to GlobalRootEntity spawning, in the case of spawning inside of a water park. Cell level will be set to initial cell level which corresponds to the prefab's relevant cell level. Because all global root entities have their cell entities automatically set to GlobalRoot (from a previous PR of mine), we now have to manage this precise case.

In case you happened to run into this issue before this is merged, you can look through your EntityData.json for all entities of type WorldEntity with a cell level of 100 and set their it to something like 1 or just remove them if you don't need em.

Fixes #2450 