### PR TITLE
Fix vehicles not charging with multiple players connected

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/Vehicle_AddEnergy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_AddEnergy_Patch.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Ensures vehicle charging from modules only occurs on the simulating player.
+/// </summary>
+public sealed partial class Vehicle_AddEnergy_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Vehicle t) => t.AddEnergy(default));
+
+    public static bool Prefix(Vehicle __instance)
+    {
+        return __instance.TryGetNitroxId(out NitroxId vehicleId) && Resolve<SimulationOwnership>().HasAnyLockType(vehicleId);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Vehicle_UpdateEnergyRecharge_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Vehicle_UpdateEnergyRecharge_Patch.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxModel.DataStructures;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Ensures vehicle charging from moonpool only occurs on the simulating player.
+/// </summary>
+public sealed partial class Vehicle_UpdateEnergyRecharge_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Vehicle t) => t.UpdateEnergyRecharge());
+
+    public static bool Prefix(Vehicle __instance)
+    {
+        return __instance.TryGetNitroxId(out NitroxId vehicleId) && Resolve<SimulationOwnership>().HasAnyLockType(vehicleId);
+    }
+}


### PR DESCRIPTION
I fixed both when vehicles are charged from thermic/solar modules, and from moonpool.
Now only the simulating player is responsible for charging vehicles.

Fixes #2486 