### PR TITLE
Fixed EGS killing the game because it's not authenticated

### DIFF
--- a/Nitrox.Model/Platforms/Store/EpicGames.cs
+++ b/Nitrox.Model/Platforms/Store/EpicGames.cs
@@ -26,7 +26,7 @@ public sealed class EpicGames : IGamePlatform
                 pathToGameExe,
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                $"-EpicPortal -epicuserid=0 {launchArguments}")
+                $"-EpicPortal {launchArguments}")
         );
     }
 }


### PR DESCRIPTION
**Nvm: the issue was EGS platform wasn't detected because the file structure changed. Closing this PR.**

___

> [!IMPORTANT]
> Needs testing with EGS!

This likely solves the issue, but not sure yet. The `-epicuserid=0` was added to fix the timecapsules submit. But timecapsules are a degraded feature of Subnautica so fixing the crashing is more important.

In Discord we ask users to follow this guide as a workaround:

> 1. If you're using the **Epic Games** version and Subnautica crashes when you open it through Nitrox, refer to the following:
> 2. In the Nitrox launcher, click on the **Options** tab.
> 3. Now in the **Subnautica Launch Arguments** section, add the following:
>     ```
>     -EpicPortal -vrmode none
>     ```
> See if it works. If it doesn't, ask in the ⁠[💡help-channel💡](https://discord.com/channels/525437013403631617/525438387105038346) .
>
> _Credits to @BairWithMe for finding this fix_