### PR TITLE
Fix typo: "aquire" -> "acquire" in SimulationOwnership comment

### DIFF
--- a/Nitrox.Server.Subnautica/Models/GameLogic/SimulationOwnership.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/SimulationOwnership.cs
@@ -24,7 +24,7 @@ namespace Nitrox.Server.Subnautica.Models.GameLogic
         {
             lock (playerLocksById)
             {
-                // If no one is simulating then aquire a lock for this player
+                // If no one is simulating then acquire a lock for this player
                 if (!playerLocksById.TryGetValue(id, out PlayerLock playerLock))
                 {
                     playerLocksById[id] = new PlayerLock(player, requestedLock);


### PR DESCRIPTION
## Summary
- Fixed a minor typo in `SimulationOwnershipData.TryToAcquire` comment: "aquire" -> "acquire"

## Test plan
- [x] Verified build succeeds with 0 errors on macOS arm64

Made with [Cursor](https://cursor.com)