### PR TITLE
Disabled CET

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,8 @@
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
         <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+        <!-- Disable CET because not everyone running Nitrox uses an up-to-date Windows. See for more info: https://github.com/SubnauticaNitrox/Nitrox/issues/2637 -->
+        <CETCompat Condition="'$(_IsWindowsTarget)' == 'true'">false</CETCompat>
     </PropertyGroup>
 
     <!-- Nitrox specific properties -->


### PR DESCRIPTION
CET can fail when Windows is missing updates from 2022. But we still get reports today so it's likely not going away for the foreseeable future.

No warning message happens if CET fails, Nitrox Launcher will fail to start. This is extremely bad UX so lets disable.

See https://github.com/SubnauticaNitrox/Nitrox/issues/2637 for more info.