### PR TITLE
Restore Nautilus GameInput compatibility

### DIFF
--- a/Nitrox.Launcher/Program.cs
+++ b/Nitrox.Launcher/Program.cs
@@ -75,7 +75,7 @@ internal static class Program
 
                 try
                 {
-                    return Assembly.LoadFile(dllPath);
+                    return Assembly.LoadFrom(dllPath);
                 }
                 catch
                 {
@@ -88,7 +88,14 @@ internal static class Program
                 cache[args.Name] = assembly = ResolveFromLib(args.Name);
                 if (assembly == null && !args.Name.Contains(".resources"))
                 {
-                    cache[args.Name] = assembly = Assembly.Load(args.Name);
+                    try
+                    {
+                        cache[args.Name] = assembly = Assembly.Load(args.Name);
+                    }
+                    catch
+                    {
+                        cache[args.Name] = assembly = null;
+                    }
                 }
             }
 

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
@@ -1,3 +1,3 @@
 namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
-public readonly record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);
+public record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
@@ -1,3 +1,3 @@
 namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
-public record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);
+public readonly record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
@@ -5,7 +5,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
 public class ChatKeyBindingAction : KeyBinding
 {
-    public ChatKeyBindingAction() : base("Nitrox_Settings_Keybind_OpenChat", "y") { }
+    public ChatKeyBindingAction() : base("Nitrox_Settings_Keybind_OpenChat", "y", "dpad/up") { }
 
     public override void Execute(InputAction.CallbackContext _)
     {

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/DiscordFocusBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/DiscordFocusBindingAction.cs
@@ -6,7 +6,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
 public class DiscordFocusBindingAction : KeyBinding
 {
-    public DiscordFocusBindingAction() : base("Nitrox_Settings_Keybind_FocusDiscord", "i") { }
+    public DiscordFocusBindingAction() : base("Nitrox_Settings_Keybind_FocusDiscord", "i", "dpad/down") { }
 
     public override void Execute(InputAction.CallbackContext _)
     {

--- a/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -9,21 +11,92 @@ using UnityEngine.InputSystem;
 namespace NitroxPatcher.Patches.Persistent;
 
 /// <summary>
-/// Inserts Nitrox's keybinds in the new Subnautica input system
+///     Inserts Nitrox's keybinds in the new Subnautica input system.
+///     Extends GameInput.AllActions so the game creates InputAction entries for Nitrox buttons,
+///     which is required for compatibility with Nautilus when both mods run together.
 /// </summary>
-public partial class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistentPatch
+public class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistentPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((GameInputSystem t) => t.Initialize());
+    private static readonly MethodInfo DEINITIALIZE_METHOD = Reflect.Method((GameInputSystem t) => t.Deinitialize());
+    private static GameInput.Button[] oldAllActions;
 
-    public static void Prefix(GameInputSystem __instance)
+    public override void Patch(Harmony harmony)
     {
-        CachedEnumString<GameInput.Button> actionNames = GameInput.ActionNames;
+        PatchPrefix(harmony, TARGET_METHOD, ((Action<GameInputSystem>)Prefix).Method);
+        PatchTranspiler(harmony, TARGET_METHOD, ((Func<IEnumerable<CodeInstruction>, IEnumerable<CodeInstruction>>)Transpiler).Method);
+        PatchPrefix(harmony, DEINITIALIZE_METHOD, ((Action)DeinitializePrefix).Method);
+    }
 
+    /// <summary>
+    ///     Set the actions callbacks for our own keybindings once they're actually created.
+    ///     If the game didn't create entries (e.g. when AllActions extension doesn't apply to this game version),
+    ///     we create and add the InputActions ourselves, matching Nautilus's approach.
+    /// </summary>
+    private static void RegisterKeybindsActions(GameInputSystem gameInputSystem)
+    {
         int buttonId = KeyBindingManager.NITROX_BASE_ID;
         foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
         {
             GameInput.Button button = (GameInput.Button)buttonId++;
+            if (!gameInputSystem.actions.TryGetValue(button, out InputAction action))
+            {
+                // Game didn't create this action (AllActions may not be used for action creation in this build).
+                // Create and add it ourselves, matching Nautilus's InitializePostfix pattern.
+                string buttonName = GameInput.ActionNames.valueToString.TryGetValue(button, out string name) ? name : button.ToString();
+                action = new InputAction(buttonName, InputActionType.Button);
+                if (!string.IsNullOrEmpty(keyBinding.DefaultKeyboardKey))
+                {
+                    action.AddBinding($"<Keyboard>/{keyBinding.DefaultKeyboardKey}");
+                }
+                if (!string.IsNullOrEmpty(keyBinding.DefaultControllerKey))
+                {
+                    action.AddBinding($"<Gamepad>/{keyBinding.DefaultControllerKey}");
+                }
+                gameInputSystem.actions[button] = action;
+                action.started += gameInputSystem.OnActionStarted;
+                action.Enable();
+            }
+            action.started += keyBinding.Execute;
+        }
+    }
+
+    private static void Prefix(GameInputSystem __instance)
+    {
+        int buttonId = KeyBindingManager.NITROX_BASE_ID;
+        oldAllActions = GameInput.AllActions;
+
+        // Only extend AllActions if Nitrox buttons aren't already present.
+        // AllActions is typically initialized from Enum.GetValues (patched by Enum_GetValues_Patch),
+        // so it may already contain Nitrox buttons. Adding them again would cause duplicate keybinds
+        // in the settings UI since the game builds the binding list from both sources.
+        if (!GameInput.AllActions.Any(b => (int)b >= buttonId && (int)b < buttonId + KeyBindingManager.KeyBindings.Count))
+        {
+            GameInputAccessor.AllActions =
+            [
+                .. GameInput.AllActions,
+                .. Enumerable.Range(buttonId, KeyBindingManager.KeyBindings.Count).Cast<GameInput.Button>()
+            ];
+        }
+
+        CachedEnumString<GameInput.Button> actionNames = GameInput.ActionNames;
+
+        // Access Language.main's internal strings dictionary so we can register "Option{buttonId}"
+        // entries for the binding conflict dialog (the game formats conflict messages using
+        // "Option" + button.ToString(), which yields "Option1000" for Nitrox buttons).
+        Dictionary<string, string> langStrings = null;
+        if (Language.main != null)
+        {
+            langStrings = (Dictionary<string, string>)AccessTools.Field(typeof(Language), "strings").GetValue(Language.main);
+        }
+
+        foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
+        {
+            GameInput.Button button = (GameInput.Button)buttonId++;
             actionNames.valueToString[button] = keyBinding.ButtonLabel;
+
+            // Register the "Option1000" style key so the conflict dialog shows the translated label
+            langStrings?.TryAdd($"Option{(int)button}", Language.main.Get(keyBinding.ButtonLabel));
 
             if (!string.IsNullOrEmpty(keyBinding.DefaultKeyboardKey))
             {
@@ -38,37 +111,38 @@ public partial class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistent
         }
     }
 
+    private static void DeinitializePrefix()
+    {
+        GameInputAccessor.AllActions = oldAllActions;
+    }
+
     /*
      * Modifying the actions must happen before actionMapGameplay.Enable because that line is responsible
      * for activating the actions callback we'll be setting
-     * 
+     *
      * GameInputSystem_Initialize_Patch.RegisterKeybindsActions(this); <--- [INSERTED LINE]
      * this.actionMapGameplay.Enable();
      */
-    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        return new CodeMatcher(instructions).MatchStartForward([
-                                                new(OpCodes.Ldarg_0),
-                                                new(OpCodes.Ldfld),
-                                                new(OpCodes.Callvirt, Reflect.Method((InputActionMap t) => t.Enable()))
-                                            ])
-                                            .Insert([
-                                                new CodeInstruction(OpCodes.Ldarg_0),
-                                                new CodeInstruction(OpCodes.Call, Reflect.Method(() => RegisterKeybindsActions(default)))
-                                            ])
+        return new CodeMatcher(instructions).MatchStartForward(new(OpCodes.Ldarg_0), new(OpCodes.Ldfld), new(OpCodes.Callvirt, Reflect.Method((InputActionMap t) => t.Enable())))
+                                            .Insert(new CodeInstruction(OpCodes.Ldarg_0), new CodeInstruction(OpCodes.Call, Reflect.Method(() => RegisterKeybindsActions(default))))
                                             .InstructionEnumeration();
     }
-    
-    /// <summary>
-    /// Set the actions callbacks for our own keybindings once they're actually created only
-    /// </summary>
-    public static void RegisterKeybindsActions(GameInputSystem gameInputSystem)
+
+    private static class GameInputAccessor
     {
-        int buttonId = KeyBindingManager.NITROX_BASE_ID;
-        foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
+        /// <summary>
+        ///     Required because "GameInput.AllActions" is a read only field.
+        /// </summary>
+        private static readonly FieldInfo allActionsField = Reflect.Field(() => GameInput.AllActions);
+
+        public static GameInput.Button[] AllActions
         {
-            GameInput.Button button = (GameInput.Button)buttonId++;
-            gameInputSystem.actions[button].started += keyBinding.Execute;
+            set
+            {
+                allActionsField.SetValue(null, value);
+            }
         }
     }
 }

--- a/NitroxPatcher/Patches/Persistent/uGUI_TabbedControlsPanel_AddBindingOption_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/uGUI_TabbedControlsPanel_AddBindingOption_Patch.cs
@@ -1,26 +1,45 @@
+using System;
 using System.Reflection;
+using NitroxClient.MonoBehaviours.Gui.Input;
 
 namespace NitroxPatcher.Patches.Persistent;
 
 /// <summary>
-/// Intercepts binding options created by Nitrox to remove the "Option" prefix given by <see cref="GameInputSystem.PopulateBindingSettings"/>
+/// Intercepts binding options created by Nitrox to use the proper label instead of "Option[ButtonID]".
+/// We modify the label by reference so the original method runs once with the correct display text,
+/// avoiding recursive calls to AddBindingOption which would break the uGUI_Bindings component.
 /// </summary>
 public partial class uGUI_TabbedControlsPanel_AddBindingOption_Patch : NitroxPatch, IPersistentPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_TabbedControlsPanel t) => t.AddBindingOption(default, default, default, default));
 
     private const string SUBNAUTICA_OPTION_PREFIX = "Option";
-    private const string DETECT_OPTION_PREFIX = "OptionNitrox";
 
-    public static bool Prefix(uGUI_TabbedControlsPanel __instance, int tabIndex, string label, GameInput.Device device, GameInput.Button button, ref uGUI_Bindings __result)
+    public static void Prefix(ref string label, GameInput.Button button)
     {
-        if (label.StartsWith(DETECT_OPTION_PREFIX))
+        try
         {
-            // Cut "Option" from the label
-            __result = __instance.AddBindingOption(tabIndex, label[SUBNAUTICA_OPTION_PREFIX.Length..], device, button);
-            return false;
-        }
+            // Check if this is a Nitrox button by its ID and translate the label
+            int buttonId = (int)button;
+            if (buttonId >= KeyBindingManager.NITROX_BASE_ID && buttonId < KeyBindingManager.NITROX_BASE_ID + KeyBindingManager.KeyBindings.Count)
+            {
+                if (GameInput.ActionNames.valueToString.TryGetValue(button, out string localizationKey))
+                {
+                    label = Language.main != null ? Language.main.Get(localizationKey) : localizationKey;
+                    return;
+                }
+            }
 
-        return true;
+            // Fallback: check for "OptionNitrox" prefix (label set by the game as "Option" + actionName)
+            if (label.StartsWith(SUBNAUTICA_OPTION_PREFIX + "Nitrox"))
+            {
+                string localizationKey = label[SUBNAUTICA_OPTION_PREFIX.Length..];
+                label = Language.main != null ? Language.main.Get(localizationKey) : localizationKey;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error in uGUI_TabbedControlsPanel_AddBindingOption_Patch");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Restores compatibility between Nitrox and newer Nautilus builds that use Nautilus's Subnautica GameInput integration.

Nautilus 1.0.0-pre.45+ introduced a new GameInput/custom button system. With Nitrox, this caused the game to reach the title/menu scene but fail to populate the expected menu/UI state, making Nitrox effectively incompatible with newer Nautilus builds.

This PR applies the focused GameInput/keybind compatibility work from JackNytely's PR #2663, excluding the unrelated launcher/server changes from that PR.

Full credit for the Nautilus GameInput compatibility work goes to JackNytely and PR #2663. This PR separates the input compatibility pieces into a smaller, focused change set.

## What changed

- Makes Nitrox's GameInput button registration compatible with Nautilus's custom GameInput button handling.
- Ensures Nitrox buttons are safely added without assuming Nitrox is the only system extending GameInput.Button / GameInput.AllActions.
- Adds duplicate-safe handling around GameInput action registration.
- Preserves support for Nautilus's new input labels, keyboard shortcuts, and assignment UI.
- Fixes a server-side spawning exception caused by UwePrefab being declared as a readonly record struct while spawning code expects to mutate Probability.

## UwePrefab fix

During multiplayer world sync, the server repeatedly threw:

System.MissingMethodException: Method not found:

'Void Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.UwePrefab.set\_Probability(Single)'.

