### PR TITLE
Few improvements for MacOS

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,21 +1,28 @@
 <Project>
+    
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     </PropertyGroup>
+    
+    <PropertyGroup>
+        <AvaloniaVersion>11.3.12</AvaloniaVersion>
+        <NetSdkVersion>10.0.5</NetSdkVersion>
+    </PropertyGroup>
+    
     <ItemGroup>
         <PackageVersion Include="AssetsTools.NET" Version="3.0.0-preview1" />
         <PackageVersion Include="Autofac" Version="[4.9.4]" />
-        <PackageVersion Include="Avalonia.Desktop" Version="11.3.4" />
-        <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.4" />
+        <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+        <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
         <PackageVersion Include="Avalonia.Svg.Skia" Version="11.3.0" />
-        <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+        <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
         <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.3.0.6" />
         <PackageVersion Include="Avalonia.Xaml.Interactivity" Version="11.3.0.6" />
-        <PackageVersion Include="Avalonia" Version="11.3.4" />
+        <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
         <PackageVersion Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" />
         <PackageVersion Include="Bogus" Version="35.6.3" />
-        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.1" />
         <PackageVersion Include="CompareNETObjects" Version="4.83.0" />
         <PackageVersion Include="ConsoleAppFramework" Version="5.6.1" />
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
@@ -31,12 +38,12 @@
         <PackageVersion Include="MagicOnion.Abstractions" Version="7.0.6" />
         <PackageVersion Include="MagicOnion.Client" Version="7.0.6" />
         <PackageVersion Include="MagicOnion.Server" Version="7.0.6" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.2" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.2" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(NetSdkVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(NetSdkVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(NetSdkVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="$(NetSdkVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(NetSdkVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="$(NetSdkVersion)" />
         <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageVersion Include="Mono.Nat" Version="3.0.4" />
         <PackageVersion Include="MSTest" Version="3.8.3" />
@@ -60,8 +67,9 @@
         <PackageVersion Include="System.Memory" Version="4.6.3" />
         <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
         <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-        <PackageVersion Include="System.Text.Json" Version="10.0.1" />
+        <PackageVersion Include="System.Text.Json" Version="$(NetSdkVersion)" />
         <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
         <PackageVersion Include="ZLogger" Version="2.5.10" />
     </ItemGroup>
+    
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageVersion Include="Nitrox.Analyzers" Version="1.0.13" />
         <PackageVersion Include="Nitrox.BinaryPack" Version="2.0.1" />
-        <PackageVersion Include="Nitrox.Discovery.MSBuild" Version="0.1.1" />
+        <PackageVersion Include="Nitrox.Discovery.MSBuild" Version="0.1.3" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="PolySharp" Version="1.15.0" />
         <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />

--- a/Nitrox.Launcher/Views/Abstract/WindowEx.cs
+++ b/Nitrox.Launcher/Views/Abstract/WindowEx.cs
@@ -12,7 +12,8 @@ internal abstract class WindowEx<T> : Window where T : ViewModelBase
         this.ApplyOsWindowStyling();
 
         // On Linux systems, Avalonia has trouble allowing windows to resize without "decorations". So we enable it in full, but hide the custom titlebar as it'll look bad.
-        if (OperatingSystem.IsLinux())
+        // On macOS, we need the native toolbar as every app is using it
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
         {
             SystemDecorations = SystemDecorations.Full;
             NitroxAttached.SetUseCustomTitleBar(this, false);


### PR DESCRIPTION
* **Bumped Nitrox.Discovery to latest version** : [Adds support for little endian Mach-O binaries and universal binaries](https://github.com/SubnauticaNitrox/Nitrox.Discovery/pull/3), and [Heroic Launcher](https://github.com/SubnauticaNitrox/Nitrox.Discovery/commit/f1df0bf055ef911e4e91b8647421a590f2cb7cf0)
* Bumped Avalonia version to latest patch : Various fixes needed for MacOS (especially [11.3.9](https://github.com/AvaloniaUI/Avalonia/releases/tag/11.3.9))
* Removed Nitrox Custom Titlebar on MacOS