### PR TITLE
Fixed '#' not being marked as a header in patchnotes

### DIFF
--- a/Nitrox.Launcher/Models/Extensions/DtoExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/DtoExtensions.cs
@@ -17,9 +17,9 @@ internal static class DtoExtensions
         buffer.Clear();
         foreach (string patchNote in changeLog.PatchNotes)
         {
-            if (patchNote.StartsWith('-'))
+            if ((GetAsHeaderOrNull(patchNote, '-') ?? GetAsHeaderOrNull(patchNote, '#')) is {} header)
             {
-                buffer.AppendLine($"\n[b][u]{patchNote.TrimStart('-', ' ')}[/u][/b]");
+                buffer.AppendLine(header);
             }
             else
             {
@@ -27,5 +27,14 @@ internal static class DtoExtensions
             }
         }
         return new NitroxChangelog(changeLog.Version, changeLog.Released.DateTime, string.Join(Environment.NewLine, buffer.ToString()));
+
+        static string? GetAsHeaderOrNull(string line, char prefix)
+        {
+            if (line.StartsWith(prefix))
+            {
+                return $"\n[b][u]{line.TrimStart(prefix, ' ')}[/u][/b]";
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
<img width="1037" height="668" alt="image" src="https://github.com/user-attachments/assets/f32be434-5659-4d62-b122-e71922efedaf" />
