### PR TITLE
Added player list tooltip to Nitrox Launcher

### DIFF
--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -92,7 +93,11 @@ internal sealed partial class ServerEntry : ObservableObject
     private Perms playerPermissions = serverDefaults.DefaultPlayerPerm;
 
     [ObservableProperty]
-    private int players;
+    private int playerCount;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PlayerNamesTooltip))]
+    private List<string> playerNames = [];
 
     [ObservableProperty]
     private int port = serverDefaults.ServerPort;
@@ -111,6 +116,7 @@ internal sealed partial class ServerEntry : ObservableObject
 
     internal ServerProcess? Process { get; private set; }
     public AvaloniaList<OutputLine> Output { get; } = [];
+    public string? PlayerNamesTooltip => PlayerNames.Count == 0 ? null : string.Join(Environment.NewLine, PlayerNames);
 
     /// <summary>
     ///     Gets the last process id known by this server entry.
@@ -337,7 +343,7 @@ internal sealed partial class ServerEntry : ObservableObject
         switch (e.PropertyName)
         {
             case nameof(IsOnline) when LastProcessId > 0:
-                WeakReferenceMessenger.Default.Send(new ServerStatusMessage(LastProcessId, IsOnline, Players));
+                WeakReferenceMessenger.Default.Send(new ServerStatusMessage(LastProcessId, IsOnline, PlayerCount));
                 break;
         }
         base.OnPropertyChanged(e);
@@ -372,7 +378,8 @@ internal sealed partial class ServerEntry : ObservableObject
                         }
                     }
                     CommandQueue = Channel.CreateUnbounded<string>();
-                    Players = 0;
+                    PlayerCount = 0;
+                    PlayerNames = [];
                     IsOnline = false;
                     Output.Clear();
                 });

--- a/Nitrox.Launcher/Models/Services/ServersManagement.cs
+++ b/Nitrox.Launcher/Models/Services/ServersManagement.cs
@@ -20,14 +20,15 @@ internal sealed class ServersManagement(ServerService serverService) : Streaming
     private int processId;
     private string saveName;
 
-    public ValueTask SetPlayerCount(int playerCount)
+    public ValueTask SetPlayers(string[] players)
     {
         ServerEntry? entry = serverService.GetServerEntryByAnyOf(processId, saveName);
         if (entry == null)
         {
             return CompletedTask;
         }
-        entry.Players = playerCount;
+        entry.PlayerCount = players.Length;
+        entry.PlayerNames = [..players];
         return CompletedTask;
     }
 

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -111,7 +111,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private int serverPlayers;
+    private int serverPlayerCount;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
@@ -147,7 +147,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
                 return;
             }
             vm.ServerIsOnline = status.IsOnline;
-            vm.ServerPlayers = status.PlayerCount;
+            vm.ServerPlayerCount = status.PlayerCount;
         });
     }
 
@@ -185,7 +185,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
         ServerDefaultPlayerPerm = Server.PlayerPermissions;
         ServerAutoSaveInterval = Server.AutoSaveInterval;
         ServerMaxPlayers = Server.MaxPlayers;
-        ServerPlayers = Server.Players;
+        ServerPlayerCount = Server.PlayerCount;
         ServerPort = Server.Port;
         ServerAutoPortForward = Server.PortForward;
         ServerAllowLanDiscovery = Server.AllowLanDiscovery;
@@ -203,7 +203,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
                                   ServerDefaultPlayerPerm != Server.PlayerPermissions ||
                                   ServerAutoSaveInterval != Server.AutoSaveInterval ||
                                   ServerMaxPlayers != Server.MaxPlayers ||
-                                  ServerPlayers != Server.Players ||
+                                  ServerPlayerCount != Server.PlayerCount ||
                                   ServerPort != Server.Port ||
                                   ServerAutoPortForward != Server.PortForward ||
                                   ServerAllowLanDiscovery != Server.AllowLanDiscovery ||
@@ -261,7 +261,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
         Server.PlayerPermissions = ServerDefaultPlayerPerm;
         Server.AutoSaveInterval = ServerAutoSaveInterval;
         Server.MaxPlayers = ServerMaxPlayers;
-        Server.Players = ServerPlayers;
+        Server.PlayerCount = ServerPlayerCount;
         Server.Port = ServerPort;
         Server.PortForward = ServerAutoPortForward;
         Server.AllowLanDiscovery = ServerAllowLanDiscovery;
@@ -311,7 +311,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
         ServerDefaultPlayerPerm = Server.PlayerPermissions;
         ServerAutoSaveInterval = Server.AutoSaveInterval;
         ServerMaxPlayers = Server.MaxPlayers;
-        ServerPlayers = Server.Players;
+        ServerPlayerCount = Server.PlayerCount;
         ServerPort = Server.Port;
         ServerAutoPortForward = Server.PortForward;
         ServerAllowLanDiscovery = Server.AllowLanDiscovery;

--- a/Nitrox.Launcher/ViewModels/ServersViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ServersViewModel.cs
@@ -41,7 +41,7 @@ internal partial class ServersViewModel : RoutableViewModelBase
             {
                 return;
             }
-            entry.Players = message.PlayerCount;
+            entry.PlayerCount = message.PlayerCount;
             entry.IsOnline = message.IsOnline;
         });
 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -119,11 +119,18 @@
                             </StackPanel>
                         </Panel>
                         <TextBlock Text="{Binding Server.GameMode, Converter={converters:ToStringConverter}, FallbackValue=Survival}" />
-                        <TextBlock TextWrapping="NoWrap">
-                            <Run Text="{Binding Server.Players, FallbackValue=0}" />
-                            <Run Text="/" />
+                        <TextBlock TextWrapping="NoWrap" Background="Transparent"
+                                   Classes.online="{Binding Server.IsOnline, FallbackValue=False}"
+                                   ToolTip.Tip="{Binding Server.PlayerNamesTooltip, FallbackValue=''}">
+                            <Run Text="{Binding Server.PlayerCount, FallbackValue=0}" />
+                            <Run Text=" / " />
                             <Run Text="{Binding Server.MaxPlayers, FallbackValue=100}" />
-                            <Run Text="playing" />
+                            <Run Text=" playing" />
+                            <TextBlock.Styles>
+                                <Style Selector="TextBlock.online:pointerover">
+                                    <Setter Property="TextDecorations" Value="Underline" />
+                                </Style>
+                            </TextBlock.Styles>
                         </TextBlock>
                     </StackPanel>
 

--- a/Nitrox.Launcher/Views/ServersView.axaml
+++ b/Nitrox.Launcher/Views/ServersView.axaml
@@ -118,11 +118,18 @@
                                                     </StackPanel>
                                                 </Panel>
                                                 <TextBlock Text="{Binding GameMode, Converter={converters:ToStringConverter}}" />
-                                                <TextBlock TextWrapping="NoWrap">
-                                                    <Run Text="{Binding Players}" />
-                                                    <Run Text="/" />
+                                                <TextBlock TextWrapping="NoWrap" Background="Transparent"
+                                                           Classes.online="{Binding IsOnline}"
+                                                           ToolTip.Tip="{Binding PlayerNamesTooltip}">
+                                                    <Run Text="{Binding PlayerCount}" />
+                                                    <Run Text=" / " />
                                                     <Run Text="{Binding MaxPlayers}" />
-                                                    <Run Text="playing" />
+                                                    <Run Text=" playing" />
+                                                    <TextBlock.Styles>
+                                                        <Style Selector="TextBlock.online:pointerover">
+                                                            <Setter Property="TextDecorations" Value="Underline" />
+                                                        </Style>
+                                                    </TextBlock.Styles>
                                                 </TextBlock>
                                             </WrapPanel>
                                         </StackPanel>

--- a/Nitrox.Model/MagicOnion/IServersManagement.cs
+++ b/Nitrox.Model/MagicOnion/IServersManagement.cs
@@ -9,7 +9,7 @@ namespace Nitrox.Model.MagicOnion;
 /// </summary>
 public interface IServersManagement : IStreamingHub<IServersManagement, IServerManagementReceiver>
 {
-    ValueTask SetPlayerCount(int playerCount);
+    ValueTask SetPlayers(string[] players);
     ValueTask AddOutputLine(string category, DateTimeOffset? localTime, int level, string message);
 }
 

--- a/Nitrox.Server.Subnautica/Models/GameLogic/PlayerManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/PlayerManager.cs
@@ -188,8 +188,6 @@ internal sealed partial class PlayerManager(SessionManager sessionManager, IOpti
         return player;
     }
 
-    public int PlayerCount => connectedPlayersBySessionId.Count;
-
     public bool SetPlayerProperty<T>(SessionId sessionId, T value, Action<Player, T> action)
     {
         if (!TryGetPlayerBySessionId(sessionId, out Player? player))

--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.IO;
+using System.Linq;
 using System.Threading.Channels;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -114,7 +115,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
 
     private async Task PushPollDataAsync(IServersManagement api)
     {
-        await api.SetPlayerCount(playerManager.PlayerCount);
+        await api.SetPlayers(playerManager.ConnectedPlayers().Select(player => player.Name).ToArray());
     }
 
     private async Task PushLogsAsync(IServersManagement api, CancellationToken cancellationToken)


### PR DESCRIPTION
This PR adds a tooltip to the online player count on ServersView and ManageServerView which lists the names of all online players in that server.

<img width="550" height="479" alt="image" src="https://github.com/user-attachments/assets/21879240-d4d7-4a7b-b567-af937dd6dee7" />