### PR TITLE
Fix scanner room upgrades disappearing on reconnect

### DIFF
--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -59,6 +59,10 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             {
                 case MapRoomEntity mapRoomEntity:
                     yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    if (mapRoomEntity.ChildEntities.Count > 0)
+                    {
+                        yield return entities.SpawnBatchAsync(mapRoomEntity.ChildEntities, true);
+                    }
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;


### PR DESCRIPTION
Fixes #2696 where map room upgrades are lost by adding an if to correctly spawn its child entities via SpawnBatchAsync.

<!--
Before filing a pull request please look at our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md.

We recommend that if you want to do a non trivial feature or a feature without an already open issue, to contact us on Discord https://discord.gg/E8B4X9s before investing your time.
-->
