### PR TITLE
[MacOS] Implement SetForegroundWindowAndRestore using Osascript

### DIFF
--- a/Nitrox.Launcher/Models/Extensions/ProcessExExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/ProcessExExtensions.cs
@@ -37,7 +37,7 @@ public static class ProcessExExtensions
                 ArgumentList =
                 {
                     "-e",
-                    $"tell application \"System Events\" to set frontmost of the first process whose unix id is {process.Id} to true",
+                    $"tell application \"System Events\" to set frontmost of every process whose unix id is {process.Id} to true",
                 },
                 UseShellExecute = false,
                 RedirectStandardError = true,


### PR DESCRIPTION
## Summary
- Implement `SetForegroundWindowAndRestore` for macOS using `osascript` + System Events (`frontmost` by unix process id).

## Test plan
- [x] `dotnet build Nitrox.Launcher` on macOS arm64
- [ ] Manual: focus another app, trigger bring-to-front for launcher; window should activate (may require Accessibility permission for Terminal/Cursor if testing from dev host).

Made with [Cursor](https://cursor.com)