### PR TITLE
Handle entities that exist before spawning phase

### DIFF
--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -189,6 +189,17 @@ namespace NitroxClient.GameLogic
                     UpdateEntity(entity);
                     continue;
                 }
+                // Some entities (like PlayerEntity) may already exist because they were set up by earlier
+                // sync processors before the entity spawning phase. In this case, just apply metadata and mark as spawned.
+                else if (entity is WorldEntity && NitroxEntity.TryGetObjectFrom(entity.Id, out GameObject existingObject))
+                {
+                    Log.Debug($"[Entities] Entity already exists, applying metadata: {entity.Id} ({entity.GetType().Name})");
+                    entityMetadataManager.ApplyMetadata(existingObject, entity.Metadata);
+                    simulationOwnership.ApplyNewerSimulation(entity.Id);
+                    MarkAsSpawned(entity);
+                    batch.AddRange(entity.ChildEntities);
+                    continue;
+                }
                 else if (entity.ParentId != null && !IsParentReady(entity.ParentId))
                 {
                     AddPendingParentEntity(entity);


### PR DESCRIPTION
During initial sync, some entities (like PlayerEntity) are set up by earlier sync processors before GlobalRootInitialSyncProcessor spawns entities. This causes the entity spawning phase to encounter entities that already have NitroxIds and GameObjects.

This fix detects such cases and applies metadata to the existing object instead of attempting to respawn it, preventing errors during player join.