### PR TITLE
Show path to loaded DLL on unhandled type-related exceptions

### DIFF
--- a/Nitrox.Server.Subnautica/Program.cs
+++ b/Nitrox.Server.Subnautica/Program.cs
@@ -532,7 +532,7 @@ public class Program
 
         // Extract just the assembly name without version info
         string shortName = assemblyName.Split(',')[0].Trim();
-        Assembly loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
+        Assembly? loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => a.GetName().Name?.Equals(shortName, StringComparison.OrdinalIgnoreCase) == true);
 
         if (loadedAssembly != null)

--- a/Nitrox.Server.Subnautica/Program.cs
+++ b/Nitrox.Server.Subnautica/Program.cs
@@ -517,7 +517,7 @@ public class Program
     /// </summary>
     private static void LogAssemblyPathFromException(Exception ex)
     {
-        string assemblyName = ex switch
+        string? assemblyName = ex switch
         {
             TypeLoadException tle => ExtractAssemblyNameFromTypeLoadException(tle),
             FileLoadException fle => fle.FileName,

--- a/Nitrox.Server.Subnautica/Program.cs
+++ b/Nitrox.Server.Subnautica/Program.cs
@@ -547,11 +547,11 @@ public class Program
         try
         {
             // Extract just the assembly name without version info
-            AssemblyName name = new(assemblyName);
             Assembly? loadedAssembly = AppDomain
                                        .CurrentDomain
                                        .GetAssemblies()
-                                       .FirstOrDefault(a => a.GetName().Name?.Equals(name.Name, StringComparison.OrdinalIgnoreCase) == true);
+                                       .OrderBy(a => a.GetName().FullName.Equals(assemblyName) ? 0 : 1) // Sorts full matches before weak matches.
+                                       .FirstOrDefault(a => a.GetName().Name?.Equals(new AssemblyName(assemblyName).Name, StringComparison.OrdinalIgnoreCase) == true);
 
             if (loadedAssembly != null && loadedAssembly.GetName() is { } asmName)
             {


### PR DESCRIPTION
Fixes #2556
when a TypeLoadException occurs, it now logs the path and version of the loaded assembly to help diagnose version conflicts

## Testing

Can trigger a TypeLoadException for testing using this code and calling `new Error()` somewhere:

```cs
using System;
using System.Runtime.InteropServices;

namespace Nitrox.Server.Subnautica;

public class Error
{
    public Error()
    {
        foreach (var field in typeof(Container).GetFields())
        {
            Console.WriteLine($"{field.Name}: {field.FieldType}");
        }
    }

    private abstract class Abstract
    {
        public int a;
    }

    [StructLayout(LayoutKind.Sequential)]
    private sealed class TestClass : Abstract
    {
        public int x;
    }

    private sealed class Container
    {
        public TestClass tc;
    }
}
```