### PR TITLE
Fix cache stampede in SubnauticaUwePrefabFactory

### DIFF
--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/SubnauticaUwePrefabFactory.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/SubnauticaUwePrefabFactory.cs
@@ -1,15 +1,18 @@
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.Resources.Parsers;
 using static LootDistributionData;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 
-internal sealed class SubnauticaUwePrefabFactory(EntityDistributionsResource distributionData) : IUwePrefabFactory
+internal sealed class SubnauticaUwePrefabFactory(IEntityDistributionsAccessor distributionData) : IUwePrefabFactory
 {
-    private readonly EntityDistributionsResource resource = distributionData;
-    private readonly Dictionary<string, List<UwePrefab>> cache = new();
-    private readonly Lock cacheLock = new();
+    private readonly IEntityDistributionsAccessor resource = distributionData;
+    private readonly ConcurrentDictionary<string, Lazy<Task<List<UwePrefab>>>> cache = new();
 
     public async Task<List<UwePrefab>> TryGetPossiblePrefabsAsync(string? biome)
     {
@@ -17,18 +20,16 @@ internal sealed class SubnauticaUwePrefabFactory(EntityDistributionsResource dis
         {
             return [];
         }
-        List<UwePrefab> prefabs;
-        lock (cacheLock)
-        {
-            if (cache.TryGetValue(biome, out prefabs))
-            {
-                return prefabs;
-            }
-        }
 
-        prefabs = new();
+        Lazy<Task<List<UwePrefab>>> lazy = cache.GetOrAdd(biome, key => new Lazy<Task<List<UwePrefab>>>(() => LoadPrefabsForBiomeAsync(key), LazyThreadSafetyMode.ExecutionAndPublication));
+        return await lazy.Value.ConfigureAwait(false);
+    }
+
+    private async Task<List<UwePrefab>> LoadPrefabsForBiomeAsync(string biome)
+    {
+        List<UwePrefab> prefabs = [];
         BiomeType biomeType = (BiomeType)Enum.Parse(typeof(BiomeType), biome);
-        LootDistributionData distributionData = await resource.GetLootDistributionDataAsync();
+        LootDistributionData distributionData = await resource.GetLootDistributionDataAsync().ConfigureAwait(false);
         if (distributionData.GetBiomeLoot(biomeType, out DstData dstData))
         {
             foreach (PrefabData prefabData in dstData.prefabs)
@@ -39,17 +40,11 @@ internal sealed class SubnauticaUwePrefabFactory(EntityDistributionsResource dis
                     // You can verify this by looping through all of SrcData (e.g in LootDistributionData.Initialize)
                     // print the prefabPath and check the TechType related to the provided classId (WorldEntityDatabase.TryGetInfo) with PDAScanner.IsFragment
                     bool isFragment = srcData.prefabPath.Contains("Fragment") || srcData.prefabPath.Contains("BaseGlassDome");
-                    lock (cacheLock)
-                    {
-                        prefabs.Add(new(prefabData.classId, prefabData.count, prefabData.probability, isFragment));
-                    }
+                    prefabs.Add(new(prefabData.classId, prefabData.count, prefabData.probability, isFragment));
                 }
             }
         }
-        lock (cacheLock)
-        {
-            cache[biome] = prefabs;
-        }
+
         return prefabs;
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Resources/Parsers/EntityDistributionsResource.cs
+++ b/Nitrox.Server.Subnautica/Models/Resources/Parsers/EntityDistributionsResource.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text.Json;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
@@ -7,7 +7,7 @@ using LootDictionary = System.Collections.Generic.Dictionary<string, LootDistrib
 
 namespace Nitrox.Server.Subnautica.Models.Resources.Parsers;
 
-internal sealed class EntityDistributionsResource(SubnauticaAssetsManager assetsManager, IOptions<ServerStartOptions> options) : IGameResource
+internal sealed class EntityDistributionsResource(SubnauticaAssetsManager assetsManager, IOptions<ServerStartOptions> options) : IGameResource, IEntityDistributionsAccessor
 {
     private readonly SubnauticaAssetsManager assetsManager = assetsManager;
 

--- a/Nitrox.Server.Subnautica/Models/Resources/Parsers/IEntityDistributionsAccessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Resources/Parsers/IEntityDistributionsAccessor.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nitrox.Server.Subnautica.Models.Resources.Parsers;
+
+/// <summary>
+///     Abstraction for tests and <see cref="SubnauticaUwePrefabFactory" /> to consume loot distribution data without coupling to <see cref="EntityDistributionsResource" />.
+/// </summary>
+internal interface IEntityDistributionsAccessor
+{
+    Task<LootDistributionData> GetLootDistributionDataAsync(CancellationToken cancellationToken = default);
+}

--- a/Nitrox.Server.Subnautica/Nitrox.Server.Subnautica.csproj
+++ b/Nitrox.Server.Subnautica/Nitrox.Server.Subnautica.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -36,6 +36,13 @@
         <_ServerDevelopmentJsonFilePath>$(MSBuildThisFileDirectory)\server.Development.json</_ServerDevelopmentJsonFilePath>
     </PropertyGroup>
     
+    <!-- Allow NSubstitute to proxy internal types (e.g. IEntityDistributionsAccessor) from Nitrox.Test -->
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
     <Target Name="GenerateServerDevelopmentJson" BeforeTargets="BeforeBuild" Condition="'$(_ServerDevelopmentJsonFilePath)' != '' and !Exists('$(_ServerDevelopmentJsonFilePath)')">
         <PropertyGroup>
             <_ServerDevelopmentJsonContent>

--- a/Nitrox.Test/Server/GameLogic/Entities/SubnauticaUwePrefabFactoryTest.cs
+++ b/Nitrox.Test/Server/GameLogic/Entities/SubnauticaUwePrefabFactoryTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
+using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+using Nitrox.Server.Subnautica.Models.Resources.Parsers;
+using NSubstitute;
+using LootDictionary = System.Collections.Generic.Dictionary<string, LootDistributionData.SrcData>;
+
+namespace Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+
+[TestClass]
+public class SubnauticaUwePrefabFactoryTest
+{
+    private static LootDistributionData CreateEmptyInitializedLootDistributionData()
+    {
+        LootDictionary empty = [];
+        LootDistributionData data = new();
+        data.Initialize(empty);
+        return data;
+    }
+
+    [TestMethod]
+    public async Task TryGetPossiblePrefabsAsync_NullBiome_ReturnsEmptyWithoutCallingResource()
+    {
+        IEntityDistributionsAccessor accessor = Substitute.For<IEntityDistributionsAccessor>();
+        SubnauticaUwePrefabFactory factory = new(accessor);
+
+        List<UwePrefab> result = await factory.TryGetPossiblePrefabsAsync(null);
+
+        result.Should().BeEmpty();
+        await accessor.DidNotReceive().GetLootDistributionDataAsync(Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task TryGetPossiblePrefabsAsync_ConcurrentCallsSameBiome_LoadsDistributionOnce()
+    {
+        int callCount = 0;
+        IEntityDistributionsAccessor accessor = Substitute.For<IEntityDistributionsAccessor>();
+        accessor.GetLootDistributionDataAsync(Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    Interlocked.Increment(ref callCount);
+                    return Task.FromResult(CreateEmptyInitializedLootDistributionData());
+                });
+
+        SubnauticaUwePrefabFactory factory = new(accessor);
+
+        string biomeName = Enum.GetNames(typeof(BiomeType))[0];
+        Task[] tasks = Enumerable.Range(0, 10).Select(_ => factory.TryGetPossiblePrefabsAsync(biomeName)).ToArray();
+        await Task.WhenAll(tasks);
+
+        callCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task TryGetPossiblePrefabsAsync_SecondCall_ReusesCachedTask()
+    {
+        IEntityDistributionsAccessor accessor = Substitute.For<IEntityDistributionsAccessor>();
+        accessor.GetLootDistributionDataAsync(Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(CreateEmptyInitializedLootDistributionData()));
+
+        SubnauticaUwePrefabFactory factory = new(accessor);
+
+        string biomeName = Enum.GetNames(typeof(BiomeType))[0];
+        List<UwePrefab> first = await factory.TryGetPossiblePrefabsAsync(biomeName);
+        List<UwePrefab> second = await factory.TryGetPossiblePrefabsAsync(biomeName);
+
+        second.Should().BeSameAs(first);
+        await accessor.Received(1).GetLootDistributionDataAsync(Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a thundering-herd race where concurrent callers for the same biome could all miss the cache and trigger redundant `GetLootDistributionDataAsync` loads.

## Changes
- Replace `Dictionary` + `Lock` with `ConcurrentDictionary<string, Lazy<Task<List<UwePrefab>>>>` and `LazyThreadSafetyMode.ExecutionAndPublication` so exactly one load runs per biome key.
- Extract `IEntityDistributionsAccessor` so the factory can be unit-tested; `EntityDistributionsResource` implements it.
- `InternalsVisibleTo("DynamicProxyGenAssembly2")` for NSubstitute on internal types.
- Add `SubnauticaUwePrefabFactoryTest`: null biome (no resource call), concurrent same-biome (single load), sequential calls (same list instance + single resource call).

## Testing
`dotnet test Nitrox.Test/Nitrox.Test.csproj --filter FullyQualifiedName~SubnauticaUwePrefabFactoryTest`

Made with [Cursor](https://cursor.com)