### PR TITLE
Fix Query Command

### DIFF
--- a/Nitrox.Model/DataStructures/NitroxId.cs
+++ b/Nitrox.Model/DataStructures/NitroxId.cs
@@ -12,6 +12,10 @@ namespace Nitrox.Model.DataStructures;
 [DataContract]
 public sealed class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<NitroxId>
 {
+    [IgnoredMember]
+    private static readonly int[] byteOrder = [15, 14, 13, 12, 11, 10, 9, 8, 6, 7, 4, 5, 0, 1, 2, 3];
+
+
     [DataMember(Order = 1)]
     [SerializableMember]
     private Guid guid { get; init; }
@@ -22,10 +26,6 @@ public sealed class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<
         guid = Guid.NewGuid();
     }
 
-    /// <summary>
-    ///     Create a NitroxId from a string
-    /// </summary>
-    /// <param name="str">a NitroxID as string</param>
     public NitroxId(string str)
     {
         guid = new Guid(str);
@@ -47,22 +47,19 @@ public sealed class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<
         guid = new Guid(bytes);
     }
 
-    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue("id", guid.ToByteArray());
     }
 
     public static bool operator ==(NitroxId? id1, NitroxId? id2)
     {
-        if (id1 is null)
+        if (id1 is not null)
         {
-            if (id2 is null)
-            {
-                return true;
-            }
-            return false;
+            return id1.Equals(id2);
         }
-        return id1.Equals(id2);
+
+        return id2 is null;
     }
 
     public static bool operator !=(NitroxId? id1, NitroxId? id2)
@@ -70,49 +67,26 @@ public sealed class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<
         return !(id1 == id2);
     }
 
-    public override bool Equals(object obj)
+    public static implicit operator NitroxId(string str)
     {
-        if (ReferenceEquals(null, obj))
-        {
-            return false;
-        }
-        
-        if (obj.GetType() != GetType())
-        {
-            return false;
-        }
-
-        return Equals((NitroxId)obj);
+        return new NitroxId(str);
     }
 
-        
+    public static implicit operator NitroxId(Guid guid)
+    {
+        return new NitroxId(guid);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as NitroxId);
+
     public bool Equals(NitroxId? other)
     {
-        if (ReferenceEquals(null, other))
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        return guid.Equals(other.guid);
-    }
-        
-    public override int GetHashCode()
-    {
-        return guid.GetHashCode();
+        return other is not null && guid.Equals(other.guid);
     }
 
-    public override string ToString()
-    {
-        return guid.ToString();
-    }
+    public override int GetHashCode() => guid.GetHashCode();
 
-    [IgnoredMember]
-    private static int[] byteOrder = { 15, 14, 13, 12, 11, 10, 9, 8, 6, 7, 4, 5, 0, 1, 2, 3 };
+    public override string ToString() => guid.ToString();
 
     public NitroxId Increment()
     {
@@ -123,18 +97,13 @@ public sealed class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<
         return new NitroxId(nextGuid);
     }
 
-    public int CompareTo(NitroxId other)
+    public int CompareTo(NitroxId? other)
     {
-        if (ReferenceEquals(this, other))
+        if (Equals(this, other))
         {
             return 0;
         }
 
-        if (ReferenceEquals(null, other))
-        {
-            return 1;
-        }
-
-        return guid.CompareTo(other.guid);
+        return other is null ? 1 : guid.CompareTo(other.guid);
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Commands/ArgConverters/StringToNitroxIdConverter.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/ArgConverters/StringToNitroxIdConverter.cs
@@ -1,0 +1,23 @@
+using Nitrox.Model.DataStructures;
+using Nitrox.Server.Subnautica.Models.Commands.ArgConverters.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Commands.ArgConverters;
+
+/// <summary>
+///     Converts a string to a NitroxId, if valid.
+/// </summary>
+internal sealed class StringToNitroxIdConverter : IArgConverter<string, NitroxId>
+{
+    public Task<ConvertResult> ConvertAsync(string nitroxId)
+    {
+        try 
+        {
+            NitroxId id = new(nitroxId);
+            return Task.FromResult(ConvertResult.Ok(id));
+        }
+        catch (Exception)
+        {
+            return Task.FromResult(ConvertResult.Fail());
+        }
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Commands/Debugging/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/Debugging/QueryCommand.cs
@@ -1,5 +1,5 @@
-#if DEBUG
 using System.ComponentModel;
+using System.Text;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
@@ -10,7 +10,7 @@ using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 
 namespace Nitrox.Server.Subnautica.Models.Commands.Debugging;
 
-[RequiresPermission(Perms.HOST)]
+[RequiresPermission(Perms.ADMIN)]
 internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwnershipData simulationOwnershipData, ILogger<QueryCommand> logger) : ICommandHandler<NitroxId>
 {
     private readonly EntityRegistry entityRegistry = entityRegistry;
@@ -26,21 +26,36 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
             return Task.CompletedTask;
         }
 
-        logger.ZLogInformation($"{entity}");
-        if (entity is WorldEntity worldEntity and not GlobalRootEntity)
+        StringBuilder builder = new();
+        builder.AppendLine("Entity");
+        builder.AppendLine($" └ Type: {entity.GetType().Name}");
+        builder.AppendLine($" └ Id: {entity.Id}");
+        builder.AppendLine($" └ TechType: {entity.TechType}");
+        builder.AppendLine($" └ ParentId: {entity.ParentId?.ToString() ?? "none"}");
+        builder.AppendLine($" └ Children: {entity.ChildEntities.Count}");
+        builder.AppendLine($" └ Metadata: {entity.Metadata?.ToString() ?? "none"}");
+
+        if (entity is WorldEntity worldEntity)
         {
-            logger.ZLogInformation($"{worldEntity.AbsoluteEntityCell}");
+            builder.AppendLine("World");
+            builder.AppendLine($" └ ClassId: {worldEntity.ClassId}");
+            builder.AppendLine($" └ Level: {worldEntity.Level}");
+            builder.AppendLine($" └ SpawnedByServer: {worldEntity.SpawnedByServer}");
+            builder.AppendLine($" └ {worldEntity.Transform}");
+            builder.AppendLine($" └ Cell: {(worldEntity is GlobalRootEntity ? "global root" : worldEntity.AbsoluteEntityCell.ToString())}");
         }
-        if (simulationOwnershipData.TryGetLock(entityId, out SimulationOwnershipData.PlayerLock playerLock))
-        {
-            logger.ZLogInformation($"Lock owner: {playerLock.Player.Name}");
-        }
-        else
-        {
-            logger.ZLogInformation($"Not locked");
-        }
+
+        bool isLocked = simulationOwnershipData.TryGetLock(entityId, out SimulationOwnershipData.PlayerLock playerLock);
+
+        builder.AppendLine("Lock status");
+        builder.AppendLine($" └ Locked: {isLocked}");
+        builder.AppendLine($" └ Owner: {(isLocked ? playerLock.Player.Name : "none")}");
+
+        builder.AppendLine("Raw Data");
+        builder.AppendLine(entity.ToString());
+
+        logger.ZLogInformation($"{builder.ToString()}");
 
         return Task.CompletedTask;
     }
 }
-#endif

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -31,8 +31,8 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
         builder.AppendLine($" └ Type: {entity.GetType().Name}");
         builder.AppendLine($" └ Id: {entity.Id}");
         builder.AppendLine($" └ TechType: {entity.TechType}");
-        builder.AppendLine($" └ ParentId: {entity.ParentId?.ToString() ?? "none"}");
-        builder.AppendLine($" └ Metadata: {entity.Metadata?.ToString() ?? "none"}");
+        builder.AppendLine($" └ ParentId: {entity.ParentId?.ToString() ?? "<null>"}");
+        builder.AppendLine($" └ Metadata: {entity.Metadata?.ToString() ?? "<null>"}");
         builder.AppendLine($" └ Children: {entity.ChildEntities.Count}");
         if (entity.ChildEntities.Count > 0)
         {
@@ -60,7 +60,7 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
 
         builder.AppendLine("Lock status");
         builder.AppendLine($" └ Locked: {isLocked}");
-        builder.AppendLine($" └ Owner: {(isLocked ? playerLock.Player.Name : "none")}");
+        builder.AppendLine($" └ Owner: {(isLocked ? $"{playerLock.Player.Name} #{playerLock.Player.SessionId}" : "<null>")}");
 
         builder.AppendLine("Raw Data");
         builder.AppendLine(entity.ToString());

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -8,7 +8,7 @@ using Nitrox.Server.Subnautica.Models.Commands.Core;
 using Nitrox.Server.Subnautica.Models.GameLogic;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 
-namespace Nitrox.Server.Subnautica.Models.Commands.Debugging;
+namespace Nitrox.Server.Subnautica.Models.Commands;
 
 [RequiresPermission(Perms.ADMIN)]
 internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwnershipData simulationOwnershipData, ILogger<QueryCommand> logger) : ICommandHandler<NitroxId>
@@ -18,12 +18,12 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
     private readonly ILogger<QueryCommand> logger = logger;
 
     [Description("Query the entity associated with the given NitroxId")]
-    public Task Execute(ICommandContext context, [Description("NitroxId of an entity")] NitroxId entityId)
+    public async Task Execute(ICommandContext context, [Description("NitroxId of an entity")] NitroxId entityId)
     {
         if (!entityRegistry.TryGetEntityById(entityId, out Entity entity))
         {
-            logger.ZLogError($"Entity with id {entityId} not found");
-            return Task.CompletedTask;
+            await context.ReplyAsync($"Entity with id {entityId} not found");
+            return;
         }
 
         StringBuilder builder = new();
@@ -54,8 +54,6 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
         builder.AppendLine("Raw Data");
         builder.AppendLine(entity.ToString());
 
-        logger.ZLogInformation($"{builder.ToString()}");
-
-        return Task.CompletedTask;
+        await context.ReplyAsync(builder.ToString());
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -32,8 +32,19 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
         builder.AppendLine($" └ Id: {entity.Id}");
         builder.AppendLine($" └ TechType: {entity.TechType}");
         builder.AppendLine($" └ ParentId: {entity.ParentId?.ToString() ?? "none"}");
-        builder.AppendLine($" └ Children: {entity.ChildEntities.Count}");
         builder.AppendLine($" └ Metadata: {entity.Metadata?.ToString() ?? "none"}");
+        builder.AppendLine($" └ Children: {entity.ChildEntities.Count}");
+        if (entity.ChildEntities.Count > 0)
+        {
+            foreach (Entity childEntity in entity.ChildEntities)
+            {
+                builder.AppendLine("   └ Child");
+                builder.AppendLine($"     └ Type: {childEntity.GetType().Name}");
+                builder.AppendLine($"     └ Id: {childEntity.Id}");
+                builder.AppendLine($"     └ Metadata: {childEntity.Metadata?.ToString() ?? "none"}");
+                builder.AppendLine($"     └ Children: {childEntity.ChildEntities.Count}");
+            }
+        }
 
         if (entity is WorldEntity worldEntity)
         {

--- a/Nitrox.Test/Model/DataStructures/NitroxIdTest.cs
+++ b/Nitrox.Test/Model/DataStructures/NitroxIdTest.cs
@@ -3,16 +3,15 @@
 [TestClass]
 public class NitroxIdTest
 {
-    private NitroxId id1;
-    private NitroxId id2;
-
     [TestMethod]
     public void SameGuidEquality()
     {
+        // Arrange
         Guid guid = Guid.NewGuid();
-        id1 = new(guid);
-        id2 = new(guid);
+        NitroxId id1 = new(guid);
+        NitroxId id2 = new(guid);
 
+        // Act & Assert
         (id1 == id2).Should().BeTrue();
         id1.Equals(id2).Should().BeTrue();
         (id1 != id2).Should().BeFalse();
@@ -20,11 +19,39 @@ public class NitroxIdTest
     }
 
     [TestMethod]
+    public void SameReferenceEquality()
+    {
+        // Arrange
+        NitroxId id1 = new(Guid.NewGuid());
+        NitroxId id2 = id1;
+
+        // Act & Assert
+        (id1 == id2).Should().BeTrue();
+        id1.Equals(id2).Should().BeTrue();
+        id1.Equals((object)id2).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DifferentGuidEquality()
+    {
+        // Arrange
+        NitroxId id1 = new(Guid.NewGuid());
+        NitroxId id2 = new(Guid.NewGuid());
+
+        // Act & Assert
+        (id1 == id2).Should().BeFalse();
+        id1.Equals(id2).Should().BeFalse();
+        (id1 != id2).Should().BeTrue();
+    }
+
+    [TestMethod]
     public void NullGuidEquality()
     {
-        id1 = new();
-        id2 = null;
+        // Arrange
+        NitroxId id1 = new();
+        NitroxId id2 = null;
 
+        // Act & Assert
         (id1 == id2).Should().BeFalse();
         id1.Equals(id2).Should().BeFalse();
         (id1 != id2).Should().BeTrue();
@@ -34,8 +61,101 @@ public class NitroxIdTest
     [TestMethod]
     public void BothNullEquality()
     {
-        id1 = id2 = null;
+        // Arrange
+        NitroxId? id1 = null;
+        NitroxId? id2 = null;
+
+        // Act & Assert
         (id1 != id2).Should().BeFalse();
         (id1 == id2).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void EqualsObjectReturnsFalseForDifferentType()
+    {
+        // Arrange
+        NitroxId id = new(Guid.NewGuid());
+
+        // Act & Assert
+        id.Equals(new object()).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void EqualIdsHaveSameHashCode()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+        NitroxId id1 = new(guid);
+        NitroxId id2 = new(guid);
+
+        // Act & Assert
+        id1.GetHashCode().Should().Be(id2.GetHashCode());
+    }
+
+    [TestMethod]
+    public void CompareToReturnsZeroForEqualIds()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+        NitroxId id1 = new(guid);
+        NitroxId id2 = new(guid);
+
+        // Act & Assert
+        id1.CompareTo(id2).Should().Be(0);
+    }
+
+    [TestMethod]
+    public void CompareToReturnsOneForNull()
+    {
+        // Arrange
+        NitroxId id = new(Guid.NewGuid());
+
+        // Act & Assert
+        id.CompareTo(null).Should().Be(1);
+    }
+
+    [TestMethod]
+    public void CompareToUsesUnderlyingGuidOrdering()
+    {
+        // Arrange
+        NitroxId id1 = new("00000000-0000-0000-0000-000000000001");
+        NitroxId id2 = new("00000000-0000-0000-0000-000000000002");
+
+        // Act & Assert
+        id1.CompareTo(id2).Should().BeNegative();
+        id2.CompareTo(id1).Should().BePositive();
+    }
+
+    [TestMethod]
+    public void IncrementAdvancesId()
+    {
+        // Arrange
+        NitroxId id = new(Guid.Empty);
+
+        // Act
+        NitroxId next = id.Increment();
+
+        // Assert
+        next.Should().NotBe(id);
+        next.CompareTo(id).Should().BePositive();
+    }
+
+    [TestMethod]
+    public void IncrementWrapsAroundFromMaxValue()
+    {
+        // Arrange
+        NitroxId id = new(new Guid(
+        [
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+            255, 255, 255, 255
+        ]));
+
+        // Act
+        NitroxId wrapped = id.Increment();
+
+        // Assert
+        wrapped.Should().Be(new NitroxId(Guid.Empty));
     }
 }


### PR DESCRIPTION
* Added `StringToNitroxIdConverter` to convert strings to `NitroxId`. The lack of this converter make the `query` command unusable
* Code Cleanup inside NitroxId
* Improved the `QueryCommand`:
  - Changed required permission from `HOST` to `ADMIN`.
  - Enhanced logging output to show detailed entity, world, lock, and raw data in a structured format.

<img width="1774" height="540" alt="image" src="https://github.com/user-attachments/assets/fbeb643e-18f7-4b4c-bdc4-aba902057a08" />
