### PR TITLE
Improve version mismatch message

### DIFF
--- a/Nitrox.Launcher/Models/Services/ServerService.cs
+++ b/Nitrox.Launcher/Models/Services/ServerService.cs
@@ -140,7 +140,7 @@ internal sealed class ServerService : IMessageReceiver, INotifyPropertyChanged
         await dialogService.ShowAsync<DialogBoxViewModel>(model =>
         {
             model.Title = "Version Mismatch Detected";
-            model.Description = $"The version of '{server.Name}' is v{(server.Version != null ? server.Version.ToString() : "X.X.X.X")} and current Nitrox version is v{NitroxEnvironment.Version}{Environment.NewLine}{Environment.NewLine}It is advisable to find out about the latest changes and whether the backup is compatible.{Environment.NewLine}Note that it's always possible to use the world backup feature in case of failures.{Environment.NewLine}{Environment.NewLine}Would you still like to continue?";
+            model.Description = $"The save '{server.Name}' is v{(server.Version != null ? server.Version.ToString() : "X.X.X.X")} but current Nitrox version is v{NitroxEnvironment.Version}{Environment.NewLine}{Environment.NewLine}It is advisable to find out about the latest changes and whether the backup is compatible.{Environment.NewLine}Note that it's always possible to use the world backup feature in case of failures.{Environment.NewLine}{Environment.NewLine}Would you still like to continue?";
             model.ButtonOptions = ButtonOptions.YesNo;
         });
 


### PR DESCRIPTION
Context: #2534
Context:
> Nitrox will always show a scary message to user when the current version of Nitrox is strictly different from the one specific in a world save

Alternative to #2534, until we'll able to figure out how to deal properly with save compatibility and warn the user only when needed.

|  Before:  | After: | 
|---|---|
| <img width="940" height="267" alt="image" src="https://github.com/user-attachments/assets/d82bc520-fcb1-4df4-b6ce-a91ab949835e" /> | <img width="655" height="310" alt="image" src="https://github.com/user-attachments/assets/c379199a-dc14-4b25-adc2-91da21c57502" />  |  


