### PR TITLE
Fix tech lights being indestructible

### DIFF
--- a/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/ModuleEntitySpawner.cs
@@ -1,16 +1,15 @@
 using System.Collections;
 using System.Linq;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
 using NitroxClient.GameLogic.Bases;
 using NitroxClient.GameLogic.Helper;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.Cyclops;
-using Nitrox.Model.DataStructures;
-using Nitrox.Model.Subnautica.DataStructures;
-using Nitrox.Model.Subnautica.DataStructures.GameLogic;
-using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
-using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Spawning.Bases;
@@ -107,7 +106,16 @@ public class ModuleEntitySpawner : EntitySpawner<ModuleEntity>
             SkyEnvironmentChanged.Send(moduleObject, (Component)null);
         }
         constructable.constructedAmount = moduleEntity.ConstructedAmount;
-        constructable.SetState(moduleEntity.ConstructedAmount >= 1f, false);
+
+        // We need to force this state first because when we spawn constructables, they are constructed by default
+        // some MonoBehaviours like TechLight need this intermediary step
+        constructable.NotifyConstructedChanged(false);
+        
+        // constructable._constructed must be the opposite value so SetState is effective
+        bool constructed = moduleEntity.ConstructedAmount >= 1f;
+        constructable._constructed = !constructed;
+        constructable.SetState(constructed, false);
+
         constructable.UpdateMaterial();
         NitroxEntity.SetNewId(moduleObject, moduleEntity.Id);
 


### PR DESCRIPTION
Bug report from Discord user "Matty"

```
Ahh no worries then. I did put a bug in for it with 100% repro rate steps. 
- Start a new server with access to Floodlights.
- Join the server.
- Equip the habitat tool and construct the Floodlight on a platform.
- Leave the server and then shut down the server.
- Start the server up again and re-join the server.
- Equip the habitat tool again and attempt to deconstruct the floodlight created in step 3.

Results: 
Players are unable to deconstruct the floodlight buildable. 

Repo rate: 
8/8. 100%.
```

The fix consists in forcing ``constructable.NotifyConstructedChanged(false)`` to happen when spawning a Constructable because they're in the constructed state by default.
The bug originates from TechLights having a placedByPlayer field which prevents players from destroying it if it's not true (and it's set to true by NotifyConstructedChanged).

