### PR TITLE
Fix Proton version detection when using a different default Proton verion (Such as Proton-GE)

### DIFF
--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -445,6 +445,14 @@ public sealed class Steam : IGamePlatform
                     {
                         return appIdMatch.Groups[1].Value;
                     }
+                    
+                    const string defaultPattern = @"""0""[^{]*\{[^}]*""name""\s*""([^""]+)""";
+                    Match defaultMatch = Regex.Match(compatToolMapping, defaultPattern);
+                    
+                    if (defaultMatch.Success)
+                    {
+                        return defaultMatch.Groups[1].Value;
+                    }
                 }
 
                 return null;


### PR DESCRIPTION
### The problem
With "Default compatibility tool" set to GE-Proton10-34 (or some other non-Valve Proton) in Steam settings, and no override is set for Subnautica specifically, Nitrox refuses to launch. 

### The solution
This patch fixes that by looking at the default AppId ("0") under `"CompatToolMapping"` in the `config.vdf` file, after looking for the Subnautica-specific override.
Before my patch, it defaulted `protonVersion` to `proton_9`, which I don't have installed on my system.