### PR TITLE
Fix UwePrefab probability setter

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
@@ -1,3 +1,3 @@
 namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
-public readonly record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);
+public record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);


### PR DESCRIPTION
## Summary

Fixes a server-side world sync / spawning runtime exception involving `UwePrefab.Probability`.

## Background

During multiplayer world sync and later cell / batch loading, the server repeatedly threw this exception:

> System.MissingMethodException: Method not found: 'Void Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.UwePrefab.set_Probability(Single)'.

The failure occurred in the entity spawning path:

- `BatchEntitySpawner.SpawnEntitiesUsingRandomDistributionAsync(...)`
- `BatchEntitySpawner.SpawnEntitiesAsync(...)`
- `BatchEntitySpawner.LoadBatchInternalAsync(...)`
- `WorldEntityManager.LoadAndRegisterBatchInternalAsync(...)`
- `CellVisibilityChangedProcessor.Process(...)`
- `LiteNetLibServer.ProcessPacket(...)`

## Why

`UwePrefab` is currently declared as a `readonly record struct`, but the server-side spawning / random distribution path expects a writable `Probability` API surface.

At runtime, the compiled caller attempts to use `set_Probability(Single)`, but that setter is not available with the current readonly struct shape. This causes a `MissingMethodException` during world sync / spawning.

Changing `UwePrefab` to a non-readonly `record struct` restores the expected setter-compatible API surface.

## What changed

- Changed `UwePrefab` from `readonly record struct` to `record struct`.

## Dependency / testing note

This was tested on top of the Release launcher dependency-loading fix because my current mod / test setup requires that fix to create and start servers reliably in a clean Release environment.

This change is otherwise isolated to `UwePrefab`.

## Tested

Tested using a fresh server / world after clearing and rebuilding the relevant prefab placeholder cache.

Before this change:

- The server repeatedly threw `MissingMethodException: UwePrefab.set_Probability(Single)`.
- The exception occurred during `BatchEntitySpawner`, `WorldEntityManager.LoadAndRegisterBatchInternalAsync`, and `CellVisibilityChangedProcessor` processing.

After this change:

- Created and started a fresh server / world.
- `PrefabPlaceholderGroupsResource` rebuilt successfully.
- Player joined and initial multiplayer sync completed.
- Initial spawn batches completed successfully.
- Traveled more than 200m to force additional cell / batch loading.
- Additional `BatchEntitySpawner` batches spawned successfully.
- No `UwePrefab`, `set_Probability`, or `MissingMethodException` error appeared during the same reproduction path.
