### PR TITLE
Fix cyclops having negative power when removing all power cells

### DIFF
--- a/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
+++ b/Nitrox.Test/Patcher/Patches/PatchesTranspilerTest.cs
@@ -35,6 +35,7 @@ public class PatchesTranspilerTest
         [typeof(CreatureDeath_SpawnRespawner_Patch), 2],
         [typeof(CyclopsDestructionEvent_DestroyCyclops_Patch), 3],
         [typeof(CyclopsDestructionEvent_SpawnLootAsync_Patch), 7],
+        [typeof(CyclopsHelmHUDManager_Update_Patch), 2],
         [typeof(CyclopsShieldButton_OnClick_Patch), -6],
         [typeof(CyclopsSonarButton_Update_Patch), 3],
         [typeof(CyclopsSonarDisplay_NewEntityOnSonar_Patch), 3],

--- a/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsHelmHUDManager_Update_Patch.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -28,5 +31,22 @@ public sealed partial class CyclopsHelmHUDManager_Update_Patch : NitroxPatch, ID
                 __instance.engineToggleAnimator.SetTrigger("EngineOff");
             }
         }
+    }
+
+    /*
+     * Fix for #2525: vanilla computes
+     *     int num = Mathf.CeilToInt(subRoot.powerRelay.GetPower() / subRoot.powerRelay.GetMaxPower() * 100f);
+     * When all powercells are removed GetMaxPower() returns 0, so 0f / 0f is NaN and
+     * Mathf.CeilToInt(NaN) is int.MinValue, making the HUD read "-2147483648%".
+     * Clamp the result to a minimum of 0 so vanilla's own "{num}%" formatting renders "0%":
+     *     int num = Mathf.Max(Mathf.CeilToInt(...), 0);
+     */
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions).MatchStartForward(new CodeMatch(OpCodes.Call, Reflect.Method(() => UnityEngine.Mathf.CeilToInt(default(float)))))
+                                            .Advance(1)
+                                            .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_I4_0))
+                                            .Insert(new CodeInstruction(OpCodes.Call, Reflect.Method(() => UnityEngine.Mathf.Max(default(int), default(int)))))
+                                            .InstructionEnumeration();
     }
 }


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2525

## Description of Change

Vanilla `CyclopsHelmHUDManager.Update` computes the displayed power percent as:

```csharp
int num = Mathf.CeilToInt(subRoot.powerRelay.GetPower() / subRoot.powerRelay.GetMaxPower() * 100f);
```

With all powercells removed, `GetMaxPower()` returns `0`, so `0f / 0f` is `NaN` and `Mathf.CeilToInt(NaN)` is `int.MinValue`. The HUD then reads `-2147483648%` instead of `0%`.

This state is normally unreachable in vanilla Subnautica because the engine auto-shuts when the player exits the helm, but Nitrox intentionally patches that out for MP reasons (see [`CyclopsMotorMode_SaveEngineStateAndPowerDown_Patch.cs`](https://github.com/SubnauticaNitrox/Nitrox/blob/master/NitroxPatcher/Patches/Dynamic/CyclopsMotorMode_SaveEngineStateAndPowerDown_Patch.cs)). With auto-shutdown disabled, pulling all powercells at the helm exposes the divide-by-zero path.

**The fix transpiles `Update` to clamp the `Mathf.CeilToInt` result with `Mathf.Max(0, …)`**, so the bad value never gets written and vanilla's own `$"{num}%"` formatting renders `0%`. The clamp is a single insertion right after the uniquely-matchable `Mathf.CeilToInt` call.

> Note: an earlier revision of this PR used a Postfix that overwrote the text after the fact. That approach wrote `IntStringCache.GetStringForInt(0)` = `"0"`, which dropped the `%` sign that vanilla's `$"{num}%"` includes. The transpiler fixes the value at the source and lets vanilla's formatting run, producing the correct `"0%"`. Thanks to the reviewer for pushing for the source-level fix.

The patch is registered in `PatchesTranspilerTest` so the IL match is covered by the test suite.

This patches a vanilla Subnautica bug (closed-source, can't be upstreamed), but the clamp is a no-op for all legitimate power values (0–100), so it has no effect in normal play.

## Validation

Tested locally on Windows, Subnautica build 83031, Nitrox InDev master (bbf5124c):

1. Spawn a Cyclops via Developer → Give → Cyclops.
2. Enter the cyclops, walk to the helm.
3. Remove all 6 power cells.
4. HUD power readout shows `0%` (was `-2147483648%` before the fix).
5. Insert a powercell back → shows a normal positive percent. Remove it again → back to `0%`.

The transpiler is also covered by `PatchesTranspilerTest.AllPatchesTranspilerSanity`, which runs it against the real game IL and asserts it matches and inserts exactly 2 instructions.

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [x] Has tests for the changes (registered in `PatchesTranspilerTest`)
- [x] Has a linked issue (#2525)
- [x] Has been tested in-game
- [ ] Has been tested on Windows/Linux/macOS (Windows only)

---

🤖 This code was created with the help of AI.
