### PR TITLE
Fix duplicated simulation state text inside NitroxEntity Debugger

### DIFF
--- a/NitroxClient/Debuggers/Drawer/Nitrox/NitroxEntityDrawer.cs
+++ b/NitroxClient/Debuggers/Drawer/Nitrox/NitroxEntityDrawer.cs
@@ -9,17 +9,20 @@ namespace NitroxClient.Debuggers.Drawer.Nitrox;
 
 public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
 {
-    private const float LABEL_WIDTH = 250;
-
     public void Draw(NitroxEntity nitroxEntity)
     {
-        Draw(nitroxEntity.Id);
+        using (new GUILayout.HorizontalScope())
+        {
+            GUILayout.Label("NitroxId", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
+            NitroxGUILayout.Separator();
+            GUILayout.TextField(nitroxEntity.Id == null ? "<null>" : nitroxEntity.Id.ToString());
+        }
 
         GUILayout.Space(8);
 
         using (new GUILayout.HorizontalScope())
         {
-            GUILayout.Label("GameObject with IDs", GUILayout.Width(LABEL_WIDTH));
+            GUILayout.Label("GameObject with IDs", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
             NitroxGUILayout.Separator();
             GUILayout.TextField(NitroxEntity.GetGameObjects().Count().ToString());
         }
@@ -28,7 +31,7 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
 
         using (new GUILayout.HorizontalScope())
         {
-            GUILayout.Label("Simulating state", GUILayout.Width(LABEL_WIDTH));
+            GUILayout.Label("Simulating state", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
             NitroxGUILayout.Separator();
             if (NitroxServiceLocator.Cache<SimulationOwnership>.Value.TryGetLockType(nitroxEntity.Id, out SimulationLockType simulationLockType))
             {
@@ -45,16 +48,16 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
     {
         using (new GUILayout.HorizontalScope())
         {
-            GUILayout.Label("NitroxId", GUILayout.Width(LABEL_WIDTH));
+            GUILayout.Label("NitroxId", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
             NitroxGUILayout.Separator();
-            GUILayout.TextField(nitroxId == null ? "ID IS NULL!!!" : nitroxId.ToString());
+            GUILayout.TextField(nitroxId == null ? "<null>" : nitroxId.ToString());
         }
 
         GUILayout.Space(8);
 
         using (new GUILayout.HorizontalScope())
         {
-            GUILayout.Label("Simulating state", GUILayout.Width(LABEL_WIDTH));
+            GUILayout.Label("Simulating state", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
             NitroxGUILayout.Separator();
             if (NitroxServiceLocator.Cache<SimulationOwnership>.Value.TryGetLockType(nitroxId, out SimulationLockType simulationLockType))
             {

--- a/NitroxClient/Debuggers/Drawer/Nitrox/NitroxEntityDrawer.cs
+++ b/NitroxClient/Debuggers/Drawer/Nitrox/NitroxEntityDrawer.cs
@@ -11,12 +11,7 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
 {
     public void Draw(NitroxEntity nitroxEntity)
     {
-        using (new GUILayout.HorizontalScope())
-        {
-            GUILayout.Label("NitroxId", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
-            NitroxGUILayout.Separator();
-            GUILayout.TextField(nitroxEntity.Id == null ? "<null>" : nitroxEntity.Id.ToString());
-        }
+        DrawNitroxIdField(nitroxEntity.Id);
 
         GUILayout.Space(8);
 
@@ -29,22 +24,19 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
 
         GUILayout.Space(8);
 
-        using (new GUILayout.HorizontalScope())
-        {
-            GUILayout.Label("Simulating state", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
-            NitroxGUILayout.Separator();
-            if (NitroxServiceLocator.Cache<SimulationOwnership>.Value.TryGetLockType(nitroxEntity.Id, out SimulationLockType simulationLockType))
-            {
-                GUILayout.TextField(simulationLockType.ToString());
-            }
-            else
-            {
-                GUILayout.TextField("NONE");
-            }
-        }
+        DrawSimulatingStateField(nitroxEntity.Id);
     }
 
     public void Draw(NitroxId nitroxId)
+    {
+        DrawNitroxIdField(nitroxId);
+
+        GUILayout.Space(8);
+
+        DrawSimulatingStateField(nitroxId);
+    }
+
+    private static void DrawNitroxIdField(NitroxId? nitroxId)
     {
         using (new GUILayout.HorizontalScope())
         {
@@ -52,9 +44,10 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
             NitroxGUILayout.Separator();
             GUILayout.TextField(nitroxId == null ? "<null>" : nitroxId.ToString());
         }
+    }
 
-        GUILayout.Space(8);
-
+    private static void DrawSimulatingStateField(NitroxId? nitroxId)
+    {
         using (new GUILayout.HorizontalScope())
         {
             GUILayout.Label("Simulating state", GUILayout.Width(NitroxGUILayout.DEFAULT_LABEL_WIDTH));
@@ -62,11 +55,10 @@ public class NitroxEntityDrawer : IDrawer<NitroxEntity>, IDrawer<NitroxId>
             if (NitroxServiceLocator.Cache<SimulationOwnership>.Value.TryGetLockType(nitroxId, out SimulationLockType simulationLockType))
             {
                 GUILayout.TextField(simulationLockType.ToString());
+                return;
             }
-            else
-            {
-                GUILayout.TextField("NONE");
-            }
+
+            GUILayout.TextField("NONE");
         }
     }
 }


### PR DESCRIPTION
For some reason NitroxId drawer also print `SimulationState`, instead of removing that behavior. I'll just print the NitroxId by hand instead of calling the other Drawer