### PR TITLE
Sync DataBox (BlueprintHandTarget) state across players

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BlueprintHandTargetMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BlueprintHandTargetMetadata.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable]
+[DataContract]
+public class BlueprintHandTargetMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public bool Used { get; }
+
+    [IgnoreConstructor]
+    protected BlueprintHandTargetMetadata()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
+    public BlueprintHandTargetMetadata(bool used)
+    {
+        Used = used;
+    }
+
+    public override string ToString()
+    {
+        return $"[BlueprintHandTargetMetadata Used: {Used}]";
+    }
+}

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -43,6 +43,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata
     [ProtoInclude(84, typeof(DrillableMetadata))]
     [ProtoInclude(85, typeof(PrecursorComputerTerminalMetadata))]
     [ProtoInclude(86, typeof(GenericConsoleMetadata))]
+    [ProtoInclude(87, typeof(BlueprintHandTargetMetadata))]
     public abstract class EntityMetadata
     {
     }

--- a/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
@@ -345,6 +345,9 @@ internal sealed class WorldServiceTest
             case GenericConsoleMetadata metadata when entityAfter.Metadata is GenericConsoleMetadata metadataAfter:
                 Assert.AreEqual(metadata.GotUsed, metadataAfter.GotUsed);
                 break;
+            case BlueprintHandTargetMetadata metadata when entityAfter.Metadata is BlueprintHandTargetMetadata metadataAfter:
+                Assert.AreEqual(metadata.Used, metadataAfter.Used);
+                break;
             default:
                 Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.Metadata?.GetType().Name} - {entityAfter.Metadata?.GetType().Name}");
                 break;

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/BlueprintHandTargetMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/BlueprintHandTargetMetadataExtractor.cs
@@ -1,0 +1,15 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+/// <summary>
+/// Extracts the current state of a DataBox (BlueprintHandTarget) for syncing to new players.
+/// </summary>
+public class BlueprintHandTargetMetadataExtractor : EntityMetadataExtractor<BlueprintHandTarget, BlueprintHandTargetMetadata>
+{
+    public override BlueprintHandTargetMetadata Extract(BlueprintHandTarget entity)
+    {
+        return new BlueprintHandTargetMetadata(entity.used);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/BlueprintHandTargetMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/BlueprintHandTargetMetadataProcessor.cs
@@ -8,14 +8,14 @@ namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
 /// Processes DataBox (BlueprintHandTarget) metadata updates from other players.
 /// When another player opens a DataBox, this applies the visual state change locally.
 /// </summary>
-public class BlueprintHandTargetMetadataProcessor : EntityMetadataProcessor<BlueprintHandTargetMetadata>
+public sealed class BlueprintHandTargetMetadataProcessor : EntityMetadataProcessor<BlueprintHandTargetMetadata>
 {
     public override void ProcessMetadata(GameObject gameObject, BlueprintHandTargetMetadata metadata)
     {
         BlueprintHandTarget blueprintHandTarget = gameObject.GetComponent<BlueprintHandTarget>();
         if (!blueprintHandTarget)
         {
-            Log.Warn($"[BlueprintHandTargetMetadataProcessor] No BlueprintHandTarget component found on {gameObject.name}");
+            Log.Error($"[BlueprintHandTargetMetadataProcessor] No BlueprintHandTarget component found on {gameObject.name}");
             return;
         }
 
@@ -24,8 +24,6 @@ public class BlueprintHandTargetMetadataProcessor : EntityMetadataProcessor<Blue
         {
             return;
         }
-
-        Log.Debug($"[BlueprintHandTargetMetadataProcessor] Processing metadata for {gameObject.name}: Used={metadata.Used}");
 
         blueprintHandTarget.used = metadata.Used;
 

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/BlueprintHandTargetMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/BlueprintHandTargetMetadataProcessor.cs
@@ -1,0 +1,53 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+/// <summary>
+/// Processes DataBox (BlueprintHandTarget) metadata updates from other players.
+/// When another player opens a DataBox, this applies the visual state change locally.
+/// </summary>
+public class BlueprintHandTargetMetadataProcessor : EntityMetadataProcessor<BlueprintHandTargetMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, BlueprintHandTargetMetadata metadata)
+    {
+        BlueprintHandTarget blueprintHandTarget = gameObject.GetComponent<BlueprintHandTarget>();
+        if (!blueprintHandTarget)
+        {
+            Log.Warn($"[BlueprintHandTargetMetadataProcessor] No BlueprintHandTarget component found on {gameObject.name}");
+            return;
+        }
+
+        // Skip if already in the target state
+        if (blueprintHandTarget.used == metadata.Used)
+        {
+            return;
+        }
+
+        Log.Debug($"[BlueprintHandTargetMetadataProcessor] Processing metadata for {gameObject.name}: Used={metadata.Used}");
+
+        blueprintHandTarget.used = metadata.Used;
+
+        if (metadata.Used)
+        {
+            // Trigger the animation if the DataBox has an animator
+            if (!string.IsNullOrEmpty(blueprintHandTarget.animParam) && blueprintHandTarget.animator)
+            {
+                blueprintHandTarget.animator.SetBool(blueprintHandTarget.animParam, true);
+            }
+
+            // Disable the visual game object (the lid/door of the DataBox)
+            if (blueprintHandTarget.disableGameObject)
+            {
+                blueprintHandTarget.disableGameObject.SetActive(false);
+            }
+
+            // Unregister from resource tracker to remove the scanner ping
+            if (blueprintHandTarget.resourceTracker)
+            {
+                blueprintHandTarget.resourceTracker.OnBlueprintHandTargetUsed();
+            }
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/BlueprintHandTarget_UnlockBlueprint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BlueprintHandTarget_UnlockBlueprint_Patch.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Syncs DataBox (BlueprintHandTarget) usage across players.
+/// When a player opens a DataBox to unlock a blueprint, this broadcasts the state to other players.
+/// </summary>
+public sealed partial class BlueprintHandTarget_UnlockBlueprint_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((BlueprintHandTarget t) => t.UnlockBlueprint());
+
+    public static void Postfix(BlueprintHandTarget __instance)
+    {
+        if (__instance.used && __instance.TryGetIdOrWarn(out NitroxId id))
+        {
+            Resolve<Entities>().BroadcastMetadataUpdate(id, new BlueprintHandTargetMetadata(__instance.used));
+        }
+    }
+}


### PR DESCRIPTION
Syncs DataBox state so when one player opens a DataBox:
- Other players see the animation and visual state change
- The scanner ping is removed for all players
- New players joining see the correct state