### PR TITLE
Always enable client logs

### DIFF
--- a/NitroxModel/Helper/Validate.cs
+++ b/NitroxModel/Helper/Validate.cs
@@ -11,7 +11,7 @@ public static class Validate
     // "where T : class" prevents non-nullable valuetypes from getting boxed to objects.
     // In other words: Error when trying to assert non-null on something that can't be null in the first place.
     [ContractAnnotation("o:null => halt")]
-    public static void NotNull<T>(T o, [CallerArgumentExpression("o")] string argumentExpression = null) where T : class
+    public static void NotNull<T>(T? o, [CallerArgumentExpression("o")] string argumentExpression = null) where T : class
     {
         if (o != null)
         {

--- a/NitroxModel/Logger/Log.cs
+++ b/NitroxModel/Logger/Log.cs
@@ -168,7 +168,7 @@ namespace NitroxModel.Logger
                            });
                        });
                    });
-               }, e => !NitroxEnvironment.IsReleaseMode || LogEventHasPropertiesAny(e, nameof(SaveName), nameof(PlayerName)) || GetLogFileName() is "launcher");
+               }, e => LogEventHasPropertiesAny(e, nameof(SaveName)) || GetLogFileName() is "launcher" or "game");
         });
 
         private static LoggerConfiguration AppendConsoleSink(this LoggerSinkConfiguration sinkConfig, bool makeAsync, bool useShorterTemplate, Action<string>? logOutputCallback = null) => sinkConfig.Logger(cnf =>

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -65,6 +65,7 @@ public static class Main
         AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
         AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += CurrentDomainOnAssemblyResolve;
 
+        Console.WriteLine("Checking if Nitrox should run...");
         if (!Directory.Exists(Environment.GetEnvironmentVariable(NitroxUser.LAUNCHER_PATH_ENV_KEY)))
         {
             Environment.SetEnvironmentVariable(NitroxUser.LAUNCHER_PATH_ENV_KEY, nitroxLauncherDir.Value, EnvironmentVariableTarget.Process);
@@ -75,6 +76,7 @@ public static class Main
             return;
         }
 
+        Console.WriteLine("Now initializing Nitrox...");
         InitWithDependencies();
     }
 

--- a/NitroxPatcher/Patcher.cs
+++ b/NitroxPatcher/Patcher.cs
@@ -23,7 +23,7 @@ internal static class Patcher
     /// <summary>
     ///     Dependency Injection container used by NitroxPatcher only.
     /// </summary>
-    private static IContainer container;
+    private static IContainer? container;
 
     private static readonly Harmony harmony = new("com.nitroxmod.harmony");
     private static bool isApplied;


### PR DESCRIPTION
Some users report issues with Nitrox starting up. By enabling client logs we'll see any errors to fix.

Closes #2481