### PR TITLE
Fix negative Cyclops power HUD display — clamp value to 0% when negative

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -17,6 +17,12 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
         {
             __instance.hudActive = true;
         }
+        if (__instance.hudActive && 
+            int.TryParse(__instance.powerText.text.Replace("%", ""), out int value) &&
+            value < 0)
+        {
+            __instance.powerText.text = "0%";
+        }
         if (__instance.subLiveMixin.IsAlive())
         {
             if (__instance.motorMode.engineOn)


### PR DESCRIPTION
### **Issue Related**
https://github.com/SubnauticaNitrox/Nitrox/issues/2525
**📋 Problem Summary**

When all power cells are removed from the Cyclops (or under edge conditions), the HUD’s charge counter can show a negative percentage (e.g. “-5%”) instead of clamping to zero or indicating no power. This is confusing or misleading.

### **🛠 Solution Overview**

Intercept the HUD update logic when rendering the power percentage display.

Parse the numeric portion (strip the “%” sign), then check if the value is negative.

If negative, force it to show “0%” (or the zero-equivalent) instead.

Ensures no negative value is displayed even if internal logic briefly computes a negative number.

### **✅ Changes & Key Modifications**

Added a safe float.TryParse(...) wrapper around the string-to-number conversion from powerText.text.Replace("%", "").

Introduced a conditional check: value < 0 → value = 0 (clamp).

Updated the HUD text assignment to always produce a non-negative percentage.


### **🔍 Testing Done**

Removed all power cells from Cyclops, observed HUD displays “0%” instead of negative values.

Tested normal operation with power cells: continues to show correct positive percentages.

Verified that no new parsing errors or crashes occur when the HUD text is in unexpected formats.


### **📝 Notes for Reviewers / Considerations**

This patch does not alter the underlying power logic or distribution — only the UI display layer.
