### PR TITLE
Use named pipes for GRPC on Windows for faster IPC

### DIFF
--- a/Nitrox.Launcher/App.axaml.cs
+++ b/Nitrox.Launcher/App.axaml.cs
@@ -112,7 +112,19 @@ internal class App : Application
                        .ClearProviders()
                        .Services
                        .AddAppServices();
-            hostBuilder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Any, 0, o => o.Protocols = HttpProtocols.Http2));
+            
+            // Use named pipes on Windows for faster IPC, sockets on Linux
+            if (OperatingSystem.IsWindows())
+            {
+                hostBuilder.WebHost.ConfigureKestrel(options => 
+                    options.ListenNamedPipe(LauncherConstants.GRPC_NAMED_PIPE_NAME, o => o.Protocols = HttpProtocols.Http2));
+            }
+            else
+            {
+                hostBuilder.WebHost.ConfigureKestrel(options => 
+                    options.Listen(IPAddress.Any, 0, o => o.Protocols = HttpProtocols.Http2));
+            }
+            
             WebApplication host = hostBuilder.Build();
             host.MapMagicOnionService();
             host.MapGrpcService<ServersManagement>();

--- a/Nitrox.Launcher/Models/Services/WriteGrpcPortFileService.cs
+++ b/Nitrox.Launcher/Models/Services/WriteGrpcPortFileService.cs
@@ -7,11 +7,12 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Hosting;
 using Nitrox.Model.Constants;
+using Nitrox.Model.Logger;
 
 namespace Nitrox.Launcher.Models.Services;
 
 /// <summary>
-///     Writes the gRPC port in a file that Nitrox servers can access. This service is necessary because the listening port is dynamic to prevent "port in use" issues.
+///     Writes the gRPC connection info in a file that Nitrox servers can access. On Windows, writes the named pipe name. On Linux, writes the port number.
 /// </summary>
 internal class WriteGrpcPortFileService(IServer server) : IHostedLifecycleService
 {
@@ -26,19 +27,32 @@ internal class WriteGrpcPortFileService(IServer server) : IHostedLifecycleServic
 
     public async Task StartedAsync(CancellationToken cancellationToken)
     {
-        IServerAddressesFeature? addressFeature = server.Features.Get<IServerAddressesFeature>();
-        // We expect only one port to be known by .NET server (kestrel). If there are more, we need to refactor this code to ONLY write the gRPC port.
-        int grpcPort = addressFeature.Addresses.Select(a => new Uri(a).Port).First(); // Should throw if more than one port.
+        string connectionInfo;
+        
+        if (OperatingSystem.IsWindows())
+        {
+            // On Windows, write the named pipe name
+            connectionInfo = LauncherConstants.GRPC_NAMED_PIPE_NAME;
+        }
+        else
+        {
+            // On Linux, write the port number
+            IServerAddressesFeature? addressFeature = server.Features.Get<IServerAddressesFeature>();
+            int grpcPort = addressFeature.Addresses.Select(a => new Uri(a).Port).First();
+            connectionInfo = grpcPort.ToString();
+        }
+        
         int attempts = 10;
         while (attempts-- > 0)
         {
             try
             {
-                await File.WriteAllTextAsync(filePath, grpcPort.ToString(), cancellationToken);
+                await File.WriteAllTextAsync(filePath, connectionInfo, cancellationToken);
                 break;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Log.Warn($"Failed to write gRPC connection info (attempt {10 - attempts}/10): {ex.Message}");
                 await Task.Delay(500, cancellationToken);
             }
         }

--- a/Nitrox.Launcher/Models/Services/WriteGrpcPortFileService.cs
+++ b/Nitrox.Launcher/Models/Services/WriteGrpcPortFileService.cs
@@ -28,7 +28,6 @@ internal class WriteGrpcPortFileService(IServer server) : IHostedLifecycleServic
     public async Task StartedAsync(CancellationToken cancellationToken)
     {
         string connectionInfo;
-        
         if (OperatingSystem.IsWindows())
         {
             // On Windows, write the named pipe name
@@ -36,13 +35,15 @@ internal class WriteGrpcPortFileService(IServer server) : IHostedLifecycleServic
         }
         else
         {
-            // On Linux, write the port number
+            // On Non-Windows, write the port number.
+            // We expect only one port to be known by .NET server (kestrel). If there are more, we need to refactor this code to ONLY write the gRPC port.
             IServerAddressesFeature? addressFeature = server.Features.Get<IServerAddressesFeature>();
             int grpcPort = addressFeature.Addresses.Select(a => new Uri(a).Port).First();
             connectionInfo = grpcPort.ToString();
         }
-        
-        int attempts = 10;
+
+        const int INITIAL_ATTEMPTS = 10;
+        int attempts = INITIAL_ATTEMPTS;
         while (attempts-- > 0)
         {
             try
@@ -52,7 +53,7 @@ internal class WriteGrpcPortFileService(IServer server) : IHostedLifecycleServic
             }
             catch (Exception ex)
             {
-                Log.Warn($"Failed to write gRPC connection info (attempt {10 - attempts}/10): {ex.Message}");
+                Log.Warn($"Failed to write gRPC connection info (attempt {INITIAL_ATTEMPTS - attempts}/{INITIAL_ATTEMPTS}): {ex.Message}");
                 await Task.Delay(500, cancellationToken);
             }
         }

--- a/Nitrox.Model/Constants/LauncherConstants.cs
+++ b/Nitrox.Model/Constants/LauncherConstants.cs
@@ -3,4 +3,5 @@ namespace Nitrox.Model.Constants;
 public static class LauncherConstants
 {
     public const string GRPC_LISTEN_PORT_TEMP_FILE_NAME = "nitrox-launcher-grpc-port.txt";
+    public const string GRPC_NAMED_PIPE_NAME = "nitrox-launcher";
 }

--- a/Nitrox.Model/Extensions/TaskExtensions.cs
+++ b/Nitrox.Model/Extensions/TaskExtensions.cs
@@ -5,7 +5,7 @@ namespace Nitrox.Model.Extensions;
 
 public static class TaskExtensions
 {
-    public static bool IsBusyOrDone(this Task? task) => task is { IsCompleted: true, IsFaulted: false, IsCanceled: false };
+    public static bool IsBusyOrSuccessful(this Task? task) => task is { IsCompleted: true, IsFaulted: false, IsCanceled: false };
 
     /// <summary>
     ///     Calls an action if an error happens.

--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -1,6 +1,8 @@
 using System.Buffers;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Channels;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -21,11 +23,15 @@ namespace Nitrox.Server.Subnautica.Services;
 internal sealed class ServersManagementService(PlayerManager playerManager, IPacketSender packetSender, CommandService commandProcessor, IOptions<ServerStartOptions> options, ILogger<ServersManagementService> logger) : BackgroundService
 {
     public static readonly Channel<LogEntry> LogQueue = Channel.CreateBounded<LogEntry>(new BoundedChannelOptions(1000) { FullMode = BoundedChannelFullMode.DropOldest });
+    
     private readonly CommandService commandProcessor = commandProcessor;
     private readonly ILogger<ServersManagementService> logger = logger;
     private readonly IOptions<ServerStartOptions> options = options;
     private readonly PlayerManager playerManager = playerManager;
+    
     private GrpcChannel? channel;
+    private string? currentPipeName;
+    private int? currentPort;
     private Task? pushLogsTask;
 
     public override void Dispose() => channel?.Dispose();
@@ -40,26 +46,44 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
         {
             try
             {
-                int? launcherGrpcPortAsync = await GetLauncherGrpcPortAsync();
-                if (launcherGrpcPortAsync == null)
+                if (OperatingSystem.IsWindows())
                 {
-                    await WaitNextAsync();
-                    continue;
+                    // On Windows, connection info is the named pipe name
+                    string pipeName = await GetLauncherConnectionInfoAsync();
+                    if (string.IsNullOrEmpty(pipeName))
+                    {
+                        await WaitNextAsync();
+                        continue;
+                    }
+                    await RefreshConnectionAsync(null, pipeName);
                 }
-                await RefreshConnectionAsync(launcherGrpcPortAsync);
+                else
+                {
+                    // On Linux, connection info is the port number
+                    int? launcherGrpcPort = await GetLauncherGrpcPortAsync();
+                    if (launcherGrpcPort == null)
+                    {
+                        await WaitNextAsync();
+                        continue;
+                    }
+                    await RefreshConnectionAsync(launcherGrpcPort, null);
+                }
 
                 // Push data
-                await PushPollDataAsync(api);
-                if (!pushLogsTask.IsBusyOrDone())
+                if (api != null)
                 {
-                    pushLogsTask = CreateLoopingTask(PushLogsAsync, api, stoppingToken);
+                    await PushPollDataAsync(api);
+                    if (pushLogsTask == null || pushLogsTask.IsCompleted)
+                    {
+                        pushLogsTask = CreateLoopingTask(PushLogsAsync, api, stoppingToken);
+                    }
                 }
             }
             catch (Exception ex)
             {
                 if (!ShouldIgnoreException(ex))
                 {
-                    logger.ZLogTrace($"{ex.Message}");
+                    logger.ZLogError(ex, $"Error in ServersManagementService");
                 }
             }
             await WaitNextAsync();
@@ -67,20 +91,60 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
 
         ValueTask<bool> WaitNextAsync() => refreshTimer.WaitForNextTickAsync(stoppingToken);
 
-        async Task RefreshConnectionAsync(int? grpcPort)
+        async Task RefreshConnectionAsync(int? grpcPort, string pipeName)
         {
-            if (channel?.Target.EndsWith(grpcPort.ToString(), StringComparison.Ordinal) == false)
+            if (OperatingSystem.IsWindows())
             {
-                channel?.Dispose();
-                channel = null;
-                if (api != null)
+                // On Windows, use named pipes for faster IPC
+                if (currentPipeName != pipeName)
                 {
-                    await api.DisposeAsync();
+                    channel?.Dispose();
+                    channel = null;
+                    if (api != null)
+                    {
+                        await api.DisposeAsync();
+                    }
+                    api = null;
+                    currentPipeName = pipeName;
                 }
-                api = null;
-            }
 
-            channel ??= GrpcChannel.ForAddress($"http://localhost:{grpcPort}");
+                if (channel == null)
+                {
+                    channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+                    {
+                        HttpHandler = new SocketsHttpHandler
+                        {
+                            ConnectCallback = async (context, cancellationToken) =>
+                            {
+                                var clientStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                                await clientStream.ConnectAsync(cancellationToken);
+                                return clientStream;
+                            }
+                        }
+                    });
+                }
+            }
+            else
+            {
+                // On Linux, use sockets
+                if (currentPort != grpcPort)
+                {
+                    channel?.Dispose();
+                    channel = null;
+                    if (api != null)
+                    {
+                        await api.DisposeAsync();
+                    }
+                    api = null;
+                    currentPort = grpcPort;
+                }
+
+                if (channel == null)
+                {
+                    channel = GrpcChannel.ForAddress($"http://localhost:{grpcPort}");
+                }
+            }
+            
             if (api == null)
             {
                 StreamingHubClientOptions grpcOptions = StreamingHubClientOptions.CreateWithDefault()
@@ -173,6 +237,20 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
         catch (Exception)
         {
             logger.ZLogWarningOnce($"Unable to get gRPC listen port from Nitrox Launcher, it might not be running. Retrying...");
+        }
+        return null;
+    }
+
+    private async Task<string> GetLauncherConnectionInfoAsync()
+    {
+        try
+        {
+            string info = await File.ReadAllTextAsync(Path.Combine(Path.GetTempPath(), LauncherConstants.GRPC_LISTEN_PORT_TEMP_FILE_NAME));
+            return info.Trim();
+        }
+        catch (Exception)
+        {
+            logger.ZLogWarningOnce($"Unable to get gRPC connection info from Nitrox Launcher, it might not be running. Retrying...");
         }
         return null;
     }

--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -61,7 +61,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
                 if (api != null)
                 {
                     await PushPollDataAsync(api);
-                    if (pushLogsTask == null || pushLogsTask.IsCompleted)
+                    if (!pushLogsTask.IsBusyOrSuccessful())
                     {
                         pushLogsTask = CreateLoopingTask(PushLogsAsync, api, stoppingToken);
                     }
@@ -71,7 +71,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
             {
                 if (!ShouldIgnoreException(ex))
                 {
-                    logger.ZLogError(ex, $"Error in ServersManagementService");
+                    logger.ZLogTrace($"{ex.Message}");
                 }
             }
             await WaitNextAsync();

--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -1,8 +1,10 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.Versioning;
 using System.Threading.Channels;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -30,8 +32,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
     private readonly PlayerManager playerManager = playerManager;
     
     private GrpcChannel? channel;
-    private string? currentPipeName;
-    private int? currentPort;
+    private ConnectionInfo? currentConnectionInfo;
     private Task? pushLogsTask;
 
     public override void Dispose() => channel?.Dispose();
@@ -46,28 +47,15 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
         {
             try
             {
-                if (OperatingSystem.IsWindows())
+                // On Windows, connection info is the named pipe name
+                // On Non-Windows, connection info is the port number
+                ConnectionInfo connectionInfo = await GetLauncherConnectionInfoAsync();
+                if (!connectionInfo.IsValid)
                 {
-                    // On Windows, connection info is the named pipe name
-                    string pipeName = await GetLauncherConnectionInfoAsync();
-                    if (string.IsNullOrEmpty(pipeName))
-                    {
-                        await WaitNextAsync();
-                        continue;
-                    }
-                    await RefreshConnectionAsync(null, pipeName);
+                    await WaitNextAsync();
+                    continue;
                 }
-                else
-                {
-                    // On Linux, connection info is the port number
-                    int? launcherGrpcPort = await GetLauncherGrpcPortAsync();
-                    if (launcherGrpcPort == null)
-                    {
-                        await WaitNextAsync();
-                        continue;
-                    }
-                    await RefreshConnectionAsync(launcherGrpcPort, null);
-                }
+                await TryRefreshConnectionAsync(connectionInfo);
 
                 // Push data
                 if (api != null)
@@ -91,58 +79,47 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
 
         ValueTask<bool> WaitNextAsync() => refreshTimer.WaitForNextTickAsync(stoppingToken);
 
-        async Task RefreshConnectionAsync(int? grpcPort, string pipeName)
+        async Task TryRefreshConnectionAsync(ConnectionInfo connectionInfo)
         {
+            if (!connectionInfo.IsValid)
+            {
+                return;
+            }
+            if (currentConnectionInfo != connectionInfo)
+            {
+                channel?.Dispose();
+                channel = null;
+                if (api != null)
+                {
+                    await api.DisposeAsync();
+                }
+                api = null;
+                currentConnectionInfo = connectionInfo;
+            }
+
             if (OperatingSystem.IsWindows())
             {
                 // On Windows, use named pipes for faster IPC
-                if (currentPipeName != pipeName)
+                channel ??= GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
                 {
-                    channel?.Dispose();
-                    channel = null;
-                    if (api != null)
+                    HttpHandler = new SocketsHttpHandler
                     {
-                        await api.DisposeAsync();
-                    }
-                    api = null;
-                    currentPipeName = pipeName;
-                }
-
-                if (channel == null)
-                {
-                    channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
-                    {
-                        HttpHandler = new SocketsHttpHandler
+                        ConnectCallback = async (_, cancellationToken) =>
                         {
-                            ConnectCallback = async (context, cancellationToken) =>
+                            if (!OperatingSystem.IsWindows())
                             {
-                                var clientStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
-                                await clientStream.ConnectAsync(cancellationToken);
-                                return clientStream;
+                                throw new InvalidOperationException($"{nameof(NamedPipeClientStream)} requires Windows OS");
                             }
+                            NamedPipeClientStream? clientStream = new(".", connectionInfo.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                            await clientStream.ConnectAsync(cancellationToken);
+                            return clientStream;
                         }
-                    });
-                }
+                    }
+                });
             }
             else
             {
-                // On Linux, use sockets
-                if (currentPort != grpcPort)
-                {
-                    channel?.Dispose();
-                    channel = null;
-                    if (api != null)
-                    {
-                        await api.DisposeAsync();
-                    }
-                    api = null;
-                    currentPort = grpcPort;
-                }
-
-                if (channel == null)
-                {
-                    channel = GrpcChannel.ForAddress($"http://localhost:{grpcPort}");
-                }
+                channel ??= GrpcChannel.ForAddress($"http://localhost:{connectionInfo.Port}");
             }
             
             if (api == null)
@@ -171,7 +148,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
                 {
                     if (!ShouldIgnoreException(ex))
                     {
-                        logger.ZLogError(ex, $"Error during looping task");
+                        logger.ZLogTrace(ex, $"Error during looping task");
                     }
                 }
             }, cancellationToken);
@@ -224,35 +201,18 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
         };
     }
 
-    private async Task<int?> GetLauncherGrpcPortAsync()
-    {
-        try
-        {
-            string port = await File.ReadAllTextAsync(Path.Combine(Path.GetTempPath(), LauncherConstants.GRPC_LISTEN_PORT_TEMP_FILE_NAME));
-            if (int.TryParse(port.Trim(), out int result))
-            {
-                return result;
-            }
-        }
-        catch (Exception)
-        {
-            logger.ZLogWarningOnce($"Unable to get gRPC listen port from Nitrox Launcher, it might not be running. Retrying...");
-        }
-        return null;
-    }
-
-    private async Task<string> GetLauncherConnectionInfoAsync()
+    private async Task<ConnectionInfo> GetLauncherConnectionInfoAsync()
     {
         try
         {
             string info = await File.ReadAllTextAsync(Path.Combine(Path.GetTempPath(), LauncherConstants.GRPC_LISTEN_PORT_TEMP_FILE_NAME));
-            return info.Trim();
+            return ConnectionInfo.From(info);
         }
         catch (Exception)
         {
             logger.ZLogWarningOnce($"Unable to get gRPC connection info from Nitrox Launcher, it might not be running. Retrying...");
         }
-        return null;
+        return new ConnectionInfo();
     }
 
     private class ServerManagementReceiver(CommandService commandProcessor, IPacketSender packetSender) : IServerManagementReceiver
@@ -261,4 +221,36 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
     }
 
     internal record LogEntry(IZLoggerEntry Entry, IZLoggerFormatter Formatter, ZLoggerPlainOptions.LogGeneratorCall Generator, ArrayBufferWriter<byte> Writer);
+
+    internal record ConnectionInfo(int Port = 0,
+                                   [property: SupportedOSPlatform("windows")]
+                                   string? PipeName = null)
+    {
+        [MemberNotNullWhen(true, nameof(PipeName))]
+        public bool IsValid
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    return !string.IsNullOrWhiteSpace(PipeName);
+                }
+                return Port > 0;
+            }
+        }
+
+        public static ConnectionInfo From(string info)
+        {
+            if (string.IsNullOrWhiteSpace(info))
+            {
+                return new ConnectionInfo();
+            }
+            info = info.Trim();
+            if (int.TryParse(info, out int port))
+            {
+                return new ConnectionInfo(port);
+            }
+            return new ConnectionInfo(PipeName: info);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2651

Changes:
- Use named pipes for GRPC communication on Windows instead of sockets
- Keep socket-based GRPC on Linux (named pipes have limited functionality there)
- Improves server output connection time from ~2 seconds to ~200ms on Windows

Testing:
- Tested on Windows (server output appears almost immediately in launcher but could use more testing)