### PR TITLE
Start game exe directly if no game platform detected

### DIFF
--- a/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
@@ -243,12 +243,12 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
             HeroicGames => await HeroicGames.StartGameAsync(gameInfo.EgsNamespace, launchArguments),
             MSStore => await MSStore.StartGameAsync(gameExePath, launchArguments),
             Discord => await Discord.StartGameAsync(gameExePath, launchArguments),
-            _ => throw new Exception($"Directory '{NitroxUser.GamePath}' is not a valid {gameInfo.Name} game installation or the game platform is unsupported by Nitrox.")
+            _ => await Standalone.StartGameAsync(gameExePath, launchArguments),
         };
 
         if (game is null)
         {
-            throw new Exception($"Game failed to start through {NitroxUser.GamePlatform.Name}");
+            throw new Exception($"Game failed to start through {NitroxUser.GamePlatform?.Name ?? "Standalone"}");
         }
     }
 

--- a/Nitrox.Model/Platforms/Store/Standalone.cs
+++ b/Nitrox.Model/Platforms/Store/Standalone.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using System.Threading.Tasks;
+using Nitrox.Model.Helper;
+using Nitrox.Model.Platforms.OS.Shared;
+
+namespace Nitrox.Model.Platforms.Store;
+
+public static class Standalone
+{
+    public static Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)
+    {
+        return Task.FromResult(
+            ProcessEx.Start(
+                pathToGameExe,
+                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
+                Path.GetDirectoryName(pathToGameExe),
+                launchArguments
+            )
+        );
+    }
+}

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -22,14 +22,21 @@ public sealed class Steam : IGamePlatform
 
     private static string SteamProcessName => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "steam_osx" : "steam";
 
-    public bool OwnsGame(string gameRootPath) =>
-        gameRootPath switch
+    public bool OwnsGame(string gameRootPath)
+    {
+        if (GetExeFile() == null)
+        {
+            return false;
+        }
+
+        return gameRootPath switch
         {
             not null when RuntimeInformation.IsOSPlatform(OSPlatform.OSX) => Directory.Exists(Path.Combine(gameRootPath, "Plugins", "steam_api.bundle")),
             not null when File.Exists(Path.Combine(gameRootPath, GameInfo.Subnautica.DataFolder, "Plugins", "x86_64", "steam_api64.dll")) => true,
             not null when File.Exists(Path.Combine(gameRootPath, GameInfo.Subnautica.DataFolder, "Plugins", "steam_api64.dll")) => true,
             _ => false
         };
+    }
 
     private static async Task<ProcessEx?> StartPlatformAsync()
     {


### PR DESCRIPTION
Fixes #2585 
Steam.OwnsGame now checks if Steam is installed before claiming ownership
Added Standalone fallback to run game exe directly when no platform is detected