### PR TITLE
Disabled drill_loop and drill_hit_loop auto sync as it's handled manually

### DIFF
--- a/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
+++ b/Nitrox.Assets.Subnautica/Resources/SoundWhitelist_Subnautica.csv
@@ -790,8 +790,8 @@ event:/sub/exo/claw_pickup;true;true;40
 event:/sub/exo/claw_punch;true;true;40
 event:/sub/exo/dock_exo_cyclops;false;false;0
 event:/sub/exo/dock_exo_moonpool;false;false;0
-event:/sub/exo/drill_hit_loop;true;true;50
-event:/sub/exo/drill_loop;true;true;50
+event:/sub/exo/drill_hit_loop;false;true;50
+event:/sub/exo/drill_loop;false;true;50
 event:/sub/exo/enter_exo;false;false;0
 event:/sub/exo/hook_hit;true;true;50
 event:/sub/exo/hook_loop;true;true;50

--- a/NitroxClient/MonoBehaviours/Vehicles/ExosuitMovementReplicator.cs
+++ b/NitroxClient/MonoBehaviours/Vehicles/ExosuitMovementReplicator.cs
@@ -1,7 +1,5 @@
 using FMOD.Studio;
 using NitroxClient.GameLogic;
-using NitroxClient.GameLogic.FMOD;
-using NitroxClient.GameLogic.Helper;
 using Nitrox.Model.GameLogic.FMOD;
 using Nitrox.Model.Subnautica.Packets;
 using UnityEngine;
@@ -12,7 +10,7 @@ public class ExosuitMovementReplicator : VehicleMovementReplicator
 {
     private const string DRILL_LOOP_SOUND_PATH = "event:/sub/exo/drill_loop";
 
-    private Exosuit exosuit;
+    private Exosuit exosuit = null!;
 
     public Vector3 velocity;
     private float jetLoopingSoundDistance;

--- a/NitroxPatcher/Patches/Dynamic/BreakableResource_BreakIntoResources_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BreakableResource_BreakIntoResources_Patch.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.MonoBehaviours;
 using Nitrox.Model.DataStructures;
-using Nitrox.Model.Packets;
 using Nitrox.Model.Subnautica.Packets;
 
 namespace NitroxPatcher.Patches.Dynamic;

--- a/NitroxPatcher/Patches/Dynamic/FMOD_CustomEmitter_OnPlay_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/FMOD_CustomEmitter_OnPlay_Patch.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using FMOD.Studio;
 using NitroxClient.GameLogic.FMOD;
 using NitroxClient.MonoBehaviours;
-using Nitrox.Model.Subnautica.DataStructures;
 using Nitrox.Model.GameLogic.FMOD;
 
 namespace NitroxPatcher.Patches.Dynamic;


### PR DESCRIPTION
Previously the FMOD sync for these 2 looping sounds conflicted with the prawnsuit action sync, causing sound to never stop in some cases.
Also makes "volume by distance" work done in this PR function properly:
- https://github.com/SubnauticaNitrox/Nitrox/pull/2600

Only the slight rumble sound on resource node hit (drill_hit_loop) will not play for remote player. In future, we should sync this up manually through the remotely controlled prawnsuit, which would proper match visuals with sound too.

On client that controls prawn suit, drill audio is as expected.