### PR TITLE
Grant access to steam libraries in sandbox

### DIFF
--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -359,9 +359,21 @@ public sealed class Steam : IGamePlatform
             result.EnvironmentVariables.Add("STEAM_COMPAT_CLIENT_INSTALL_PATH", steamPath);
             result.EnvironmentVariables.Add("STEAM_COMPAT_DATA_PATH", compatdataPath);
             result.EnvironmentVariables.Add("STEAM_OVERLAY_LINUX", "1"); // Enable Steam overlay and API for controller input and OSK support (Proton-specific)
+            result.EnvironmentVariables.Add("PRESSURE_VESSEL_FILESYSTEMS_RW", JoinPaths(GetAllLibraryPaths(steamPath)));
         }
 
         return result;
+
+        static string JoinPaths(params IEnumerable<string?> paths)
+        {
+            paths = paths.Where(path => path != null).Distinct().ToList();
+            string? invalidPath = paths.FirstOrDefault(path => path != null && path.Contains(':'));
+            if (invalidPath != null)
+            {
+                throw new Exception($"Path '{invalidPath}' contains invalid character ':'");
+            }
+            return string.Join(":", paths);
+        }
 
         // function to get library path for given game id
         static string GetLibraryPath(string steamPath, string gameId)

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -34,7 +34,7 @@ public static class Main
         {
             string path = (args[i], args[i + 1]) switch
             {
-                ("--nitrox", { } value) when Directory.Exists(value) => Path.GetFullPath(value),
+                ("--nitrox", { } value) when !string.IsNullOrEmpty(value) => Path.GetFullPath(value),
                 _ => null
             };
             if (!string.IsNullOrEmpty(path))
@@ -69,9 +69,14 @@ public static class Main
         AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += CurrentDomainOnAssemblyResolve;
 
         Console.WriteLine("Checking if Nitrox should run...");
+        if (string.IsNullOrEmpty(nitroxLauncherDir.Value))
+        {
+            Console.WriteLine($"Nitrox will not load because launcher path was not provided");
+            return;
+        }
         if (!Directory.Exists(nitroxLauncherDir.Value))
         {
-            Console.WriteLine($"Nitrox will not load because launcher path was not provided or does not exist: {nitroxLauncherDir.Value}");
+            Console.WriteLine($"Nitrox will not load because launcher path does not exist or is inaccessible: '{nitroxLauncherDir.Value}'");
             return;
         }
 


### PR DESCRIPTION
The Steam Runtime (Pressure Vessel) sandboxes applications and doesn't grant it access to the whole file system. So if `steamapps` is installed in an unusual location, starting proton will fail. This change adds all steam libraries to the locations the game can access.

Fixes #2688 