### PR TITLE
[Launcher] Migrate to partial properties for ObservableProperty

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
         <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
         <PackageVersion Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" />
         <PackageVersion Include="Bogus" Version="35.6.3" />
-        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.1" />
+        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
         <PackageVersion Include="CompareNETObjects" Version="4.83.0" />
         <PackageVersion Include="ConsoleAppFramework" Version="5.6.1" />
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/Nitrox.Launcher/Models/Design/AsyncCommandButtonTagger.cs
+++ b/Nitrox.Launcher/Models/Design/AsyncCommandButtonTagger.cs
@@ -11,7 +11,7 @@ namespace Nitrox.Launcher.Models.Design;
 /// <summary>
 ///     Listens for async command changes on buttons to add the chosen classname to, for use with styling.
 /// </summary>
-public class AsyncCommandButtonTagger : IDisposable
+public sealed class AsyncCommandButtonTagger : IDisposable
 {
     public string ClassName { get; init; }
     private readonly ConcurrentDictionary<ICommand, BusyState> states = [];

--- a/Nitrox.Launcher/Models/Design/NotificationItem.cs
+++ b/Nitrox.Launcher/Models/Design/NotificationItem.cs
@@ -9,11 +9,13 @@ namespace Nitrox.Launcher.Models.Design;
 public partial class NotificationItem : ObservableObject
 {
     public string Message { get; }
+
     public NotificationType Type { get; }
+    
     public ICommand CloseCommand { get; }
 
     [ObservableProperty]
-    private bool dismissed;
+    public partial bool IsDismissed { get; set; }
 
     public NotificationItem(string message, NotificationType type = NotificationType.Information, ICommand? closeCommand = null)
     {

--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -36,83 +36,82 @@ internal sealed partial class ServerEntry : ObservableObject
     public const string DEFAULT_SERVER_ICON_NAME = "servericon.png";
 
     private static readonly ConcurrentDictionary<string, ServerEntry> entriesByDirectory = [];
-
     private static readonly SubnauticaServerOptions serverDefaults = new();
 
     [ObservableProperty]
-    private bool allowCommands = !serverDefaults.DisableConsole;
+    public partial bool AllowCommands { get; set; } = !serverDefaults.DisableConsole;
 
     [ObservableProperty]
-    private bool allowKeepInventory = serverDefaults.KeepInventoryOnDeath;
+    public partial bool AllowKeepInventory { get; set; } = serverDefaults.KeepInventoryOnDeath;
 
     [ObservableProperty]
-    private bool allowLanDiscovery = serverDefaults.LanDiscovery;
+    public partial bool AllowLanDiscovery { get; set; } = serverDefaults.LanDiscovery;
 
     [ObservableProperty]
-    private bool allowPvP = serverDefaults.PvpEnabled;
+    public partial bool AllowPvP { get; set; } = serverDefaults.PvpEnabled;
 
     [ObservableProperty]
-    private int autoSaveInterval = serverDefaults.SaveInterval / 1000;
+    public partial int AutoSaveInterval { get; set; } = serverDefaults.SaveInterval / 1000;
 
     public Channel<string> CommandQueue = Channel.CreateUnbounded<string>();
     private CancellationTokenSource? cts;
 
     [ObservableProperty]
-    private SubnauticaGameMode gameMode = serverDefaults.GameMode;
+    public partial SubnauticaGameMode GameMode { get; set; } = serverDefaults.GameMode;
 
     /// <summary>
     ///     Should not be set to persist <see cref="IsEmbedded"/> change. Use <see cref="IKeyValueStore" /> instead.
     /// </summary>
     [ObservableProperty]
-    private bool isEmbedded;
+    public partial bool IsEmbedded { get; set; }
 
     [ObservableProperty]
-    private bool isNewServer = true;
+    public partial bool IsNewServer { get; set; } = true;
 
     [ObservableProperty]
-    private bool isOnline;
+    public partial bool IsOnline { get; set; }
 
     [ObservableProperty]
-    private bool isServerClosing;
+    public partial bool IsServerClosing { get; set; }
 
     [ObservableProperty]
-    private DateTime lastAccessedTime = DateTime.Now;
+    public partial DateTime LastAccessedTime { get; set; } = DateTime.Now;
 
     private int lastProcessId;
 
     [ObservableProperty]
-    private int maxPlayers = serverDefaults.MaxConnections;
+    public partial int MaxPlayers { get; set; } = serverDefaults.MaxConnections;
 
     [ObservableProperty]
-    private string? name;
+    public partial string? Name { get; set; }
 
     [ObservableProperty]
-    private string? password;
+    public partial string? Password { get; set; }
 
     [ObservableProperty]
-    private Perms playerPermissions = serverDefaults.DefaultPlayerPerm;
+    public partial Perms PlayerPermissions { get; set; } = serverDefaults.DefaultPlayerPerm;
 
     [ObservableProperty]
-    private int playerCount;
+    public partial int PlayerCount { get; set; }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(PlayerNamesTooltip))]
-    private List<string> playerNames = [];
+    public partial List<string> PlayerNames { get; set; } = [];
 
     [ObservableProperty]
-    private int port = serverDefaults.ServerPort;
+    public partial int Port { get; set; } = serverDefaults.ServerPort;
 
     [ObservableProperty]
-    private bool portForward = serverDefaults.PortForward;
+    public partial bool PortForward { get; set; } = serverDefaults.PortForward;
 
     [ObservableProperty]
-    private string? seed;
+    public partial string? Seed { get; set; }
 
     [ObservableProperty]
-    private Bitmap? serverIcon;
+    public partial Bitmap? ServerIcon { get; set; }
 
     [ObservableProperty]
-    private Version version = NitroxEnvironment.Version;
+    public partial Version Version { get; set; } = NitroxEnvironment.Version;
 
     internal ServerProcess? Process { get; private set; }
     public AvaloniaList<OutputLine> Output { get; } = [];
@@ -357,7 +356,7 @@ internal sealed partial class ServerEntry : ObservableObject
             await c.CancelAsync();
         }
         cts?.Dispose();
-        cts = new();
+        cts = new CancellationTokenSource();
         cts.Token.Register(async void () =>
         {
             try

--- a/Nitrox.Launcher/ViewModels/Abstract/ModalViewModelBase.cs
+++ b/Nitrox.Launcher/ViewModels/Abstract/ModalViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,8 +13,9 @@ namespace Nitrox.Launcher.ViewModels.Abstract;
 /// </summary>
 public abstract partial class ModalViewModelBase : ObservableValidator, IMessageReceiver
 {
-    [ObservableProperty] private ButtonOptions? selectedOption;
-
+    [ObservableProperty]
+    public partial ButtonOptions? SelectedOption { get; set; }
+    
     protected ModalViewModelBase()
     {
         // Always run validation first so HasErrors is set (i.e. trigger CanExecute logic).

--- a/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -18,20 +18,20 @@ namespace Nitrox.Launcher.ViewModels;
 public partial class BackupRestoreViewModel : ModalViewModelBase
 {
     [ObservableProperty]
-    private AvaloniaList<BackupItem> backups = [];
+    public partial AvaloniaList<BackupItem> Backups { get; set; } = [];
 
     [ObservableProperty]
-    private string? saveFolderDirectory;
+    public partial string? SaveFolderDirectory { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreBackupCommand))]
     [NotifyDataErrorInfo]
     [Backup]
-    private BackupItem? selectedBackup;
+    public partial BackupItem? SelectedBackup { get; set; }
 
     [ObservableProperty]
-    private string? title;
-
+    public partial string? Title { get; set; }
+    
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);

--- a/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
@@ -11,7 +11,6 @@ using Nitrox.Launcher.Models.Design;
 using Nitrox.Launcher.Models.Validators;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Model.Constants;
-using Nitrox.Server.Subnautica.Models.Serialization.World;
 
 namespace Nitrox.Launcher.ViewModels;
 
@@ -31,7 +30,12 @@ public partial class BackupRestoreViewModel : ModalViewModelBase
 
     [ObservableProperty]
     public partial string? Title { get; set; }
-    
+
+    [RelayCommand(CanExecute = nameof(CanRestoreBackup))]
+    public void RestoreBackup() => Close(ButtonOptions.Ok);
+
+    public bool CanRestoreBackup() => !HasErrors;
+
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
@@ -43,11 +47,6 @@ public partial class BackupRestoreViewModel : ModalViewModelBase
                 break;
         }
     }
-
-    [RelayCommand(CanExecute = nameof(CanRestoreBackup))]
-    public void RestoreBackup() => Close(ButtonOptions.Ok);
-
-    public bool CanRestoreBackup() => !HasErrors;
 
     private static IEnumerable<BackupItem> GetBackups(string? saveDirectory)
     {

--- a/Nitrox.Launcher/ViewModels/BlogViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BlogViewModel.cs
@@ -18,9 +18,9 @@ internal sealed partial class BlogViewModel : RoutableViewModelBase
 {
     private readonly NitroxBlogService? nitroxBlogService;
     public static Bitmap FallbackImage { get; } = AssetHelper.GetAssetFromStream("/Assets/Images/blog/vines.png", static stream => new Bitmap(stream));
-
+    
     [ObservableProperty]
-    private AvaloniaList<NitroxBlog> nitroxBlogs = [];
+    public partial AvaloniaList<NitroxBlog> NitroxBlogs { get; set; } = [];
 
     public BlogViewModel()
     {

--- a/Nitrox.Launcher/ViewModels/BlogViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BlogViewModel.cs
@@ -18,7 +18,7 @@ internal sealed partial class BlogViewModel : RoutableViewModelBase
 {
     private readonly NitroxBlogService? nitroxBlogService;
     public static Bitmap FallbackImage { get; } = AssetHelper.GetAssetFromStream("/Assets/Images/blog/vines.png", static stream => new Bitmap(stream));
-    
+
     [ObservableProperty]
     public partial AvaloniaList<NitroxBlog> NitroxBlogs { get; set; } = [];
 

--- a/Nitrox.Launcher/ViewModels/CrashWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/CrashWindowViewModel.cs
@@ -13,10 +13,11 @@ namespace Nitrox.Launcher.ViewModels;
 internal partial class CrashWindowViewModel : ViewModelBase
 {
     [ObservableProperty]
-    private string? title;
+    public partial string? Title { get; set; }
+    
     [ObservableProperty]
-    private string? message;
-
+    public partial string? Message { get; set; }
+    
     [RelayCommand(CanExecute = nameof(CanRestart))]
     private void Restart()
     {

--- a/Nitrox.Launcher/ViewModels/CrashWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/CrashWindowViewModel.cs
@@ -14,10 +14,10 @@ internal partial class CrashWindowViewModel : ViewModelBase
 {
     [ObservableProperty]
     public partial string? Title { get; set; }
-    
+
     [ObservableProperty]
     public partial string? Message { get; set; }
-    
+
     [RelayCommand(CanExecute = nameof(CanRestart))]
     private void Restart()
     {

--- a/Nitrox.Launcher/ViewModels/CreateServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/CreateServerViewModel.cs
@@ -22,15 +22,16 @@ public partial class CreateServerViewModel : ModalViewModelBase
     [FileName]
     [NotEndsWith(".")]
     [NitroxUniqueSaveName(nameof(SavesFolderDir))]
-    private string name = "";
+    public partial string Name { get; set; } = "";
 
     [ObservableProperty]
-    private SubnauticaGameMode selectedGameMode = SubnauticaGameMode.SURVIVAL;
+    public partial SubnauticaGameMode SelectedGameMode { get; set; } = SubnauticaGameMode.SURVIVAL;
 
     private string SavesFolderDir => keyValueStore.GetSavesFolderDir();
 
     public CreateServerViewModel()
     {
+        
     }
 
     public CreateServerViewModel(IKeyValueStore keyValueStore)

--- a/Nitrox.Launcher/ViewModels/Designer/DesignOptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/Designer/DesignOptionsViewModel.cs
@@ -13,9 +13,9 @@ internal class DesignOptionsViewModel : OptionsViewModel
             Platform = Platform.STEAM
         };
         LaunchArgs = "-vrmode none";
-        ProgramDataFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox";
-        ScreenshotsFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox\screenshots";
-        SavesFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox\saves";
-        LogsFolderDir = @"C:\Users\Me\AppData\Roaming\Nitrox\logs";
+        ProgramDataPath = @"C:\Users\Me\AppData\Roaming\Nitrox";
+        ScreenshotsPath = @"C:\Users\Me\AppData\Roaming\Nitrox\screenshots";
+        SavesPath = @"C:\Users\Me\AppData\Roaming\Nitrox\saves";
+        LogsPath = @"C:\Users\Me\AppData\Roaming\Nitrox\logs";
     }
 }

--- a/Nitrox.Launcher/ViewModels/DialogBoxViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/DialogBoxViewModel.cs
@@ -12,17 +12,29 @@ namespace Nitrox.Launcher.ViewModels;
 /// </summary>
 public partial class DialogBoxViewModel : ModalViewModelBase
 {
-    [ObservableProperty] private string? windowTitle;
+    [ObservableProperty]
+    public partial string? WindowTitle { get; set; }
 
-    [ObservableProperty] private string title = "";
-    [ObservableProperty] private double titleFontSize = 24;
-    [ObservableProperty] private FontWeight titleFontWeight = FontWeight.Bold;
+    [ObservableProperty]
+    public partial string Title { get; set; } = "";
 
-    [ObservableProperty] private string description = "";
-    [ObservableProperty] private double descriptionFontSize = 14;
-    [ObservableProperty] private FontWeight descriptionFontWeight = FontWeight.Normal;
+    [ObservableProperty]
+    public partial double TitleFontSize { get; set; } = 24;
 
-    [ObservableProperty] private ButtonOptions buttonOptions = ButtonOptions.Ok;
+    [ObservableProperty]
+    public partial FontWeight TitleFontWeight { get; set; } = FontWeight.Bold;
+
+    [ObservableProperty]
+    public partial string Description { get; set; } = "";
+
+    [ObservableProperty]
+    public partial double DescriptionFontSize { get; set; } = 14;
+
+    [ObservableProperty]
+    public partial FontWeight DescriptionFontWeight { get; set; } = FontWeight.Normal;
+
+    [ObservableProperty]
+    public partial ButtonOptions ButtonOptions { get; set; } = ButtonOptions.Ok;
 
     public KeyGesture OkHotkey { get; } = new(Key.Return);
     public KeyGesture NoHotkey { get; } = new(Key.Escape);

--- a/Nitrox.Launcher/ViewModels/EmbeddedServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/EmbeddedServerViewModel.cs
@@ -23,13 +23,14 @@ internal partial class EmbeddedServerViewModel : RoutableViewModelBase
     private int? selectedHistoryIndex;
 
     [ObservableProperty]
-    private string? serverCommand;
+    public partial string? ServerCommand { get; set; }
 
     [ObservableProperty]
-    private ServerEntry serverEntry;
+    public partial ServerEntry ServerEntry { get; set; }
+    
 
     [ObservableProperty]
-    private bool shouldAutoScroll = true;
+    public partial bool ShouldAutoScroll { get; set; } = true;
 
     private int previousContentLength;
 
@@ -37,7 +38,7 @@ internal partial class EmbeddedServerViewModel : RoutableViewModelBase
 
     public EmbeddedServerViewModel(ServerEntry serverEntry)
     {
-        this.serverEntry = serverEntry;
+        ServerEntry = serverEntry;
         this.RegisterMessageListener<ServerStatusMessage, EmbeddedServerViewModel>(static (status, model) =>
         {
             if (status.ProcessId != model.ServerEntry.LastProcessId)

--- a/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
@@ -34,11 +34,11 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
     private readonly ServerService serverService = serverService;
 
     [ObservableProperty]
-    private Platform gamePlatform;
+    public partial Platform GamePlatform { get; set; }
 
     [ObservableProperty]
-    private string? platformToolTip;
-
+    public partial string? PlatformToolTip { get; set; }
+    
     public Bitmap[] GalleryImageSources { get; } =
     [
         AssetHelper.GetAssetFromStream("/Assets/Images/gallery/image-1.png", static stream => new Bitmap(stream)),

--- a/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
@@ -38,7 +38,7 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
 
     [ObservableProperty]
     public partial string? PlatformToolTip { get; set; }
-    
+
     public Bitmap[] GalleryImageSources { get; } =
     [
         AssetHelper.GetAssetFromStream("/Assets/Images/gallery/image-1.png", static stream => new Bitmap(stream)),

--- a/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
@@ -35,11 +35,11 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
     private readonly UpdatesViewModel updatesViewModel;
 
     [ObservableProperty]
-    private object? activeViewModel;
+    public partial object? ActiveViewModel { get; set; }
 
     [ObservableProperty]
-    private bool updateAvailableOrUnofficial;
-
+    public partial bool UpdateAvailableOrUnofficial { get; set; }
+    
     public AvaloniaList<NotificationItem> Notifications { get; init; } = [];
 
     public MainWindowViewModel(
@@ -75,7 +75,7 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
         });
         this.RegisterMessageListener<NotificationCloseMessage, MainWindowViewModel>(static async (message, vm) =>
         {
-            message.Item.Dismissed = true;
+            message.Item.IsDismissed = true;
             await Task.Delay(1000); // Wait for animations
             if (!IsDesignMode) // Prevent design preview crashes
             {

--- a/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
@@ -39,7 +39,7 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
 
     [ObservableProperty]
     public partial bool UpdateAvailableOrUnofficial { get; set; }
-    
+
     public AvaloniaList<NotificationItem> Notifications { get; init; } = [];
 
     public MainWindowViewModel(
@@ -145,7 +145,7 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
         }
 
         // As closing handler isn't async, cancellation might have happened anyway. So check manually if we should close the window after all the tasks are done.
-        if (args.Cancel == false && mainWindowProvider().IsClosingByUser(args))
+        if (!args.Cancel && mainWindowProvider().IsClosingByUser(args))
         {
             mainWindowProvider().CloseByCode();
         }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -41,60 +41,59 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
     private readonly StorageService storageService;
 
     [ObservableProperty]
-    private ServerEntry? server;
+    public partial ServerEntry? Server { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private bool serverAllowCommands;
+    public partial bool ServerAllowCommands { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private bool serverAllowKeepInventory;
+    public partial bool ServerAllowKeepInventory { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private bool serverAllowLanDiscovery;
+    public partial bool ServerAllowLanDiscovery { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private bool serverAllowPvP;
+    public partial bool ServerAllowPvP { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private bool serverAutoPortForward;
+    public partial bool ServerAutoPortForward { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [Range(10, 86400, ErrorMessage = "Value must be between 10s and 24 hours (86400s).")]
-    private int serverAutoSaveInterval;
+    public partial int ServerAutoSaveInterval { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private Perms serverDefaultPlayerPerm;
+    public partial Perms ServerDefaultPlayerPerm { get; set; }
 
     [ObservableProperty]
-    private bool serverEmbedded;
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private SubnauticaGameMode serverGameMode;
+    public partial bool ServerEmbedded { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private Bitmap? serverIcon;
+    public partial SubnauticaGameMode ServerGameMode { get; set; }
 
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
+    public partial Bitmap? ServerIcon { get; set; }
     private string? serverIconDir;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreBackupCommand), nameof(DeleteServerCommand))]
-    private bool serverIsOnline;
+    public partial bool ServerIsOnline { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [Range(1, 1000)]
     [NotifyDataErrorInfo]
-    private int serverMaxPlayers;
+    public partial int ServerMaxPlayers { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
@@ -103,28 +102,27 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
     [FileName]
     [NotEndsWith(".")]
     [NitroxUniqueSaveName(nameof(SavesFolderDir), true, nameof(OriginalServerName))]
-    private string? serverName;
+    public partial string? ServerName { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private string? serverPassword;
+    public partial string? ServerPassword { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
-    private int serverPlayerCount;
+    public partial int ServerPlayerCount { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [Range(ushort.MinValue, ushort.MaxValue)]
-    private int serverPort;
+    public partial int ServerPort { get; set; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand), nameof(UndoCommand), nameof(BackCommand), nameof(RestoreBackupCommand), nameof(StartServerCommand))]
     [NotifyDataErrorInfo]
     [NitroxWorldSeed]
-    private string? serverSeed;
-
+    public partial string? ServerSeed { get; set; }
     public static Array PlayerPerms => Enum.GetValues(typeof(Perms));
     public string? OriginalServerName => Server?.Name;
 
@@ -142,7 +140,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
 
         this.RegisterMessageListener<ServerStatusMessage, ManageServerViewModel>((status, vm) =>
         {
-            if (vm.server?.Process?.Id != status.ProcessId)
+            if (vm.Server?.Process?.Id != status.ProcessId)
             {
                 return;
             }

--- a/Nitrox.Launcher/ViewModels/ObjectPropertyEditorViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ObjectPropertyEditorViewModel.cs
@@ -17,22 +17,20 @@ internal partial class ObjectPropertyEditorViewModel(DialogService dialogService
     private readonly DialogService dialogService = dialogService;
 
     [ObservableProperty]
-    private AvaloniaList<EditorField> editorFields = [];
+    public partial AvaloniaList<EditorField> EditorFields { get; set; } = [];
 
     [ObservableProperty]
-    private object? ownerObject;
+    public partial object? OwnerObject { get; set; }
 
     [ObservableProperty]
-    private string? title;
-
+    public partial string? Title { get; set; }
     /// <summary>
     ///     Gets or sets the field filter to use. If filter returns false, it will omit the field.
     /// </summary>
     public Func<PropertyInfo, bool> FieldAcceptFilter { get; set; } = _ => true;
 
     [ObservableProperty]
-    private bool disableButtons;
-
+    public partial bool DisableButtons { get; set; }
     [RelayCommand(CanExecute = nameof(CanSave))]
     public async Task Save()
     {

--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -27,38 +27,37 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SetArgumentsCommand))]
-    private string launchArgs;
+    public partial string LaunchArgs { get; set; }
 
     [ObservableProperty]
-    private string programDataFolderDir;
+    public partial string ProgramDataFolderDir { get; set; }
 
     [ObservableProperty]
-    private string screenshotsFolderDir;
+    public partial string ScreenshotsFolderDir { get; set; }
 
     [ObservableProperty]
-    private string savesFolderDir;
+    public partial string SavesFolderDir { get; set; }
 
     [ObservableProperty]
-    private string logsFolderDir;
+    public partial string LogsFolderDir { get; set; }
 
     [ObservableProperty]
-    private KnownGame selectedGame;
+    public partial KnownGame SelectedGame { get; set; }
 
     [ObservableProperty]
-    private bool showResetArgsBtn;
+    public partial bool ShowResetArgsBtn { get; set; }
 
     [ObservableProperty]
-    private bool lightModeEnabled;
+    public partial bool LightModeEnabled { get; set; }
 
     [ObservableProperty]
-    private bool allowMultipleGameInstances;
+    public partial bool AllowMultipleGameInstances { get; set; }
 
     [ObservableProperty]
-    private bool useBigPictureMode;
-    
-    [ObservableProperty]
-    private bool isInReleaseMode;
+    public partial bool UseBigPictureMode { get; set; }    
 
+    [ObservableProperty]
+    public partial bool IsInReleaseMode { get; set; }
     private static string DefaultLaunchArg => "-vrmode none";
     private bool isResettingArgs;
 

--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -30,16 +30,16 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
     public partial string LaunchArgs { get; set; }
 
     [ObservableProperty]
-    public partial string ProgramDataFolderDir { get; set; }
+    public partial string ProgramDataPath { get; set; }
 
     [ObservableProperty]
-    public partial string ScreenshotsFolderDir { get; set; }
+    public partial string ScreenshotsPath { get; set; }
 
     [ObservableProperty]
-    public partial string SavesFolderDir { get; set; }
+    public partial string SavesPath { get; set; }
 
     [ObservableProperty]
-    public partial string LogsFolderDir { get; set; }
+    public partial string LogsPath { get; set; }
 
     [ObservableProperty]
     public partial KnownGame SelectedGame { get; set; }
@@ -58,6 +58,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
 
     [ObservableProperty]
     public partial bool IsInReleaseMode { get; set; }
+    
     private static string DefaultLaunchArg => "-vrmode none";
     private bool isResettingArgs;
 
@@ -65,10 +66,10 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
     {
         SelectedGame = new() { PathToGame = NitroxUser.GamePath, Platform = NitroxUser.GamePlatform?.Platform ?? Platform.NONE };
         LaunchArgs = keyValueStore.GetLaunchArguments(GameInfo.Subnautica, DefaultLaunchArg);
-        ProgramDataFolderDir = NitroxUser.AppDataPath;
-        ScreenshotsFolderDir = NitroxUser.ScreenshotsPath;
-        SavesFolderDir = keyValueStore.GetSavesFolderDir();
-        LogsFolderDir = Model.Logger.Log.LogDirectory;
+        ProgramDataPath = NitroxUser.AppDataPath;
+        ScreenshotsPath = NitroxUser.ScreenshotsPath;
+        SavesPath = keyValueStore.GetSavesFolderDir();
+        LogsPath = Model.Logger.Log.LogDirectory;
         LightModeEnabled = keyValueStore.GetIsLightModeEnabled();
         AllowMultipleGameInstances = keyValueStore.GetIsMultipleGameInstancesAllowed();
         UseBigPictureMode = keyValueStore.GetUseBigPictureMode();

--- a/Nitrox.Launcher/ViewModels/ServersViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ServersViewModel.cs
@@ -25,8 +25,7 @@ internal partial class ServersViewModel : RoutableViewModelBase
     private readonly ServerService serverService;
     private readonly ManageServerViewModel manageServerViewModel;
     [ObservableProperty]
-    private AvaloniaList<ServerEntry>? servers;
-
+    public partial AvaloniaList<ServerEntry>? Servers { get; set; }
     public ServersViewModel(IKeyValueStore keyValueStore, DialogService dialogService, ServerService serverService, ManageServerViewModel manageServerViewModel)
     {
         this.keyValueStore = keyValueStore;

--- a/Nitrox.Launcher/ViewModels/UpdatesViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/UpdatesViewModel.cs
@@ -32,29 +32,28 @@ internal partial class UpdatesViewModel(NitroxWebsiteApiService nitroxWebsiteApi
     private CancellationTokenSource? downloadCts;
 
     [ObservableProperty]
-    private double downloadProgress;
+    public partial double DownloadProgress { get; set; }
 
     [ObservableProperty]
-    private string? downloadStatus;
+    public partial string? DownloadStatus { get; set; }
 
     [ObservableProperty]
-    private bool newUpdateAvailable;
+    public partial bool NewUpdateAvailable { get; set; }
 
     [ObservableProperty]
-    private AvaloniaList<NitroxChangelog> nitroxChangelogs = [];
+    public partial AvaloniaList<NitroxChangelog> NitroxChangelogs { get; set; } = [];
 
     [ObservableProperty]
-    private string? officialVersion;
+    public partial string? OfficialVersion { get; set; }
 
     [ObservableProperty]
-    private bool usingOfficialVersion;
+    public partial bool UsingOfficialVersion { get; set; }
 
     [ObservableProperty]
-    private AvaloniaList<BackupInfo> availableBackups = [];
+    public partial AvaloniaList<BackupInfo> AvailableBackups { get; set; } = [];
 
     [ObservableProperty]
-    private string? version;
-
+    public partial string? Version { get; set; }
     public async Task<bool> IsNitroxUpdateAvailableAsync()
     {
         try

--- a/Nitrox.Launcher/Views/MainWindow.axaml
+++ b/Nitrox.Launcher/Views/MainWindow.axaml
@@ -384,7 +384,7 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Border
-                            Classes.dismiss="{Binding Dismissed}"
+                            Classes.dismiss="{Binding IsDismissed}"
                             Classes.error="{Binding Type, Converter={converters:EqualityConverter}, ConverterParameter={x:Static NotificationType.Error}}"
                             Classes.info="{Binding Type, Converter={converters:EqualityConverter}, ConverterParameter={x:Static NotificationType.Information}}"
                             Classes.success="{Binding Type, Converter={converters:EqualityConverter}, ConverterParameter={x:Static NotificationType.Success}}"

--- a/Nitrox.Launcher/Views/OptionsView.axaml
+++ b/Nitrox.Launcher/Views/OptionsView.axaml
@@ -236,12 +236,12 @@
                             FontSize="15"
                             Foreground="{DynamicResource BrandBlack}"
                             Opacity="0.75"
-                            Text="{Binding ProgramDataFolderDir}"
+                            Text="{Binding ProgramDataPath}"
                             VerticalAlignment="Center" />
                         <Button
                             Classes="primary"
                             Command="{Binding OpenFolderCommand}"
-                            CommandParameter="{Binding ProgramDataFolderDir}"
+                            CommandParameter="{Binding ProgramDataPath}"
                             Content="Open"
                             Grid.Column="1"
                             HorizontalAlignment="Right"
@@ -252,24 +252,24 @@
                 </Border>
 
                 <Button Classes="icon" Command="{Binding OpenFolderCommand}"
-                        CommandParameter="{Binding ScreenshotsFolderDir}"
-                        ToolTip.Tip="{Binding ScreenshotsFolderDir}">
+                        CommandParameter="{Binding ScreenshotsPath}"
+                        ToolTip.Tip="{Binding ScreenshotsPath}">
                     <StackPanel>
                         <controls:RecolorImage Source="/Assets/Images/world-manager/window.png" />
                         <TextBlock Text="Open Screenshots folder" />
                     </StackPanel>
                 </Button>
                 <Button Classes="icon" Command="{Binding OpenFolderCommand}"
-                        CommandParameter="{Binding SavesFolderDir}"
-                        ToolTip.Tip="{Binding SavesFolderDir}">
+                        CommandParameter="{Binding SavesPath}"
+                        ToolTip.Tip="{Binding SavesPath}">
                     <StackPanel>
                         <controls:RecolorImage Source="/Assets/Images/world-manager/window.png" />
                         <TextBlock Text="Open Saves folder" />
                     </StackPanel>
                 </Button>
                 <Button Classes="icon" Command="{Binding OpenFolderCommand}"
-                        CommandParameter="{Binding LogsFolderDir}"
-                        ToolTip.Tip="{Binding LogsFolderDir}">
+                        CommandParameter="{Binding LogsPath}"
+                        ToolTip.Tip="{Binding LogsPath}">
                     <StackPanel>
                         <controls:RecolorImage Source="/Assets/Images/world-manager/window.png" />
                         <TextBlock Text="Open Logs folder" />


### PR DESCRIPTION
Context: [https://github.com/CommunityToolkit/dotnet/pull/966](https://github.com/CommunityToolkit/dotnet/pull/966)
---

MVVM Toolkit always had the support for partial properties, but it was gatekeeped behind <LangVersion>preview</LangVersion> because of field keyword being an experimental language feature for a long time.

Since C# 14 this is now a language feature, so the version 8.4.1 of the toolkit updated analyzers and source generators to Roslyn 5.0, so they can work with C# 14 out of the box.

## Why ?

We're now able to navigate properties references as it was c# casual auto properties (able to see code usage, xaml usage, ...)

<img width="1386" height="584" alt="image" src="https://github.com/user-attachments/assets/b6a4c1d1-2084-4f63-9eb4-f9f3f86235ab" />
