### PR TITLE
Removed unnecessary Regex.Unescape call on Steam library path

### DIFF
--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
@@ -91,7 +91,7 @@ public sealed class SteamFinder : IGameFinder
 
         while (file.ReadLine() is { } line)
         {
-            line = Regex.Unescape(line.Trim(trimChars));
+            line = line.Trim(trimChars);
             Match regMatch = Regex.Match(line, "\"(.*)\"\t*\"(.*)\"");
             string key = regMatch.Groups[1].Value;
 


### PR DESCRIPTION
Regex.Unescape can throw an exception if "\S" is in the text. Which happens for steam paths that contain `..\Steam\..`

```cs
System.Text.RegularExpressions.RegexParseException: Invalid pattern '"path"		"E:\Steam"' at offset 13. Unrecognized escape sequence \S.
   at System.Text.RegularExpressions.RegexParser.ScanCharEscape()
   at System.Text.RegularExpressions.RegexParser.UnescapeImpl(String input, Int32 i)
   at Nitrox.Model.Platforms.Discovery.InstallationFinders.SteamFinder.SearchAllInstallations(String libraryFolders, Int32 appid, String gameName) in Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs:line 144
   at Nitrox.Model.Platforms.Discovery.InstallationFinders.SteamFinder.FindGame(GameInfo gameInfo) in Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs:line 34
   at Nitrox.Model.Platforms.Discovery.GameInstallationFinder.FindGame(GameInfo gameInfo, GameLibraries gameLibraries)+MoveNext() in Nitrox.Model/Platforms/Discovery/GameInstallationFinder.cs:line 86
```

<!--
Before filing a pull request please look at our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md.

We recommend that if you want to do a non trivial feature or a feature without an already open issue, to contact us on Discord https://discord.gg/E8B4X9s before investing your time.
-->
