### PR TITLE
Add bulkhead door synchronization

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BulkheadDoorMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BulkheadDoorMetadata.cs
@@ -2,29 +2,28 @@ using System;
 using System.Runtime.Serialization;
 using BinaryPack.Attributes;
 
-namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable]
+[DataContract]
+public class BulkheadDoorMetadata : EntityMetadata
 {
-    [Serializable]
-    [DataContract]
-    public class BulkheadDoorMetadata : EntityMetadata
+    [DataMember(Order = 1)]
+    public bool Opened { get; }
+
+    [IgnoreConstructor]
+    protected BulkheadDoorMetadata()
     {
-        [DataMember(Order = 1)]
-        public bool Opened { get; }
+        //Constructor for serialization. Has to be "protected" for json serialization.
+    }
 
-        [IgnoreConstructor]
-        protected BulkheadDoorMetadata()
-        {
-            //Constructor for serialization. Has to be "protected" for json serialization.
-        }
+    public BulkheadDoorMetadata(bool opened)
+    {
+        Opened = opened;
+    }
 
-        public BulkheadDoorMetadata(bool opened)
-        {
-            Opened = opened;
-        }
-
-        public override string ToString()
-        {
-            return $"[BulkheadDoorMetadata Opened: {Opened}]";
-        }
+    public override string ToString()
+    {
+        return $"[{nameof(BulkheadDoorMetadata)} Opened: {Opened}]";
     }
 }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BulkheadDoorMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BulkheadDoorMetadata.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata
+{
+    [Serializable]
+    [DataContract]
+    public class BulkheadDoorMetadata : EntityMetadata
+    {
+        [DataMember(Order = 1)]
+        public bool Opened { get; }
+
+        [IgnoreConstructor]
+        protected BulkheadDoorMetadata()
+        {
+            //Constructor for serialization. Has to be "protected" for json serialization.
+        }
+
+        public BulkheadDoorMetadata(bool opened)
+        {
+            Opened = opened;
+        }
+
+        public override string ToString()
+        {
+            return $"[BulkheadDoorMetadata Opened: {Opened}]";
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/BulkheadDoorMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/BulkheadDoorMetadataProcessor.cs
@@ -15,7 +15,7 @@ public class BulkheadDoorMetadataProcessor : EntityMetadataProcessor<BulkheadDoo
 
         if (!bulkheadDoor)
         {
-            Log.Warn($"[BulkheadDoorMetadataProcessor] No BulkheadDoor component found on {gameObject.name} or its children");
+            Log.Warn($"[{nameof(BulkheadDoorMetadataProcessor)}] No BulkheadDoor component found on {gameObject.name} or its children");
             return;
         }
 

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/BulkheadDoorMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/BulkheadDoorMetadataProcessor.cs
@@ -1,0 +1,24 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class BulkheadDoorMetadataProcessor : EntityMetadataProcessor<BulkheadDoorMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, BulkheadDoorMetadata metadata)
+    {
+        if (!gameObject.TryGetComponent(out BulkheadDoor bulkheadDoor))
+        {
+            bulkheadDoor = gameObject.GetComponentInChildren<BulkheadDoor>();
+        }
+
+        if (!bulkheadDoor)
+        {
+            Log.Warn($"[BulkheadDoorMetadataProcessor] No BulkheadDoor component found on {gameObject.name} or its children");
+            return;
+        }
+
+        bulkheadDoor.SetState(metadata.Opened);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/BulkheadDoor_SetState_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BulkheadDoor_SetState_Patch.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Synchronizes bulkhead door state changes across players.
+/// Patches SetState instead of OnHandClick to catch both immediate and cinematic door opening modes.
+/// The BulkheadDoor component is on a child object, so we look up the hierarchy for the NitroxEntity.
+/// </summary>
+public sealed partial class BulkheadDoor_SetState_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((BulkheadDoor t) => t.SetState(default(bool)));
+
+    public static void Prefix(BulkheadDoor __instance, bool open, out bool __state)
+    {
+        // Store the previous state to check if it actually changed
+        __state = __instance.opened;
+    }
+
+    public static void Postfix(BulkheadDoor __instance, bool open, bool __state)
+    {
+        // Only broadcast if the state actually changed
+        if (__state == open)
+        {
+            return;
+        }
+
+        if (__instance.TryGetComponentInParent(out NitroxEntity entity, true))
+        {
+            BulkheadDoorMetadata metadata = new(open);
+            Resolve<Entities>().BroadcastMetadataUpdate(entity.Id, metadata);
+        }
+    }
+}


### PR DESCRIPTION
Fixes bulkhead doors not syncing state for remote players.

Closes #1357 