### PR TITLE
Fix remote player equipment visibility initialization

### DIFF
--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -101,6 +101,7 @@ public class RemotePlayer : INitroxPlayer
         CoroutineUtils.StartCoroutineSmart(playerModelManager.AttachPing(this));
         playerModelManager.BeginApplyPlayerColor(this);
         playerModelManager.RegisterEquipmentVisibilityHandler(PlayerModel);
+        UpdateEquipmentVisibility([]);
         SetupBody();
         SetupSkyAppliers();
         SetupPlayerSounds();


### PR DESCRIPTION
Closes #2359 

Initialize equipment visibility to empty when spawning remote players.

Previously, equipment visibility depended on what the local player had equipped when the body prototype was created, which could cause armor pieces like the rebreather to incorrectly appear or not appear on remote players.