### PR TITLE
Fix unauthenticated EscapePodChanged packet upon joining

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
@@ -61,7 +61,7 @@ public sealed class PlayerInitialSyncProcessor : InitialSyncProcessor
         Log.Info($"Received initial sync player GameObject Id: {id}");
     }
 
-    private void SetupEscapePod(bool firstTimeConnecting)
+    private static void SetupEscapePod(bool firstTimeConnecting)
     {
         EscapePod escapePod = EscapePod.main;
         if (escapePod)

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_OnConsoleCommand_randomstart_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_OnConsoleCommand_randomstart_Patch.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class EscapePod_OnConsoleCommand_randomstart_Patch : NitroxPatch, IDynamicPatch
+{
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((EscapePod t) => t.OnConsoleCommand_randomstart());
+
+    public static bool Prefix()
+    {
+        Log.InGame(Language.main.Get("Nitrox_CommandNotAvailable"));
+        return false;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_StartAtPosition_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_StartAtPosition_Patch.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class EscapePod_StartAtPosition_Patch : NitroxPatch, IDynamicPatch
+{
+    internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((EscapePod t) => t.StartAtPosition(default));
+
+    public static bool Prefix()
+    {
+        // Nitrox is responsible for choosing escape pod position see EscapePodEntitySpawner.CreateNewEscapePod()
+        return false;
+    }
+}


### PR DESCRIPTION
Context: Regressed in #2321
Context : 
<img width="832" height="200" alt="image" src="https://github.com/user-attachments/assets/6243f986-b42a-454d-93ff-899fc489f02b" />

In #2321 we did change the entrypoint ofescapepod changed packet in order to sync more behavior. However it did show up some path where SN doing some init code for escapepod position and player position during Subnautica boot. Which Nitrox is already doing behind the hood.

So I did suppress this code that shouldn't be called by Subnautica
<img width="721" height="221" alt="image" src="https://github.com/user-attachments/assets/7c054f36-7e11-47d3-8f4e-48122298324e" />

<img width="772" height="365" alt="image" src="https://github.com/user-attachments/assets/cc75328d-18a1-4769-806a-eff6e1d723df" />
