### PR TITLE
Avoid negative Cyclops power percentage with no cells

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using HarmonyLib;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -17,6 +18,7 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
         {
             __instance.hudActive = true;
         }
+
         if (__instance.subLiveMixin.IsAlive())
         {
             if (__instance.motorMode.engineOn)
@@ -27,6 +29,69 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
             {
                 __instance.engineToggleAnimator.SetTrigger("EngineOff");
             }
+        }
+
+        // FIX: prevent negative/NaN power % when no cells are installed
+        try
+        {
+            FieldInfo subRootFi = AccessTools.Field(typeof(CyclopsHelmHUDManager), "subRoot");
+            SubRoot subRoot = null;
+            if (subRootFi != null)
+            {
+                object value = subRootFi.GetValue(__instance);
+                subRoot = value as SubRoot;
+            }
+            if (subRoot == null)
+            {
+                return;
+            }
+
+            PowerRelay relay = subRoot.powerRelay;
+            if (relay == null)
+            {
+                return;
+            }
+
+            float current = relay.GetPower();
+            float max = relay.GetMaxPower();
+            float ratio = (max <= 0f) ? 0f : UnityEngine.Mathf.Clamp01(current / max);
+
+            // Update percent text
+            FieldInfo powerTextFi = AccessTools.Field(typeof(CyclopsHelmHUDManager), "powerText");
+            TMPro.TextMeshProUGUI powerText = powerTextFi != null
+                ? powerTextFi.GetValue(__instance) as TMPro.TextMeshProUGUI
+                : null;
+
+            if (powerText != null)
+            {
+                int percent = UnityEngine.Mathf.RoundToInt(ratio * 100f);
+                powerText.text = $"{percent}%";
+            }
+
+            // Update bar (Slider or Image)
+            FieldInfo powerBarFi = AccessTools.Field(typeof(CyclopsHelmHUDManager), "powerBar");
+            if (powerBarFi != null)
+            {
+                object bar = powerBarFi.GetValue(__instance);
+
+                UnityEngine.UI.Slider slider = bar as UnityEngine.UI.Slider;
+                if (slider != null)
+                {
+                    slider.value = ratio;
+                }
+                else
+                {
+                    UnityEngine.UI.Image img = bar as UnityEngine.UI.Image;
+                    if (img != null)
+                    {
+                        img.fillAmount = ratio;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Swallow reflection issues so the original UI logic continues.
         }
     }
 }


### PR DESCRIPTION
Problem: Cyclops HUD can display a negative/NaN power percentage when no power cells are installed.
Change: In CyclopsHelmHUDManager_Update_Patch, guard against max==0, clamp the ratio, and update text/bar to 0%. Existing HUD behaviour is preserved.
Test: Spawn Cyclops → remove all 6 cells → HUD shows 0%; reinsert cells → percentage updates correctly.

Refs #2525
