### PR TITLE
Fixed gamepass launch failing if there are spaces in the path

### DIFF
--- a/Nitrox.Model/Platforms/Store/MSStore.cs
+++ b/Nitrox.Model/Platforms/Store/MSStore.cs
@@ -26,7 +26,7 @@ public sealed class MSStore : IGamePlatform
                 @"C:\Windows\System32\cmd.exe",
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                $"""/C start /b "{pathToGameExe}" "--nitrox '{NitroxUser.LauncherPath}' {launchArguments}""",
+                $"""/C start /b "{pathToGameExe}" "--nitrox '{NitroxUser.LauncherPath}' {launchArguments}" """,
                 createWindow: false)
         );
     }

--- a/Nitrox.Model/Platforms/Store/MSStore.cs
+++ b/Nitrox.Model/Platforms/Store/MSStore.cs
@@ -26,7 +26,7 @@ public sealed class MSStore : IGamePlatform
                 @"C:\Windows\System32\cmd.exe",
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                @$"/C start /b {pathToGameExe} --nitrox ""{NitroxUser.LauncherPath}"" {launchArguments}",
+                @$"/C start /b ""{pathToGameExe}"" ""--nitrox '{NitroxUser.LauncherPath}' {launchArguments}""",
                 createWindow: false)
         );
     }

--- a/Nitrox.Model/Platforms/Store/MSStore.cs
+++ b/Nitrox.Model/Platforms/Store/MSStore.cs
@@ -26,7 +26,7 @@ public sealed class MSStore : IGamePlatform
                 @"C:\Windows\System32\cmd.exe",
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                $"""/C start /b "" "{pathToGameExe}" --nitrox {NitroxUser.LauncherPath} {launchArguments}""",
+                $"""/C start /b "" "{pathToGameExe}" --nitrox "{NitroxUser.LauncherPath}" {launchArguments}""",
                 createWindow: false)
         );
     }

--- a/Nitrox.Model/Platforms/Store/MSStore.cs
+++ b/Nitrox.Model/Platforms/Store/MSStore.cs
@@ -26,7 +26,7 @@ public sealed class MSStore : IGamePlatform
                 @"C:\Windows\System32\cmd.exe",
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                $"""/C start /b "{pathToGameExe}" "--nitrox '{NitroxUser.LauncherPath}' {launchArguments}" """,
+                $"""/C start /b "" "{pathToGameExe}" --nitrox {NitroxUser.LauncherPath} {launchArguments}""",
                 createWindow: false)
         );
     }

--- a/Nitrox.Model/Platforms/Store/MSStore.cs
+++ b/Nitrox.Model/Platforms/Store/MSStore.cs
@@ -26,7 +26,7 @@ public sealed class MSStore : IGamePlatform
                 @"C:\Windows\System32\cmd.exe",
                 [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
                 Path.GetDirectoryName(pathToGameExe),
-                @$"/C start /b ""{pathToGameExe}"" ""--nitrox '{NitroxUser.LauncherPath}' {launchArguments}""",
+                $"""/C start /b "{pathToGameExe}" "--nitrox '{NitroxUser.LauncherPath}' {launchArguments}""",
                 createWindow: false)
         );
     }


### PR DESCRIPTION
Needs testing with game pass version of the game!

[CMD start docs](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start#examples)