### PR TITLE
Fix nitrox files access on Linux while game running inside Wine

### DIFF
--- a/Nitrox.Model/Helper/NitroxUser.cs
+++ b/Nitrox.Model/Helper/NitroxUser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Nitrox.Model/Platforms/Store/HeroicGames.cs
+++ b/Nitrox.Model/Platforms/Store/HeroicGames.cs
@@ -72,6 +72,7 @@ public sealed class HeroicGames : IGamePlatform
         {
             startInfo = new ProcessStartInfo("xdg-open", $"\"{launchCmd}\"");
         }
+        startInfo.Environment.Add(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath);
 
         Log.Info($"Starting game with heroic uri: {startInfo.FileName} {startInfo.Arguments}");
         return await Task.FromResult(ProcessEx.From(startInfo));

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -260,10 +260,16 @@ public sealed class Steam : IGamePlatform
         {
             throw new Exception("Steam was not found on your machine.");
         }
+        // Game will play inside Proton so it needs launcher path to be a Wine-supported path!
+        string launcherPath = NitroxUser.LauncherPath;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !string.IsNullOrWhiteSpace(launcherPath))
+        {
+            launcherPath = $"Z:{launcherPath.Replace("/", "\\")}";
+        }
         // Start game through Steam so Steam Overlay loads properly. TODO: HACK - this way should be removed if we add a call SteamAPI_Init before Unity Engine shows graphics, see https://partner.steamgames.com/doc/features/overlay.
         if (!skipSteam)
         {
-            args = $@"-applaunch {steamAppId} --nitrox ""{NitroxUser.LauncherPath}"" {args}";
+            args = $@"-applaunch {steamAppId} --nitrox ""{launcherPath}"" {args}";
             if (bigPictureMode)
             {
                 // Keep Steam client minimized but active in background to maintain overlay functionality
@@ -286,7 +292,7 @@ public sealed class Steam : IGamePlatform
             Arguments = args,
             EnvironmentVariables =
             {
-                [NitroxUser.LAUNCHER_PATH_ENV_KEY] = NitroxUser.LauncherPath,
+                [NitroxUser.LAUNCHER_PATH_ENV_KEY] = launcherPath,
                 ["SteamGameId"] = steamAppId.ToString(),
                 ["SteamAppId"] = steamAppId.ToString(), // Primary Steam API var
                 ["STEAM_OVERLAY"] = "1", // Force enable Steam overlay

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -68,20 +68,53 @@ public static class Main
         AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
         AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += CurrentDomainOnAssemblyResolve;
 
-        Console.WriteLine("Checking if Nitrox should run...");
-        if (string.IsNullOrEmpty(nitroxLauncherDir.Value))
+        Console.WriteLine("[Nitrox] [INFO] Checking if it should run...");
+        if (!ShouldRun())
         {
-            Console.WriteLine($"Nitrox will not load because launcher path was not provided");
-            return;
-        }
-        if (!Directory.Exists(nitroxLauncherDir.Value))
-        {
-            Console.WriteLine($"Nitrox will not load because launcher path does not exist or is inaccessible: '{nitroxLauncherDir.Value}'");
             return;
         }
 
-        Console.WriteLine("Now initializing Nitrox...");
+        Console.WriteLine("[Nitrox] [INFO] Now initializing...");
         InitWithDependencies();
+
+        static bool ShouldRun()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(nitroxLauncherDir.Value))
+                {
+                    Console.WriteLine($"[Nitrox] [WARNING] will not load because launcher path was not provided: '{nitroxLauncherDir.Value}'");
+                    return false;
+                }
+                if (!Directory.Exists(nitroxLauncherDir.Value))
+                {
+                    Console.WriteLine($"[Nitrox] [WARNING] will not load because launcher path does not exist or is inaccessible: '{nitroxLauncherDir.Value}'");
+                    string lastPath = "";
+                    string? currentFolder = nitroxLauncherDir.Value;
+                    do
+                    {
+                        if (!Directory.Exists(currentFolder))
+                        {
+                            lastPath = currentFolder;
+                        }
+                        else
+                        {
+                            Console.WriteLine($"[Nitrox] [WARNING] Path '{lastPath}' is inaccessible, however '{currentFolder}' is.");
+                            Console.WriteLine("[Nitrox] [WARNING] To fix, please move Nitrox closer to the game so that the game can access Nitrox files.");
+                            return false;
+                        }
+                        currentFolder = Path.GetDirectoryName(currentFolder);
+                    } while (currentFolder != null);
+                    return false;
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Nitrox] [ERROR] {ex}");
+                return false;
+            }
+        }
     }
 
     /// <summary>
@@ -118,8 +151,8 @@ public static class Main
             }
         };
 
-        Log.Info($"Using Nitrox {NitroxEnvironment.VersionInfo} built on {NitroxEnvironment.BuildDate:F}");
-        Log.Info($"Game version: {Application.version}");
+        Log.Info($"[Nitrox] [INFO] Using {NitroxEnvironment.VersionInfo} built on {NitroxEnvironment.BuildDate:F}");
+        Log.Info($"[Nitrox] [INFO] Game version: {Application.version}");
         // Log if other mods are loaded
         Task.Run(async () =>
         {

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -201,14 +201,14 @@ public static class Main
         string dllPath = Path.Combine(nitroxLauncherDir.Value, "lib", "net472", dllFileName);
         if (!File.Exists(dllPath))
         {
-            Console.Write($"Did not find '{dllFileName}' at '{dllPath}'");
+            Console.Write($"[Nitrox] [WARNING] Did not find '{dllFileName}' at '{dllPath}'");
             dllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, dllFileName);
             Console.WriteLine($", looking at {dllPath}");
         }
 
         if (!File.Exists(dllPath))
         {
-            Console.WriteLine($"Nitrox dll missing: {dllPath}");
+            Console.WriteLine($"[Nitrox] [WARNING] dll missing: {dllPath}");
         }
 
         return Assembly.LoadFile(dllPath);


### PR DESCRIPTION
Fixes #2728 

On most systems, the game can figure out where Nitrox is. But particularly on Arch it often doesn't. This change should fix that.