### PR TITLE
Allow for pressing the Enter/Return key to open Dev Console

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DevConsole_Update_Patch.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
+using NitroxClient.GameLogic.ChatUI;
 using NitroxPatcher.PatternMatching;
 using UnityEngine;
 using static System.Reflection.Emit.OpCodes;
@@ -27,35 +27,14 @@ public sealed partial class DevConsole_Update_Patch : NitroxPatch, IDynamicPatch
 
     public static readonly MethodInfo TARGET_METHOD = Reflect.Method((DevConsole t) => t.Update());
 
-    private static readonly MethodInfo? shouldEnableConsoleMethod = typeof(DevConsole_Update_Patch).GetMethod(nameof(ShouldEnableConsole), BindingFlags.NonPublic | BindingFlags.Static);
-
     public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
     {
         return instructions.ChangeAtMarker(devConsoleSetStateTruePattern, "ConsoleEnableFlag", i =>
         {
             i.opcode = Call;
-            i.operand = shouldEnableConsoleMethod;
+            i.operand = Reflect.Method(() => ShouldEnableConsole());
         });
     }
-    
-    private static bool ShouldEnableConsole()
-    {
-        try
-        {
-            Type pcmType = typeof(NitroxClient.GameLogic.ChatUI.PlayerChatManager);
-            object instance = pcmType.GetField("Instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null);
-            PropertyInfo? isChatSelectedProp = pcmType.GetProperty("IsChatSelected", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
-            object val = isChatSelectedProp?.GetValue(instance);
-            if (val is false)
-            {
-                return true;
-            }
-        }
-        catch
-        {
-            // ignore
-        }
 
-        return false;
-    }
+    private static bool ShouldEnableConsole() => !PlayerChatManager.Instance.IsChatSelected;
 }


### PR DESCRIPTION
Previously, Nitrox prevented pressing the `Enter` key to open the dev console so as to allow for players to send their chat messages through Nitrox chat (since pressing `Enter` to send a message would just open the dev console instead). However, this causes issues with players not using the English keyboard layout who didn't know what the alternative key was to open the dev console (`~` on English keyboard layouts, but not on other keyboard language layouts).

This PR makes it so that players can press `Enter` to open the dev console as long as they aren't focused on the Nitrox chat box.