### PR TITLE
Added perms reset on server join until we can improve security

### DIFF
--- a/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerJoiningMultiplayerSessionProcessor.cs
@@ -56,6 +56,10 @@ namespace NitroxServer.Communication.Packets.Processors
                 playerManager.SendPacketToOtherPlayers(spawnNewEscapePod, player);
             }
 
+            // TODO: Remove this code when security of player login is improved by https://github.com/SubnauticaNitrox/Nitrox/issues/1996
+            // We need to reset permissions on join, otherwise players can impersonate an admin easily.
+            player.Permissions = serverConfig.DefaultPlayerPerm;
+
             // Make players on localhost admin by default.
             if (connection.Endpoint.Address.IsLocalhost())
             {


### PR DESCRIPTION
Closes #2497

The feature to login using a server-generated client id (instead of player name) will happen later.