### PR TITLE
Fix scanner room upgrade disappearing

### DIFF
--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -59,6 +59,11 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             {
                 case MapRoomEntity mapRoomEntity:
                     yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    // Restores Scanner Room upgrade chips (#2696)
+                    if (mapRoomEntity.ChildEntities.Count > 0)
+                    {
+                        yield return entities.SpawnBatchAsync(mapRoomEntity.ChildEntities.OfType<InventoryItemEntity>().ToList<Entity>(), true);
+                    }
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2696

## Description of Change

Scanner Room upgrade chips were lost on server restart because [`BuildEntitySpawner.SpawnAsync`](https://github.com/SubnauticaNitrox/Nitrox/blob/master/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs) did not spawn the `InventoryItemEntity` children of a `MapRoomEntity` after `InteriorPieceEntitySpawner.RestoreMapRoom`.

The chip data was already being preserved on the server: when a chip is slotted, `EntityReparented` fires and the server-side processor calls `EntityRegistry.ReparentEntity`, which adds the chip to `MapRoomEntity.ChildEntities`. That gets serialized and reloaded across server restarts. The bug was purely on the client-side respawn path — the children were in the entity tree but never materialized in-game.

The fix batch-spawns the `InventoryItemEntity` children after `RestoreMapRoom` sets the NitroxId on the in-game `MapRoomFunctionality`. `InventoryContainerHelper.TryGetContainerByOwner` already routes any GameObject with a `StorageContainer` in its hierarchy to the right `ItemsContainer`, so no helper changes are required.

## Validation

Tested locally on Windows, Subnautica build 83031, Nitrox InDev master (bbf5124c):

1. Built a Scanner Room on a foundation.
2. Crafted a Map Room Range Upgrade chip at the scanner room's upgrade fabricator.
3. Slotted the chip — antennae lengthened, confirming the upgrade was active.
4. Saved and quit to main menu.
5. Stopped and restarted the local server.
6. Rejoined via the Nitrox launcher.
7. Walked back to the scanner room — chip was still slotted ✅.

Reproduced the original bug on the unmodified baseline before applying the fix (chip vanished after step 6). Also verified with multiple chips slotted across server restarts.

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [ ] Has tests for the changes (no existing test coverage for `BuildEntitySpawner.SpawnAsync` MapRoom branch; happy to add one if reviewers want it)
- [x] Has a linked issue (#2696)
- [x] Has been tested in-game
- [ ] Has been tested on Windows/Linux/macOS (Windows only)

---

🤖 This code was created with the help of AI.
