### PR TITLE
Fix exosuits falling through the ground

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/SpawnEntitiesProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/SpawnEntitiesProcessor.cs
@@ -1,6 +1,7 @@
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxModel.DataStructures;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
@@ -9,11 +10,13 @@ public class SpawnEntitiesProcessor : ClientPacketProcessor<SpawnEntities>
 {
     private readonly Entities entities;
     private readonly SimulationOwnership simulationOwnership;
+    private readonly Terrain terrain;
 
-    public SpawnEntitiesProcessor(Entities entities, SimulationOwnership simulationOwnership)
+    public SpawnEntitiesProcessor(Entities entities, SimulationOwnership simulationOwnership, Terrain terrain)
     {
         this.entities = entities;
         this.simulationOwnership = simulationOwnership;
+        this.terrain = terrain;
     }
 
     public override void Process(SpawnEntities packet)
@@ -36,6 +39,13 @@ public class SpawnEntitiesProcessor : ClientPacketProcessor<SpawnEntities>
             // Packet processing is done in the main thread so there's no issue calling this
             // We need a cold start so that all cleaned up entities (if force respawn is true) have time to be fully destroyed
             entities.EnqueueEntitiesToSpawn(packet.Entities, packet.SpawnedCells, packet.ForceRespawn);
+            return;
+        }
+
+        // Even if there was nothing to be spawned in the cell, we need to know about it as fully spawned
+        foreach (AbsoluteEntityCell spawnedEntityCell in packet.SpawnedCells)
+        {
+            terrain.AddFullySpawnedCell(spawnedEntityCell);
         }
     }
 }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleEntitySpawner.cs
@@ -49,6 +49,7 @@ public class VehicleEntitySpawner : EntitySpawner<VehicleEntity>
     {
         TechType techType = vehicleEntity.TechType.ToUnity();
         GameObject gameObject = null;
+        Vehicle vehicle = null;
 
         bool isCyclops = techType == TechType.Cyclops;
         if (isCyclops)
@@ -66,9 +67,8 @@ public class VehicleEntitySpawner : EntitySpawner<VehicleEntity>
             GameObject techPrefab = techPrefabCoroutine.GetResult();
             gameObject = Utils.SpawnPrefabAt(techPrefab, null, vehicleEntity.Transform.Position.ToUnity());
             Validate.NotNull(gameObject, $"{nameof(VehicleEntitySpawner)}: No prefab for tech type: {techType}");
-            Vehicle vehicle = gameObject.GetComponent<Vehicle>();
 
-            if (vehicle)
+            if (gameObject.TryGetComponent(out vehicle))
             {
                 vehicle.LazyInitialize();
             }
@@ -106,6 +106,12 @@ public class VehicleEntitySpawner : EntitySpawner<VehicleEntity>
         if (parent.HasValue)
         {
             DockVehicle(gameObject, parent.Value);
+        }
+        
+        // While spawning a vehicle, we want to make sure that it doesn't free fall as if it was just built by a constructor
+        if (gameObject.TryGetComponent(out vehicle))
+        {
+            vehicle.constructionFallOverride = false;
         }
 
         result.Set(gameObject);

--- a/NitroxServer/Communication/Packets/Processors/CellVisibilityChangedProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/CellVisibilityChangedProcessor.cs
@@ -48,10 +48,7 @@ public class CellVisibilityChangedProcessor : AuthenticatedPacketProcessor<CellV
             entitySimulation.BroadcastSimulationChanges(new(totalSimulationChanges));
         }
 
-        if (totalEntities.Count > 0)
-        {
-            SpawnEntities batchEntities = new(totalEntities, packet.Added, true);
-            player.SendPacket(batchEntities);
-        }
+        // We send this data whether or not it's empty because the client needs to know about it (see Terrain)
+        player.SendPacket(new SpawnEntities(totalEntities, packet.Added, true));
     }
 }


### PR DESCRIPTION
The server would not reply with empty cells when you'd ask for their content, but this information is actually needed to know if a cell is fully loaded on client-side.
So now we'll get this information in any way.

Also there was this Vehicle.constructionFallOverride variable that I had overlooked. It was an override that would force a vehicle to fall down until underwater when being spawned, even if the area around it wasn't loaded. Now it'll be set to false when spawning from outside of a vehicle constructor.