### PR TITLE
Prevent server from being blocked when finding level 100 world entities

### DIFF
--- a/NitroxServer/GameLogic/Entities/EntityData.cs
+++ b/NitroxServer/GameLogic/Entities/EntityData.cs
@@ -22,6 +22,8 @@ public class EntityData
         // children to their respective parent entities.
         Dictionary<NitroxId, Entity> entitiesById = Entities.ToDictionary(entity => entity.Id);
 
+        bool brokenEntitiesFound = false;
+
         foreach (Entity entity in Entities)
         {
             if (entity is WorldEntity we)
@@ -41,11 +43,23 @@ public class EntityData
                     Log.Error("Found WorldEntity with NaN or infinite rotation. Resetting rotation.");
                     we.Transform.LocalRotation = NitroxQuaternion.Identity;
                 }
+
+                if (we.Level == 100)
+                {
+                    Log.Error($"Found an entity with cell level 100. It will be hotfixed.\n{we}");
+                    we.Level = 0;
+                    brokenEntitiesFound = true;
+                }
             }
 
             // We will re-build the child hierarchy below and want to avoid duplicates.
             // TODO: Rework system to no longer persist children entities because they are duplicates.
             entity.ChildEntities.Clear();
+        }
+
+        if (brokenEntitiesFound)
+        {
+            Log.Warn($"Please consider reporting the above issues on the Discord server.");
         }
 
         foreach (Entity entity in Entities)


### PR DESCRIPTION
Currently the issue is so bad that it might happen many times during one's playthrough, so the best thing we can do while we gather more informative reports is to let players actually have the fix done automatically at each server start.