### PR TITLE
Fix constructables sending one too many packet when being destroyed

### DIFF
--- a/NitroxClient/Helpers/ThrottledPacketSender.cs
+++ b/NitroxClient/Helpers/ThrottledPacketSender.cs
@@ -47,8 +47,11 @@ namespace NitroxClient.Helpers
                 return true;
             }
 
-            throttledPackets.Add(dedupeKey, new ThrottledPacket(packet, throttleTime));
+            throttledPacket = new(packet, throttleTime);
+            throttledPackets.Add(dedupeKey, throttledPacket);
             packetSender.Send(packet);
+            // It's very important to set WasSend to true, otherwise the packet will be sent again in Update()
+            throttledPacket.WasSend = true;
             return true;
         }
 

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -103,6 +103,12 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
         // update as a normal module
         Resolve<ThrottledPacketSender>().SendThrottled(new ModifyConstructedAmount(entityId, amount),
             (packet) => { return packet.GhostId; }, 0.1f);
+
+        // If we're done with that ghost we can remove the throttled packets
+        if (amount == 0)
+        {
+            Resolve<ThrottledPacketSender>().RemovePendingPackets(entityId);
+        }
     }
 
     public static IEnumerator BroadcastObjectBuilt(ConstructableBase constructableBase, NitroxId entityId)


### PR DESCRIPTION
Issue was that when sending only one throttled packet, you'd have two packets sent.
It would occur because when you first call the throttling function it already sends one packet and then after the throttling time, another packet would be sent too.

Also I think we might want to change how it works as of now because if we never clear the throttled entries, they'll just increase forever the time spent in an o(n) Update() loop

Fixes #2393