### PR TITLE
Ignored dispose error thrown when connection is already closed

### DIFF
--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -155,6 +155,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
         {
             RpcException { Status.StatusCode: StatusCode.Unavailable or StatusCode.Cancelled } => true,
             OperationCanceledException => true,
+            ObjectDisposedException { ObjectName: nameof(StreamingHubClient) } => true,
             _ => false
         };
     }


### PR DESCRIPTION
```cs
[21:43:44.528] [fail] ServersManagementService: Error during looping task
System.ObjectDisposedException: The StreamingHubClient has already been disconnected from the server.
Object name: 'StreamingHubClient'.
   at MagicOnion.Client.StreamingHubClientBase`2.WriteMessageWithResponseValueTaskAsync[TRequest,TResponse](Int32 methodId, TRequest message)
   at MagicOnion.Client.DynamicClient.Nitrox.Model.MagicOnion.IServersManagementStreamingHubClient_88938ee5-77a2-4c40-940d-5258fe820c81.AddOutputLine(String, Nullable`1, Int32, String)
   at Nitrox.Server.Subnautica.Services.ServersManagementService.PushLogsAsync(IServersManagement api, CancellationToken cancellationToken) in Nitrox.Server.Subnautica/Services/ServersManagementService.cs:line 147```