### PR TITLE
Fix ghost/module destruction not being broadcasted

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -100,15 +100,18 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
             return;
         }
 
-        // update as a normal module
-        Resolve<ThrottledPacketSender>().SendThrottled(new ModifyConstructedAmount(entityId, amount),
-            (packet) => { return packet.GhostId; }, 0.1f);
+        ModifyConstructedAmount modifyConstructedAmount = new(entityId, amount);
 
-        // If we're done with that ghost we can remove the throttled packets
-        if (amount == 0)
+        // If we're done with that ghost we can remove the related throttled packet
+        if (amount == 0f)
         {
             Resolve<ThrottledPacketSender>().RemovePendingPackets(entityId);
+            Resolve<IPacketSender>().Send(modifyConstructedAmount);
+            return;
         }
+
+        // update as a normal module
+        Resolve<ThrottledPacketSender>().SendThrottled(modifyConstructedAmount, (packet) => { return packet.GhostId; }, 0.1f);
     }
 
     public static IEnumerator BroadcastObjectBuilt(ConstructableBase constructableBase, NitroxId entityId)


### PR DESCRIPTION
Bug was that when you'd have amount == 0 (destruction), the throttler was filled, and then directly emptied, preventing the packet with amount = 0 (the most important one) to be sent.

Now we'll just empty the throttler and send the packet manually when amount == 0.

Regression from #2503 