### PR TITLE
Fix OpenDirectory returning false on Windows

### DIFF
--- a/Nitrox.Model/Platforms/OS/Shared/ProcessEx.cs
+++ b/Nitrox.Model/Platforms/OS/Shared/ProcessEx.cs
@@ -188,7 +188,7 @@ public class ProcessEx : IDisposable
             Verb = "open",
             UseShellExecute = true
         });
-        return proc != null;
+        return true;
     }
 
     public static ProcessEx? GetFirstProcess(string procName, Func<ProcessEx, bool>? predicate = null)


### PR DESCRIPTION
Closes #2636 

on Windows, `Process.Start` with `UseShellExecute = true` returns `null` when opening directories because Explorer is already running and handles the request without spawning a new process. the fix is to just return `true` after the `Process.Start` call since we already validated the directory exists beforehand.