### PR TITLE
Added SteamOS support for starting servers

### DIFF
--- a/Nitrox.Launcher/GlobalStatic.cs
+++ b/Nitrox.Launcher/GlobalStatic.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using Avalonia.Controls;
 using Nitrox.Model.Platforms.OS.Shared;
 
@@ -7,6 +8,9 @@ namespace Nitrox.Launcher;
 
 internal static class GlobalStatic
 {
+    private const string SERVER_FILE_NAME_NO_EXT = "Nitrox.Server.Subnautica";
+    private static long isSteamOs = -1;
+
     public static bool IsDesignMode => Design.IsDesignMode;
 
     /// <inheritdoc cref="ProcessEx.OpenUri" />
@@ -44,13 +48,51 @@ internal static class GlobalStatic
         return false;
     }
 
-    public static string GetServerExeName()
+    public static string GetServerFileName()
     {
-        string serverExeName = "Nitrox.Server.Subnautica.exe";
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
-            serverExeName = "Nitrox.Server.Subnautica";
+            return $"{SERVER_FILE_NAME_NO_EXT}.exe";
         }
-        return serverExeName;
+
+        return SERVER_FILE_NAME_NO_EXT;
+    }
+
+    public static string GetServerProcessName()
+    {
+        // On Steam Deck, server process name is "dotnet" as it's started through command line.
+        if (IsSteamOs())
+        {
+            return "dotnet";
+        }
+
+        return GetServerFileName();
+    }
+
+    public static bool IsSteamOs()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return false;
+        }
+        switch (Interlocked.Read(ref isSteamOs))
+        {
+            case 1:
+                return true;
+            case 0:
+                return false;
+        }
+
+        try
+        {
+            string osReleaseInfo = File.ReadAllText("/etc/os-release");
+            bool result = osReleaseInfo.Contains(@"NAME=""SteamOS""", StringComparison.Ordinal);
+            Interlocked.Exchange(ref isSteamOs, result ? 1 : 0);
+            return result;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 }

--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -320,7 +320,7 @@ internal sealed partial class ServerEntry : ObservableObject
         using CancellationTokenSource waitProcessExitCts = new(TimeSpan.FromSeconds(20));
         try
         {
-            while (ProcessEx.ProcessExists(GetServerExeName(), ex => ex.Id == LastProcessId))
+            while (ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
             {
                 await Task.Delay(200, waitProcessExitCts.Token);
             }
@@ -364,7 +364,7 @@ internal sealed partial class ServerEntry : ObservableObject
                 await Dispatcher.UIThread.InvokeAsync(() => IsServerClosing = true);
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    while (ProcessEx.ProcessExists(GetServerExeName(), ex => ex.Id == LastProcessId))
+                    while (ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
                     {
                         try
                         {
@@ -411,7 +411,7 @@ internal sealed partial class ServerEntry : ObservableObject
                     throw new Exception($"{nameof(launcherPath)} must be set");
                 }
 
-                string serverFile = Path.Combine(launcherPath, GetServerExeName());
+                string serverFile = Path.Combine(launcherPath, GetServerFileName());
                 ProcessStartInfo startInfo = new(serverFile)
                 {
                     WorkingDirectory = launcherPath,
@@ -425,6 +425,17 @@ internal sealed partial class ServerEntry : ObservableObject
                     WindowStyle = isEmbeddedMode ? ProcessWindowStyle.Hidden : ProcessWindowStyle.Normal,
                     CreateNoWindow = isEmbeddedMode
                 };
+                // On Steam Deck, start through user-wide .dotnet. The default is system-wide which might not work.
+                if (IsSteamOs())
+                {
+                    string dotnetExecutable = Path.Combine(NitroxUser.HomePath, ".dotnet", "dotnet");
+                    if (!File.Exists(dotnetExecutable))
+                    {
+                        throw new FileNotFoundException("A compatible .NET version must be installed by the user to run the server on SteamOS. Please install dotnet to your user home: ~/.dotnet/");
+                    }
+                    startInfo.FileName = dotnetExecutable;
+                    startInfo.ArgumentList.Insert(0, $"{serverFile}.dll");
+                }
                 // Assist server with finding launcher location.
                 if (Directory.Exists(launcherPath))
                 {

--- a/Nitrox.Launcher/Models/Services/DialogService.cs
+++ b/Nitrox.Launcher/Models/Services/DialogService.cs
@@ -49,7 +49,7 @@ internal sealed class DialogService(Func<Window> dialogOwnerProvider, IEnumerabl
         ShowAsync<DialogBoxViewModel>(model =>
         {
             model.Title = title ?? "Error";
-            model.Description = string.IsNullOrWhiteSpace(description) ? exception.ToString() : $"{description}{Environment.NewLine}{exception}";
+            model.Description = string.IsNullOrWhiteSpace(description) ? exception.ToString() : $"[b][i]{description}[/b][/i]{Environment.NewLine}{Environment.NewLine}[#f94239]{exception}";
             model.ButtonOptions = ButtonOptions.OkClipboard;
         });
 

--- a/Nitrox.Launcher/Models/Services/ServerService.cs
+++ b/Nitrox.Launcher/Models/Services/ServerService.cs
@@ -116,7 +116,7 @@ internal sealed class ServerService : IMessageReceiver, INotifyPropertyChanged
         catch (Exception ex)
         {
             Log.Error(ex, $"Error while starting server \"{server.Name}\"");
-            await Dispatcher.UIThread.InvokeAsync(async () => await dialogService.ShowErrorAsync(ex, $"Error while starting server \"{server.Name}\""));
+            await Dispatcher.UIThread.InvokeAsync(async () => await dialogService.ShowErrorAsync(ex, $"Error while starting server \"{server.Name}\"", ex.GetFirstNonAggregateMessage()));
             return false;
         }
     }

--- a/Nitrox.Launcher/Views/DialogBoxModal.axaml
+++ b/Nitrox.Launcher/Views/DialogBoxModal.axaml
@@ -38,7 +38,7 @@
             Grid.Row="1"
             HorizontalScrollBarVisibility="Disabled"
             Margin="24,20,10,20">
-            <SelectableTextBlock
+            <controls:SelectableRichTextBlock
                 FontSize="{Binding DescriptionFontSize}"
                 FontWeight="{Binding DescriptionFontWeight}"
                 IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"

--- a/Nitrox.Model/Helper/NitroxUser.cs
+++ b/Nitrox.Model/Helper/NitroxUser.cs
@@ -56,7 +56,6 @@ public static class NitroxUser
         }
     };
 
-    [field: MaybeNull, AllowNull]
     public static string AppDataPath
     {
         get
@@ -140,12 +139,6 @@ public static class NitroxUser
 
     public static string GamePath => string.IsNullOrEmpty(gamePath) ? string.Empty : gamePath;
 
-    public static void SetGamePathAndPlatform(string path, IGamePlatform? platform)
-    {
-        gamePath = Path.GetFullPath(path);
-        GamePlatform = platform ?? GamePlatforms.GetPlatformByGameDir(path);
-    }
-
     public static string ExecutableRootPath
     {
         get
@@ -220,5 +213,35 @@ public static class NitroxUser
             }
             return field = nitroxAssets;
         }
+    }
+
+    /// <summary>
+    ///     Gets the user home directory of the current operating system user.
+    /// </summary>
+    public static string HomePath
+    {
+        get
+        {
+            string homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (string.IsNullOrWhiteSpace(homePath))
+            {
+                homePath = Environment.GetEnvironmentVariable("HOME");
+            }
+            if (!Directory.Exists(homePath))
+            {
+                throw new DirectoryNotFoundException("User home directory does not exist or is inaccessible");
+            }
+            if (string.IsNullOrWhiteSpace(homePath))
+            {
+                throw new InvalidOperationException("User home directory is not given by the operating system");
+            }
+            return homePath;
+        }
+    }
+
+    public static void SetGamePathAndPlatform(string path, IGamePlatform? platform)
+    {
+        gamePath = Path.GetFullPath(path);
+        GamePlatform = platform ?? GamePlatforms.GetPlatformByGameDir(path);
     }
 }


### PR DESCRIPTION
If user doesn't have `~/.dotnet/dotnet` binary, following error will be shown:
<img width="1204" height="748" alt="image" src="https://github.com/user-attachments/assets/6f756458-6553-4e20-81ff-5c9213d6e985" />