### PR TITLE
Fix certain world entities have global root level 100

### DIFF
--- a/NitroxClient/GameLogic/Spawning/WorldEntities/PlacedWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/PlacedWorldEntitySpawner.cs
@@ -62,17 +62,26 @@ public class PlacedWorldEntitySpawner : SyncEntitySpawner<PlacedWorldEntity>
 
     public static void AdditionalSpawningSteps(GameObject gameObject)
     {
-        if (gameObject.TryGetComponent(out PlaceTool placeTool))
+        if (!gameObject.TryGetComponent(out PlaceTool placeTool))
         {
-            if (gameObject.TryGetComponentInParent(out SubRoot subRoot))
-            {
-                SkyEnvironmentChanged.Send(gameObject, subRoot);
-            }
-            if (gameObject.TryGetComponent(out Rigidbody rigidbody))
-            {
-                UWE.Utils.SetIsKinematicAndUpdateInterpolation(rigidbody, true, false);
-            }
-            placeTool.OnPlace();
+            return;
+        }
+
+        if (gameObject.TryGetComponentInParent(out SubRoot subRoot))
+        {
+            SkyEnvironmentChanged.Send(gameObject, subRoot);
+        }
+        if (gameObject.TryGetComponent(out Rigidbody rigidbody))
+        {
+            UWE.Utils.SetIsKinematicAndUpdateInterpolation(rigidbody, true, false);
+        }
+        placeTool.OnPlace();
+
+        // Placed tools in bases are GlobalRootEntities on server-side but client-side needs them at a regular cell level (not GlobalRoot)
+        // initialCellLevel refers to the prefab's cell level which is the value we'll use
+        if (gameObject.TryGetComponent(out LargeWorldEntity largeWorldEntity))
+        {
+            largeWorldEntity.cellLevel = largeWorldEntity.initialCellLevel;
         }
     }
 


### PR DESCRIPTION
To test the bug:
- place a luggage/poster in your base (it's a GlobalRootEntity) and disconnect
- reconnect, it is now given the cell level 100 (global root)
- pick it up, and drop it in the water, it still has cell level 100

Fixes an issue where the server is not gonna start because of certain world entities with a level 100.