### PR TITLE
Fix EGS Discovery

### DIFF
--- a/Nitrox.Model/Platforms/Store/Discord.cs
+++ b/Nitrox.Model/Platforms/Store/Discord.cs
@@ -14,7 +14,9 @@ public sealed class Discord : IGamePlatform
 
     public bool OwnsGame(string gameDirectory)
     {
-        return File.Exists(Path.Combine(Directory.GetParent(gameDirectory)?.FullName ?? "..", "journal.sqlite"));
+        return File.Exists(
+            Path.Combine(Path.GetDirectoryName(Path.GetFullPath(gameDirectory)) ?? "..", "journal.sqlite")
+        );
     }
 
     public static async Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)

--- a/Nitrox.Model/Platforms/Store/EpicGames.cs
+++ b/Nitrox.Model/Platforms/Store/EpicGames.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,13 +17,16 @@ public sealed class EpicGames : IGamePlatform
     public bool OwnsGame(string gameDirectory)
     {
         string path = Path.Combine(gameDirectory, ".egstore");
-        if (!Directory.Exists(path))
+        
+        try
         {
+            return Directory.EnumerateFiles(path, "*.manifest", SearchOption.TopDirectoryOnly).Any();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
             return false;
         }
-
-        IEnumerable<string> manifestFiles = Directory.EnumerateFiles(path, "*.manifest", SearchOption.TopDirectoryOnly);
-        return manifestFiles.Any();
     }
 
     public static async Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)

--- a/Nitrox.Model/Platforms/Store/EpicGames.cs
+++ b/Nitrox.Model/Platforms/Store/EpicGames.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
@@ -15,7 +17,13 @@ public sealed class EpicGames : IGamePlatform
     public bool OwnsGame(string gameDirectory)
     {
         string path = Path.Combine(gameDirectory, ".egstore");
-        return Directory.Exists(path) && Directory.GetFiles(path).Length > 1;
+        if (!Directory.Exists(path))
+        {
+            return false;
+        }
+
+        IEnumerable<string> manifestFiles = Directory.EnumerateFiles(path, "*.manifest", SearchOption.TopDirectoryOnly);
+        return manifestFiles.Any();
     }
 
     public static async Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
Context : [Discord](https://discord.com/channels/525437013403631617/1504387511139700876)
Supersedes #2735 

## Description of Change

<!-- Describe what this PR changes and why -->
`OwnsGame` was checking inside .egstore folder for a determined number of files, however it seems to be unstable across updates because this folder might contain download cache, dead files, ...

However it (should) always contain the game manifest at least. Which is what this PR is looking for.

We could go way deeper in this check though, this file is a custom binary format, but it can be easily read with some tools like [https://github.com/meszmate/manifest](https://github.com/meszmate/manifest). The minimal check would be to check the magic number at the beginning of each manifest (Epic manifest files seems to always start with `0x44BEC00C`.  We could also check the entries to find AppId et AppName in the manifest
⚠️ However that would make us depend on the binary format, which is undocumented so it can be changed (unlikely but still)

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes
- [x] Has a linked issue
- [x] Has been tested in-game
- [x] Has been tested on Windows & macOS

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
