### PR TITLE
Fixed handling of Console.WindowWidth

### DIFF
--- a/Nitrox.Server.Subnautica/Program.cs
+++ b/Nitrox.Server.Subnautica/Program.cs
@@ -224,12 +224,13 @@ public class Program
                     // Redraw entire line
                     Console.Write($"\r{new string(' ', GetConsoleWidth(-1))}\r{inputLineBuilder}");
                 }
-                else
+                else if (start > -1)
                 {
                     // Redraw part of line
+                    start = int.Min(start, inputLineBuilder.Length);
                     string changedInputSegment = inputLineBuilder.ToString(start, end);
                     Console.CursorVisible = false;
-                    Console.Write($"{changedInputSegment}{new string(' ', int.Max(0, inputLineBuilder.Length - changedInputSegment.Length - Console.CursorLeft + 1))}");
+                    Console.Write($"{changedInputSegment}{new string(' ', int.Max(0, inputLineBuilder.Length - changedInputSegment.Length + 1))}");
                     Console.CursorVisible = true;
                 }
                 Console.CursorLeft = lastPosition;


### PR DESCRIPTION
Now server doesn't crash when it returns negative values

<img width="1092" height="267" alt="image" src="https://github.com/user-attachments/assets/36471dd8-20b9-4065-ad59-9abfaf8bdb6a" />


<!--
Before filing a pull request please look at our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md.

We recommend that if you want to do a non trivial feature or a feature without an already open issue, to contact us on Discord https://discord.gg/E8B4X9s before investing your time.
-->
