### PR TITLE
Fix Sea Emperor hatching sequence not completing in multiplayer

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -10,6 +9,8 @@ namespace NitroxPatcher.Patches.Dynamic;
 /// </summary>
 public sealed partial class IncubatorEggAnimation_OnHatchAnimationEnd_Patch : NitroxPatch, IDynamicPatch
 {
+    internal const string TEMPORARY_BABY_MARKER = "_NitroxTemporary";
+    
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((IncubatorEggAnimation t) => t.OnHatchAnimationEnd());
 
     public static bool Prefix(IncubatorEggAnimation __instance)
@@ -21,18 +22,14 @@ public sealed partial class IncubatorEggAnimation_OnHatchAnimationEnd_Patch : Ni
         }
 
         // Check if this is a temporary baby (created for animation only)
-        if (__instance.baby.name.Contains("_NitroxTemporary"))
+        if (__instance.baby.name.Contains(TEMPORARY_BABY_MARKER))
         {
             // For temporary babies, we only want to end the cinematic mode and cleanup
             // Don't call SwimToMother() as that should only happen for the real networked baby
             __instance.baby.cinematicController.SetCinematicMode(false);
             
-            // Use reflection to safely set the animationActive field to false
-            FieldInfo animationActiveField = typeof(IncubatorEggAnimation).GetField("animationActive", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (animationActiveField != null)
-            {
-                animationActiveField.SetValue(__instance, false);
-            }
+            // Set animationActive to false (field is publicized via BepInEx.AssemblyPublicizer)
+            __instance.animationActive = false;
             
             // Destroy the temporary baby - the real networked one will be spawned via server broadcast
             Object.Destroy(__instance.baby.gameObject);

--- a/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;

--- a/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEggAnimation_OnHatchAnimationEnd_Patch.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Handles cleanup of temporary babies created for animation on non-simulating players.
+/// Only the real networked baby (from simulating player) should call SwimToMother().
+/// Temporary babies are destroyed after the animation completes.
+/// </summary>
+public sealed partial class IncubatorEggAnimation_OnHatchAnimationEnd_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((IncubatorEggAnimation t) => t.OnHatchAnimationEnd());
+
+    public static bool Prefix(IncubatorEggAnimation __instance)
+    {
+        // Safety check - ensure we have a baby reference
+        if (!__instance.baby)
+        {
+            return true; // Let original method handle this case
+        }
+
+        // Check if this is a temporary baby (created for animation only)
+        if (__instance.baby.name.Contains("_NitroxTemporary"))
+        {
+            // For temporary babies, we only want to end the cinematic mode and cleanup
+            // Don't call SwimToMother() as that should only happen for the real networked baby
+            __instance.baby.cinematicController.SetCinematicMode(false);
+            
+            // Use reflection to safely set the animationActive field to false
+            FieldInfo animationActiveField = typeof(IncubatorEggAnimation).GetField("animationActive", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (animationActiveField != null)
+            {
+                animationActiveField.SetValue(__instance, false);
+            }
+            
+            // Destroy the temporary baby - the real networked one will be spawned via server broadcast
+            Object.Destroy(__instance.baby.gameObject);
+            return false; // Skip the original method
+        }
+
+        // For real networked babies, let the original method run (which calls SwimToMother)
+        return true;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
@@ -58,7 +58,7 @@ public sealed partial class IncubatorEgg_HatchNow_Patch : NitroxPatch, IDynamicP
         else
         {
             // Non-simulating player: mark baby as temporary (will be cleaned up after animation)
-            baby.name += "_NitroxTemporary";
+            baby.name += IncubatorEggAnimation_OnHatchAnimationEnd_Patch.TEMPORARY_BABY_MARKER;
         }
 
         // All players run the full animation sequence

--- a/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
@@ -26,7 +26,11 @@ public sealed partial class IncubatorEgg_HatchNow_Patch : NitroxPatch, IDynamicP
         Utils.PlayFMODAsset(__instance.hatchSound, __instance.transform, 30f);
 
         NitroxEntity serverKnownParent = __instance.GetComponentInParent<NitroxEntity>();
-        Validate.NotNull(serverKnownParent, "Could not find a server known parent for incubator egg");
+        if (!serverKnownParent)
+        {
+            Log.Error("Could not find a server known parent for incubator egg");
+            return false;
+        }
 
         bool isSimulating = Resolve<SimulationOwnership>().HasAnyLockType(serverKnownParent.Id);
 

--- a/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/IncubatorEgg_HatchNow_Patch.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
@@ -9,45 +8,64 @@ using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
+/// <summary>
+/// Handles the Sea Emperor baby hatching sequence in multiplayer.
+/// The simulating player spawns the babies and broadcasts them to other players.
+/// The simulating player also runs the full animation sequence which triggers SwimToMother().
+/// Non-simulating players just see the egg animation - their babies are spawned via server
+/// broadcast and will swim to mother via SeaEmperorBaby_Start_Patch.
+/// </summary>
 public sealed partial class IncubatorEgg_HatchNow_Patch : NitroxPatch, IDynamicPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((IncubatorEgg t) => t.HatchNow());
 
     public static bool Prefix(IncubatorEgg __instance)
     {
-        StartHatchingVisuals(__instance);
+        // Play hatching visual/sound effects for all players
+        __instance.fxControl.Play();
+        Utils.PlayFMODAsset(__instance.hatchSound, __instance.transform, 30f);
 
-        SpawnBabiesIfSimulating(__instance);
-
-        return false;
-    }
-
-    private static void StartHatchingVisuals(IncubatorEgg egg)
-    {
-        egg.fxControl.Play();
-        Utils.PlayFMODAsset(egg.hatchSound, egg.transform, 30f);
-
-        SafeAnimator.SetBool(egg.animationController.eggAnimator, egg.animParameter, true);
-    }
-
-    private static void SpawnBabiesIfSimulating(IncubatorEgg egg)
-    {
-        SimulationOwnership simulationOwnership = NitroxServiceLocator.LocateService<SimulationOwnership>();
-
-        NitroxEntity serverKnownParent = egg.GetComponentInParent<NitroxEntity>();
+        NitroxEntity serverKnownParent = __instance.GetComponentInParent<NitroxEntity>();
         Validate.NotNull(serverKnownParent, "Could not find a server known parent for incubator egg");
 
-        // Only spawn the babies if we are simulating the main incubator platform.
-        if (simulationOwnership.HasAnyLockType(serverKnownParent.Id))
+        bool isSimulating = Resolve<SimulationOwnership>().HasAnyLockType(serverKnownParent.Id);
+
+        if (isSimulating)
         {
-            GameObject baby = UnityEngine.Object.Instantiate<GameObject>(egg.seaEmperorBabyPrefab);
-            baby.transform.position = egg.attachPoint.transform.position;
+            // Simulating player: spawn baby locally and run full animation sequence
+            GameObject baby = Object.Instantiate(__instance.seaEmperorBabyPrefab);
+            baby.transform.SetParent(__instance.attachPoint);
+            baby.transform.localPosition = Vector3.zero;
             baby.transform.localRotation = Quaternion.identity;
 
+            // Broadcast the baby entity to other players
             NitroxId babyId = NitroxEntity.GenerateNewId(baby);
-
-            WorldEntity entity = new(baby.transform.position.ToDto(), baby.transform.rotation.ToDto(), baby.transform.localScale.ToDto(), TechType.SeaEmperorBaby.ToDto(), 3, "09883a6c-9e78-4bbf-9561-9fa6e49ce766", false, babyId, null);
+            WorldEntity entity = new(
+                baby.transform.position.ToDto(),
+                baby.transform.rotation.ToDto(),
+                baby.transform.localScale.ToDto(),
+                TechType.SeaEmperorBaby.ToDto(),
+                3,
+                "09883a6c-9e78-4bbf-9561-9fa6e49ce766",
+                false,
+                babyId,
+                null);
             Resolve<Entities>().BroadcastEntitySpawnedByClient(entity);
+
+            // Set up the baby reference and start the full animation sequence
+            // The animation callback OnHatchAnimationEnd() will call baby.SwimToMother()
+            __instance.babyGO = baby;
+            __instance.animationController.StartHatchAnimation(__instance.babyIdentifier, __instance.animParameter, baby);
+            __instance.Invoke("PlayFxOnBaby", 2f);
         }
+        else
+        {
+            // Non-simulating player: just play the egg animation
+            // The baby will be spawned by server broadcast and SeaEmperorBaby_Start_Patch
+            // will make it swim to mother
+            SafeAnimator.SetBool(__instance.animationController.eggAnimator, __instance.animParameter, true);
+        }
+
+        return false;
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
@@ -27,7 +27,7 @@ public sealed partial class SeaEmperorBaby_Start_Patch : NitroxPatch, IDynamicPa
         }
 
         // Skip temporary babies created for animation
-        if (__instance.name.Contains("_NitroxTemporary"))
+        if (__instance.name.Contains(IncubatorEggAnimation_OnHatchAnimationEnd_Patch.TEMPORARY_BABY_MARKER))
         {
             return;
         }

--- a/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Reflection;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// When a Sea Emperor baby is spawned on a remote client (via server broadcast),
+/// it needs to swim to mother. The simulating player handles this via the egg animation
+/// callback, but remote players receive the baby as a standalone entity.
+/// 
+/// This patch ensures the baby swims to mother if:
+/// 1. SeaEmperor.main exists (we're in the prison aquarium)
+/// 2. The baby has no parent (not attached to an egg - means it's a remote spawn)
+/// 3. The baby doesn't already have a swim target (not already swimming)
+/// </summary>
+public sealed partial class SeaEmperorBaby_Start_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((SeaEmperorBaby t) => t.Start());
+
+    public static void Postfix(SeaEmperorBaby __instance)
+    {
+        // Only trigger swim to mother for remotely spawned babies
+        if (!SeaEmperor.main)
+        {
+            return;
+        }
+
+        // If the baby has a parent, it was spawned by the local hatching sequence
+        // The animation system will handle calling SwimToMother() via OnHatchAnimationEnd()
+        if (__instance.transform.parent != null)
+        {
+            return;
+        }
+
+        // Check if this baby already has a swim target (already being handled)
+        if (__instance.swimToTarget != null && __instance.swimToTarget.target != null)
+        {
+            return;
+        }
+
+        // This is a remotely spawned baby - make it swim to mother
+        // Assign a baby ID based on how many babies are already registered
+        int babyId = SeaEmperor.main.GetBabies().Count();
+        __instance.SetId(babyId);
+        __instance.SwimToMother();
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SeaEmperorBaby_Start_Patch.cs
@@ -12,6 +12,7 @@ namespace NitroxPatcher.Patches.Dynamic;
 /// 1. SeaEmperor.main exists (we're in the prison aquarium)
 /// 2. The baby has no parent (not attached to an egg - means it's a remote spawn)
 /// 3. The baby doesn't already have a swim target (not already swimming)
+/// 4. The baby is not a temporary animation baby
 /// </summary>
 public sealed partial class SeaEmperorBaby_Start_Patch : NitroxPatch, IDynamicPatch
 {
@@ -21,6 +22,12 @@ public sealed partial class SeaEmperorBaby_Start_Patch : NitroxPatch, IDynamicPa
     {
         // Only trigger swim to mother for remotely spawned babies
         if (!SeaEmperor.main)
+        {
+            return;
+        }
+
+        // Skip temporary babies created for animation
+        if (__instance.name.Contains("_NitroxTemporary"))
         {
             return;
         }


### PR DESCRIPTION
Closes #2051 

The hatching sequence was failing because the original patch wasn't calling `StartHatchAnimation()`, which is needed to trigger the animation callback chain that calls `SwimToMother()`.

Changes:
- IncubatorEgg_HatchNow_Patch: Simulating player now spawns baby, attaches it to the egg's attach point, broadcasts the entity, and runs the full animation sequence via `StartHatchAnimation()`
- SeaEmperorBaby_Start_Patch: New patch that handles remotely spawned babies (via server broadcast) by making them swim to mother if they have no parent (meaning they weren't spawned by the local hatching sequence)

## How to test

1. Teleport 2 players to
```
warp 280 -1612 -374
```
2. Add items to inventory:
```
item precursorioncrystal 2
item hatchingenzymes
```
3. Use terminals and see animations play