### PR TITLE
Fix reefbacks barnacles being too small

### DIFF
--- a/NitroxClient/GameLogic/Spawning/WorldEntities/ReefbackChildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/ReefbackChildEntitySpawner.cs
@@ -81,8 +81,8 @@ public class ReefbackChildEntitySpawner : IWorldEntitySpawner, IWorldEntitySyncS
 
         transform.localPosition = entity.Transform.LocalPosition.ToUnity();
         transform.localRotation = entity.Transform.LocalRotation.ToUnity();
-        transform.localScale = entity.Transform.LocalScale.ToUnity();
-
+        // We don't set the localScale because it is already correct from the prefab but the server doesn't know about it (which doesn't matter)
+        
         // Positioning from ReefbackLife.SpawnPlants and ReefbackLife.SpawnCreatures
         switch (entity.Type)
         {


### PR DESCRIPTION
Reefback children entity spawning is very framed by ReefbackBootstrapper which sets correctly the local position and local rotation of the children entities. But the size of them is not known by the server since it'd require to know about the prefab itself (which would require extra server steps that we do not really need in the end for such a specific part of entity spawning), so we should not apply a local size of (1, 1, 1) to all children because some of them (e.g. barnacles) are actually meant to be (10, 10, 10).

Fixes #2485 