### PR TITLE
Change Enum.GetValues to allow other patches

### DIFF
--- a/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
+++ b/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
@@ -51,7 +51,7 @@ public class PatchesTranspilerTest
         [typeof(Flare_Update_Patch), 0],
         [typeof(FootstepSounds_OnStep_Patch), 6],
         [typeof(GrowingPlant_SpawnGrownModelAsync_Patch), -1],
-        [typeof(GameInputSystem_Patch), 2],
+        [typeof(GameInputSystem_Initialize_Patch), 2],
         [typeof(Player_TriggerInfectionRevealAsync_Patch), 1],
         [typeof(IngameMenu_OnSelect_Patch), -2],
         [typeof(IngameMenu_QuitGameAsync_Patch), 2],

--- a/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;


### PR DESCRIPTION
With our current Enum.GetValues patch, we stop further execution of more patches thus causing mods to throw exceptions. This should fix that.

potentially Fixes #2531 

### Related issues
- https://github.com/SubnauticaModding/Nautilus/issues/644