### PR TITLE
Enabled CRC for packets and use native sockets (latter only server-side)

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Communication/LiteNetLibServer.cs
+++ b/Nitrox.Server.Subnautica/Models/Communication/LiteNetLibServer.cs
@@ -1,7 +1,9 @@
 using System.Buffers;
 using System.Collections.Generic;
 using LiteNetLib;
+using LiteNetLib.Layers;
 using LiteNetLib.Utils;
+using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Server.Subnautica.Models.GameLogic;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
@@ -37,8 +39,9 @@ internal sealed class LiteNetLibServer : IHostedService
         this.options = options;
         this.logger = logger;
         listener = new EventBasedNetListener();
-        server = new NetManager(listener)
+        server = new NetManager(listener, NitroxEnvironment.IsReleaseMode ? new Crc32cLayer() : null)
         {
+            UseNativeSockets = true,
             IPv6Enabled = true
         };
     }

--- a/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
+++ b/NitroxClient/Communication/NetworkingLayer/LiteNetLib/LiteNetLibClient.cs
@@ -4,14 +4,15 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using LiteNetLib;
+using LiteNetLib.Layers;
 using LiteNetLib.Utils;
+using Nitrox.Model.Core;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.Debuggers;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.Gui.Modals;
 using Nitrox.Model.Networking;
 using Nitrox.Model.Packets;
-using Nitrox.Model.Subnautica.Packets;
 
 namespace NitroxClient.Communication.NetworkingLayer.LiteNetLib;
 
@@ -47,7 +48,7 @@ public class LiteNetLibClient : IClient
         };
 
 
-        client = new NetManager(listener)
+        client = new NetManager(listener, NitroxEnvironment.IsReleaseMode ? new Crc32cLayer() : null)
         {
             UpdateTime = 15,
             ChannelsCount = (byte)typeof(Packet.UdpChannelId).GetEnumValues().Length,


### PR DESCRIPTION
Should protect against data corruption (like when using unstable VPN connections)

<!--
Before filing a pull request please look at our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md.

We recommend that if you want to do a non trivial feature or a feature without an already open issue, to contact us on Discord https://discord.gg/E8B4X9s before investing your time.
-->
