### PR TITLE
Fix InvalidOperationException with button Animation

### DIFF
--- a/Nitrox.Launcher/Models/Styles/Theme/ButtonStyle.axaml
+++ b/Nitrox.Launcher/Models/Styles/Theme/ButtonStyle.axaml
@@ -168,14 +168,12 @@
 
         <!--  This overrides button template to use properties from parent Button. DO NOT HARD CODE VALUES HERE.  -->
         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Opacity" Value="{Binding $parent[Button].Opacity}" />
             <Setter Property="TextBlock.Foreground" Value="{Binding $parent[Button].Foreground}" />
             <Setter Property="Background" Value="{Binding $parent[Button].Background}" />
             <Setter Property="CornerRadius" Value="{Binding $parent[Button].CornerRadius}" />
         </Style>
         <Style Selector="^:pointerover">
             <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-                <Setter Property="Opacity" Value="{Binding $parent[Button].Opacity}" />
                 <Setter Property="TextBlock.Foreground" Value="{Binding $parent[Button].Foreground}" />
                 <Setter Property="Background" Value="{Binding $parent[Button].Background}" />
                 <Setter Property="Cursor" Value="{Binding $parent[Button].Cursor}" />


### PR DESCRIPTION
Fixes #2717 

Context: [https://github.com/AvaloniaUI/Avalonia/issues/12673](https://github.com/AvaloniaUI/Avalonia/issues/12673)

### What's causing that ?

Launcher’s custom Button theme created a bad interaction between an Avalonia Opacity transition and a template binding that re-subscribed to the same animated property.

In `ButtonStyle.axaml`, the Button style applies an animation to Button.Opacity, and the same style changes Opacity in several states (:pointerover, :disabled, .busy).
i.e: 
```xml
      <Transitions>
          <DoubleTransition Duration="0:0:0.075" Property="Opacity" />
      </Transitions>
```

Inside the template, `ContentPresenter#PART_ContentPresenter` also bound its own Opacity to $parent[Button].Opacity.
That means one visual state change on the button could cause Avalonia to both animate `Button.Opacity` and re-bind a template child to that same changing value.

```xml
 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Opacity" Value="{Binding $parent[Button].Opacity}" />
 </Style>
```

This matches the upstream Avalonia bug pattern in [AvaloniaUI/Avalonia#12673](https://github.com/AvaloniaUI/Avalonia/issues/12673), where transitions combined with bindings on the same property can throw `System.InvalidOperationException: The observable can only be subscribed once.`

### Note

Note that it does not change the behavior (buttons are still animated), it's just preventing double binding trigger on Opacity during animation