### PR TITLE
Sync PrecursorDisableGunTerminal firstUse state

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -44,6 +44,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata
     [ProtoInclude(85, typeof(PrecursorComputerTerminalMetadata))]
     [ProtoInclude(86, typeof(GenericConsoleMetadata))]
     [ProtoInclude(87, typeof(BlueprintHandTargetMetadata))]
+    [ProtoInclude(88, typeof(PrecursorDisableGunTerminalMetadata))]
     public abstract class EntityMetadata
     {
     }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/PrecursorDisableGunTerminalMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/PrecursorDisableGunTerminalMetadata.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable]
+[DataContract]
+public class PrecursorDisableGunTerminalMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public bool FirstUse { get; }
+
+    [IgnoreConstructor]
+    protected PrecursorDisableGunTerminalMetadata()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
+    public PrecursorDisableGunTerminalMetadata(bool firstUse)
+    {
+        FirstUse = firstUse;
+    }
+
+    public override string ToString()
+    {
+        return $"[PrecursorDisableGunTerminalMetadata FirstUse: {FirstUse}]";
+    }
+}

--- a/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
@@ -348,6 +348,9 @@ internal sealed class WorldServiceTest
             case BlueprintHandTargetMetadata metadata when entityAfter.Metadata is BlueprintHandTargetMetadata metadataAfter:
                 Assert.AreEqual(metadata.Used, metadataAfter.Used);
                 break;
+            case PrecursorDisableGunTerminalMetadata metadata when entityAfter.Metadata is PrecursorDisableGunTerminalMetadata metadataAfter:
+                Assert.AreEqual(metadata.FirstUse, metadataAfter.FirstUse);
+                break;
             default:
                 Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.Metadata?.GetType().Name} - {entityAfter.Metadata?.GetType().Name}");
                 break;

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -189,6 +189,17 @@ namespace NitroxClient.GameLogic
                     UpdateEntity(entity);
                     continue;
                 }
+                // World entities can be streamed by the game before Nitrox spawns them.
+                // In this case, we just need to apply metadata and mark as spawned.
+                else if (entity is WorldEntity && NitroxEntity.TryGetObjectFrom(entity.Id, out GameObject existingObject))
+                {
+                    Log.Debug($"[Entities] World entity already exists, applying metadata: {entity.Id} ({entity.GetType().Name})");
+                    entityMetadataManager.ApplyMetadata(existingObject, entity.Metadata);
+                    simulationOwnership.ApplyNewerSimulation(entity.Id);
+                    MarkAsSpawned(entity);
+                    batch.AddRange(entity.ChildEntities);
+                    continue;
+                }
                 else if (entity.ParentId != null && !IsParentReady(entity.ParentId))
                 {
                     AddPendingParentEntity(entity);

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -189,17 +189,6 @@ namespace NitroxClient.GameLogic
                     UpdateEntity(entity);
                     continue;
                 }
-                // Some entities (like PlayerEntity) may already exist because they were set up by earlier
-                // sync processors before the entity spawning phase. In this case, just apply metadata and mark as spawned.
-                else if (entity is WorldEntity && NitroxEntity.TryGetObjectFrom(entity.Id, out GameObject existingObject))
-                {
-                    Log.Debug($"[Entities] Entity already exists, applying metadata: {entity.Id} ({entity.GetType().Name})");
-                    entityMetadataManager.ApplyMetadata(existingObject, entity.Metadata);
-                    simulationOwnership.ApplyNewerSimulation(entity.Id);
-                    MarkAsSpawned(entity);
-                    batch.AddRange(entity.ChildEntities);
-                    continue;
-                }
                 else if (entity.ParentId != null && !IsParentReady(entity.ParentId))
                 {
                     AddPendingParentEntity(entity);

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -189,11 +189,11 @@ namespace NitroxClient.GameLogic
                     UpdateEntity(entity);
                     continue;
                 }
-                // World entities can be streamed by the game before Nitrox spawns them.
-                // In this case, we just need to apply metadata and mark as spawned.
+                // Some entities (like PlayerEntity) may already exist because they were set up by earlier
+                // sync processors before the entity spawning phase. In this case, just apply metadata and mark as spawned.
                 else if (entity is WorldEntity && NitroxEntity.TryGetObjectFrom(entity.Id, out GameObject existingObject))
                 {
-                    Log.Debug($"[Entities] World entity already exists, applying metadata: {entity.Id} ({entity.GetType().Name})");
+                    Log.Debug($"[Entities] Entity already exists, applying metadata: {entity.Id} ({entity.GetType().Name})");
                     entityMetadataManager.ApplyMetadata(existingObject, entity.Metadata);
                     simulationOwnership.ApplyNewerSimulation(entity.Id);
                     MarkAsSpawned(entity);

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/PrecursorDisableGunTerminalMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/PrecursorDisableGunTerminalMetadataExtractor.cs
@@ -1,0 +1,12 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+public class PrecursorDisableGunTerminalMetadataExtractor : EntityMetadataExtractor<PrecursorDisableGunTerminal, PrecursorDisableGunTerminalMetadata>
+{
+    public override PrecursorDisableGunTerminalMetadata Extract(PrecursorDisableGunTerminal entity)
+    {
+        return new(entity.firstUse);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/PrecursorDisableGunTerminalMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/PrecursorDisableGunTerminalMetadataProcessor.cs
@@ -1,0 +1,27 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class PrecursorDisableGunTerminalMetadataProcessor : EntityMetadataProcessor<PrecursorDisableGunTerminalMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, PrecursorDisableGunTerminalMetadata metadata)
+    {
+        // The NitroxEntity is on a parent object, so the terminal component may be on this object or a child
+        if (!gameObject.TryGetComponent(out PrecursorDisableGunTerminal terminal))
+        {
+            terminal = gameObject.GetComponentInChildren<PrecursorDisableGunTerminal>();
+        }
+        
+        if (terminal)
+        {
+            Log.Debug($"[PrecursorDisableGunTerminalMetadataProcessor] Applying metadata: firstUse={metadata.FirstUse} to {terminal.gameObject.name}");
+            terminal.firstUse = metadata.FirstUse;
+        }
+        else
+        {
+            Log.Warn($"[PrecursorDisableGunTerminalMetadataProcessor] No PrecursorDisableGunTerminal component found on {gameObject.name} or its children");
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/PrecursorDisableGunTerminalMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/PrecursorDisableGunTerminalMetadataProcessor.cs
@@ -13,15 +13,14 @@ public class PrecursorDisableGunTerminalMetadataProcessor : EntityMetadataProces
         {
             terminal = gameObject.GetComponentInChildren<PrecursorDisableGunTerminal>();
         }
-        
-        if (terminal)
-        {
-            Log.Debug($"[PrecursorDisableGunTerminalMetadataProcessor] Applying metadata: firstUse={metadata.FirstUse} to {terminal.gameObject.name}");
-            terminal.firstUse = metadata.FirstUse;
-        }
-        else
+
+        if (!terminal)
         {
             Log.Warn($"[PrecursorDisableGunTerminalMetadataProcessor] No PrecursorDisableGunTerminal component found on {gameObject.name} or its children");
+            return;
         }
+
+        Log.Debug($"[PrecursorDisableGunTerminalMetadataProcessor] Applying metadata: firstUse={metadata.FirstUse} to {terminal.gameObject.name}");
+        terminal.firstUse = metadata.FirstUse;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd_Patch.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Syncs the firstUse state of the PrecursorDisableGunTerminal (the terminal at the Precursor Gun facility).
+/// This ensures remote players see the correct animation (first use is longer, subsequent uses are shorter).
+/// The firstUse flag is set to false in OnPlayerCinematicModeEnd after the cinematic completes.
+/// </summary>
+public sealed partial class PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((PrecursorDisableGunTerminal t) => t.OnPlayerCinematicModeEnd());
+
+    public static void Postfix(PrecursorDisableGunTerminal __instance)
+    {
+        // After the cinematic ends, firstUse is set to false - sync this to other players
+        // The terminal component is on a child object, so we need to look up the hierarchy for NitroxEntity
+        if (__instance.TryGetComponentInParent(out NitroxEntity entity, true))
+        {
+            Log.Debug($"[PrecursorDisableGunTerminal] Broadcasting metadata update: firstUse={__instance.firstUse}, id={entity.Id}");
+            Resolve<Entities>().BroadcastMetadataUpdate(entity.Id, new PrecursorDisableGunTerminalMetadata(__instance.firstUse));
+        }
+        else
+        {
+            Log.Warn($"[PrecursorDisableGunTerminal] No NitroxEntity found in hierarchy for {__instance.gameObject.GetFullHierarchyPath()}");
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd_Patch.cs
@@ -18,14 +18,13 @@ public sealed partial class PrecursorDisableGunTerminal_OnPlayerCinematicModeEnd
     {
         // After the cinematic ends, firstUse is set to false - sync this to other players
         // The terminal component is on a child object, so we need to look up the hierarchy for NitroxEntity
-        if (__instance.TryGetComponentInParent(out NitroxEntity entity, true))
-        {
-            Log.Debug($"[PrecursorDisableGunTerminal] Broadcasting metadata update: firstUse={__instance.firstUse}, id={entity.Id}");
-            Resolve<Entities>().BroadcastMetadataUpdate(entity.Id, new PrecursorDisableGunTerminalMetadata(__instance.firstUse));
-        }
-        else
+        if (!__instance.TryGetComponentInParent(out NitroxEntity entity, true))
         {
             Log.Warn($"[PrecursorDisableGunTerminal] No NitroxEntity found in hierarchy for {__instance.gameObject.GetFullHierarchyPath()}");
+            return;
         }
+
+        Log.Debug($"[PrecursorDisableGunTerminal] Broadcasting metadata update: firstUse={__instance.firstUse}, id={entity.Id}");
+        Resolve<Entities>().BroadcastMetadataUpdate(entity.Id, new PrecursorDisableGunTerminalMetadata(__instance.firstUse));
     }
 }


### PR DESCRIPTION
Related to #2640

Adds metadata sync for the Precursor Gun disable terminal's firstUse flag.

Also adds handling for entities that already exist before the entity spawning phase (e.g., PlayerEntity set up by earlier sync processors), applying metadata to existing objects instead of trying to respawn.

## Testing

1. Teleport to:
```
warp 448 -91 1168
```
2. Then teleport to:
```
warp 363 -70 1081
```
3. Player A: Use gun disable terminal
4. Player B: Use gun disable terminal, see shorter animation is playing on both ends (animation of terminal arm & syringe not synced yet)