### PR TITLE
[Draft] Integration test branch for current fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,10 @@
         <PackageVersion Include="dnlib" Version="4.4.0" />
         <PackageVersion Include="FluentAssertions.Analyzers" Version="[0.34.1]" />
         <PackageVersion Include="FluentAssertions" Version="[7.2.0]" />
+        <PackageVersion Include="Grpc.Core.Api" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Net.Common" Version="2.66.0" />
+        <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.66.0" />
         <PackageVersion Include="HanumanInstitute.MvvmDialogs.Avalonia" Version="2.1.0" />
         <PackageVersion Include="HarmonyX" Version="2.10.0" />
         <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />

--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -182,7 +182,7 @@ internal sealed partial class ServerEntry : ObservableObject
         if (Process?.Id != processId)
         {
             await ResetCtsAsync();
-            Process = ServerProcess.Start(Path.Combine(KeyValueStore.Instance.GetSavesFolderDir(), Name), cts, ShouldAttachAsEmbedded(), processId);
+            Process = ServerProcess.Start(this, Path.Combine(KeyValueStore.Instance.GetSavesFolderDir(), Name), cts, ShouldAttachAsEmbedded(), processId);
         }
         if (Process is { IsRunning: true })
         {
@@ -302,7 +302,7 @@ internal sealed partial class ServerEntry : ObservableObject
         // Start server and add notify when server closed.
         await ResetCtsAsync();
         IsEmbedded = embedded;
-        Process = ServerProcess.Start(Path.Combine(savesDir, Name), cts, embedded, existingProcessId);
+        Process = ServerProcess.Start(this, Path.Combine(savesDir, Name), cts, embedded, existingProcessId);
 
         Output.Clear();
         IsNewServer = false;
@@ -312,14 +312,20 @@ internal sealed partial class ServerEntry : ObservableObject
     [RelayCommand(AllowConcurrentExecutions = false)]
     public async Task StopAsync()
     {
-        if (cts != null)
-        {
-            await cts.CancelAsync();
-        }
-        // Ensure the server is dead before continuing. On Linux, if launcher process closes it could otherwise abruptly kill the embedded servers.
-        using CancellationTokenSource waitProcessExitCts = new(TimeSpan.FromSeconds(20));
+        IsServerClosing = true;
+
         try
         {
+            if (!ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
+            {
+                return;
+            }
+
+            Log.Info($"Sending quit command to server '{Name}'.");
+            await CommandQueue.Writer.WriteAsync("quit");
+
+            using CancellationTokenSource waitProcessExitCts = new(TimeSpan.FromSeconds(20));
+
             while (ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
             {
                 await Task.Delay(200, waitProcessExitCts.Token);
@@ -327,7 +333,29 @@ internal sealed partial class ServerEntry : ObservableObject
         }
         catch (OperationCanceledException)
         {
-            // ignored
+            Log.Warn($"Server '{Name}' did not exit after graceful quit command.");
+        }
+        catch (ChannelClosedException ex)
+        {
+            Log.Warn($"Could not send quit command to server '{Name}' because the command queue is closed: {ex}");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Could not send quit command to server '{Name}'.");
+        }
+        finally
+        {
+            if (!ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
+            {
+                if (cts != null)
+                {
+                    await cts.CancelAsync();
+                }
+
+                IsOnline = false;
+            }
+
+            IsServerClosing = false;
         }
     }
 
@@ -351,7 +379,7 @@ internal sealed partial class ServerEntry : ObservableObject
     [MemberNotNull(nameof(cts))]
     internal async Task ResetCtsAsync(bool cancelPreexisting = false)
     {
-        if (cancelPreexisting && cts is {} c)
+        if (cancelPreexisting && cts is { } c)
         {
             await c.CancelAsync();
         }
@@ -362,21 +390,8 @@ internal sealed partial class ServerEntry : ObservableObject
             try
             {
                 await Dispatcher.UIThread.InvokeAsync(() => IsServerClosing = true);
-                await Dispatcher.UIThread.InvokeAsync(async () =>
+                await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    while (ProcessEx.ProcessExists(GetServerProcessName(), ex => ex.Id == LastProcessId))
-                    {
-                        try
-                        {
-                            await CommandQueue.Writer.WriteAsync("quit");
-                            CommandQueue.Writer.TryComplete();
-                        }
-                        catch (ChannelClosedException)
-                        {
-                            await Task.Delay(500);
-                        }
-                    }
-                    CommandQueue = Channel.CreateUnbounded<string>();
                     PlayerCount = 0;
                     PlayerNames = [];
                     IsOnline = false;
@@ -396,11 +411,15 @@ internal sealed partial class ServerEntry : ObservableObject
     internal class ServerProcess : IDisposable
     {
         private ProcessEx? serverProcess;
+        private readonly ServerEntry owner;
+        private readonly CancellationTokenSource processMonitorCts = new();
+        private bool disposed;
         public int Id => serverProcess?.Id ?? -1;
         public bool IsRunning => serverProcess is { IsRunning: true };
 
-        private ServerProcess(string saveDir, CancellationTokenSource cts, bool isEmbeddedMode = false, int processId = -1)
+        private ServerProcess(ServerEntry owner, string saveDir, CancellationTokenSource cts, bool isEmbeddedMode = false, int processId = -1)
         {
+            this.owner = owner;
             cts.Token.Register(Dispose);
             if (processId <= 0)
             {
@@ -453,14 +472,63 @@ internal sealed partial class ServerEntry : ObservableObject
             {
                 serverProcess = ProcessEx.From(System.Diagnostics.Process.GetProcessById(processId));
             }
+
+            _ = MonitorProcessExitAsync(processMonitorCts.Token).ContinueWithHandleError();
+
         }
 
-        public static ServerProcess Start(string saveDir, CancellationTokenSource cts, bool isEmbedded, int processId) => new(saveDir, cts, isEmbedded, processId);
+        private async Task MonitorProcessExitAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested && IsRunning)
+                {
+                    await Task.Delay(500, cancellationToken);
+                }
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        owner.IsOnline = false;
+                        owner.IsServerClosing = false;
+                        owner.PlayerCount = 0;
+                        owner.PlayerNames = [];
+                        owner.Output.Clear();
+                    });
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected during normal disposal.
+            }
+        }
+
+        public static ServerProcess Start(ServerEntry owner, string saveDir, CancellationTokenSource cts, bool isEmbedded, int processId) => new(owner, saveDir, cts, isEmbedded, processId);
 
         public void Dispose()
         {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+
+            try
+            {
+                processMonitorCts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed.
+            }
+
+            processMonitorCts.Dispose();
+
             serverProcess?.Dispose();
             serverProcess = null;
         }
     }
+
 }

--- a/Nitrox.Launcher/Nitrox.Launcher.csproj
+++ b/Nitrox.Launcher/Nitrox.Launcher.csproj
@@ -44,6 +44,8 @@
         <PackageReference Include="dnlib" />
         <PackageReference Include="LitJson" />
         <PackageReference Include="MagicOnion.Server" />
+        <PackageReference Include="Grpc.AspNetCore.Server" />
+        <PackageReference Include="Grpc.Core.Api" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="ServiceScan.SourceGenerator">
@@ -118,6 +120,42 @@
               Retries="3"
               RetryDelayMilliseconds="100"
               SkipUnchangedFiles="True" />
+    </Target>
+
+    <Target Name="_NitroxRestoreNet10RootLibAssets" AfterTargets="$(_NitroxMoveDependenciesToLibTaskName)" Condition="'$(TargetFramework)' == 'net10.0'">
+
+	<PropertyGroup>
+		<_LauncherRootLibDir>$(TargetDir)lib\</_LauncherRootLibDir>
+		<_Net10NitroxModelDll>$(MSBuildProjectDirectory)\..\Nitrox.Model\bin\$(Configuration)\net10.0\Nitrox.Model.dll</_Net10NitroxModelDll>
+		<_NetStandardGrpcCoreApiDll>$(PkgGrpc_Core_Api)\lib\netstandard2.1\Grpc.Core.Api.dll</_NetStandardGrpcCoreApiDll>
+	</PropertyGroup>
+
+	<Message Importance="Low"
+		Text="Running _NitroxRestoreNet10RootLibAssets for $(MSBuildProjectName)" />
+
+	<Message Importance="Low"
+		 Text="Restoring net10 Nitrox.Model.dll from '$(_Net10NitroxModelDll)' to '$(_LauncherRootLibDir)'" />
+
+	<Message Importance="Low"
+		 Text="Restoring netstandard2.1 Grpc.Core.Api.dll from '$(_NetStandardGrpcCoreApiDll)' to '$(_LauncherRootLibDir)'" />
+
+	<Error Text="Unable to find net10 Nitrox.Model.dll at '$(_Net10NitroxModelDll)'"
+		 Condition="!Exists('$(_Net10NitroxModelDll)')" />
+
+	<Error Text="Unable to find netstandard2.1 Grpc.Core.Api.dll at '$(_NetStandardGrpcCoreApiDll)'"
+		 Condition="!Exists('$(_NetStandardGrpcCoreApiDll)')" />
+
+	<ItemGroup>
+		 <_Net10RootLibAssets Include="$(_Net10NitroxModelDll)" />
+		 <_Net10RootLibAssets Include="$(_NetStandardGrpcCoreApiDll)" />
+	</ItemGroup>
+
+	<Copy SourceFiles="@(_Net10RootLibAssets)"
+		  DestinationFolder="$(_LauncherRootLibDir)"
+		  OverwriteReadOnlyFiles="True"
+		  SkipUnchangedFiles="False"
+		  Retries="3"
+		  RetryDelayMilliseconds="100" />
     </Target>
 
     <ItemGroup>

--- a/Nitrox.Launcher/Program.cs
+++ b/Nitrox.Launcher/Program.cs
@@ -75,7 +75,7 @@ internal static class Program
 
                 try
                 {
-                    return Assembly.LoadFile(dllPath);
+                    return Assembly.LoadFrom(dllPath);
                 }
                 catch
                 {
@@ -88,7 +88,14 @@ internal static class Program
                 cache[args.Name] = assembly = ResolveFromLib(args.Name);
                 if (assembly == null && !args.Name.Contains(".resources"))
                 {
-                    cache[args.Name] = assembly = Assembly.Load(args.Name);
+                    try
+                    {
+                        cache[args.Name] = assembly = Assembly.Load(args.Name);
+                    }
+                    catch
+                    {
+                        cache[args.Name] = assembly = null;
+                    }
                 }
             }
 

--- a/Nitrox.Launcher/Program.cs
+++ b/Nitrox.Launcher/Program.cs
@@ -94,7 +94,7 @@ internal static class Program
                     }
                     catch
                     {
-                        cache[args.Name] = assembly = null;
+                        return null;
                     }
                 }
             }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
@@ -1,3 +1,3 @@
 namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
-public readonly record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);
+public record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/UwePrefab.cs
@@ -1,3 +1,3 @@
 namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
-public record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);
+public readonly record struct UwePrefab(string ClassId, int Count, float Probability, bool IsFragment);

--- a/Nitrox.Model/Nitrox.Model.csproj
+++ b/Nitrox.Model/Nitrox.Model.csproj
@@ -8,6 +8,7 @@
         <PackageReference Include="Autofac" />
         <PackageReference Include="LiteNetLib" />
         <PackageReference Include="MagicOnion.Abstractions" />
+        <PackageReference Include="Grpc.Core.Api" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.Win32.Registry" />
         <PackageReference Include="Mono.Nat" />

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/PickupItemPacketProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/PickupItemPacketProcessor.cs
@@ -5,6 +5,7 @@ using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.GameLogic;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.Packets.Core;
+using System.Linq;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 
@@ -24,12 +25,37 @@ internal sealed class PickupItemPacketProcessor(EntityRegistry entityRegistry, W
             await context.SendToAllAsync(simulationOwnershipChange);
         }
 
+        PreserveExistingInstalledBatteries(id, packet.Item);
+
         StopTrackingExistingWorldEntity(id);
 
         entityRegistry.AddOrUpdate(packet.Item);
 
         // Have other players respawn the item inside the inventory.
         await context.SendToOthersAsync(new SpawnEntities(packet.Item, forceRespawn: true));
+    }
+
+    private void PreserveExistingInstalledBatteries(NitroxId id, InventoryItemEntity pickedUpItem)
+    {
+        Optional<Entity> existingEntity = entityRegistry.GetEntityById(id);
+        if (existingEntity is not { HasValue: true })
+        {
+            return;
+        }
+
+        foreach (InstalledBatteryEntity existingBattery in existingEntity.Value.ChildEntities.OfType<InstalledBatteryEntity>())
+        {
+            bool alreadyIncluded = pickedUpItem.ChildEntities
+                .OfType<InstalledBatteryEntity>()
+                .Any(incomingBattery =>
+                    incomingBattery.Id == existingBattery.Id ||
+                    incomingBattery.ComponentIndex == existingBattery.ComponentIndex);
+
+            if (!alreadyIncluded)
+            {
+                pickedUpItem.ChildEntities.Add(existingBattery);
+            }
+        }
     }
 
     private void StopTrackingExistingWorldEntity(NitroxId id)

--- a/Nitrox.Server.Subnautica/Nitrox.Server.Subnautica.csproj
+++ b/Nitrox.Server.Subnautica/Nitrox.Server.Subnautica.csproj
@@ -12,6 +12,9 @@
     <ItemGroup>
         <PackageReference Include="AssetsTools.NET" />
         <PackageReference Include="MagicOnion.Client" />
+        <PackageReference Include="Grpc.Core.Api" />
+        <PackageReference Include="Grpc.Net.Client" />
+        <PackageReference Include="Grpc.Net.Common" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="SixLabors.ImageSharp" />
         <PackageReference Include="ZLogger" />

--- a/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
+++ b/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
@@ -19,9 +19,10 @@ public static class BatteryChildEntityHelper
 {
     private static readonly Lazy<Entities> entities = new (() => NitroxServiceLocator.LocateService<Entities>());
 
-    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId)
+    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId, bool allowDefaultBattery = true)
     {
-        if (gameObject.TryGetComponent(out EnergyMixin energyMixin))
+        if (gameObject.TryGetComponent(out EnergyMixin energyMixin) &&
+            (allowDefaultBattery || energyMixin.batterySlot?.storedItem != null))
         {
             PopulateInstalledBattery(energyMixin, toPopulate, parentId);
         }

--- a/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
+++ b/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
@@ -21,7 +21,7 @@ public static class BatteryChildEntityHelper
 
     public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId)
     {
-        if (gameObject.TryGetComponent(out EnergyMixin energyMixin))
+        if (gameObject.TryGetComponent(out EnergyMixin energyMixin) && energyMixin.batterySlot?.storedItem != null)
         {
             PopulateInstalledBattery(energyMixin, toPopulate, parentId);
         }

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -236,7 +236,8 @@ public class Items
     /// </summary>
     private InventoryItemEntity ConvertToInventoryEntityUntracked(GameObject gameObject, NitroxId parentId)
     {
-        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager);
+        bool isExistingEntity = gameObject.TryGetNitroxId(out NitroxId existingId) && entities.IsKnownEntity(existingId);
+        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager, !isExistingEntity);
 
         // Some picked up entities are not known by the server for several reasons.  First it can be picked up via a spawn item command.  Another
         // example is that some obects are not 'real' objects until they are clicked and end up spawning a prefab.  For example, the fire extinguisher
@@ -251,7 +252,7 @@ public class Items
         return inventoryItemEntity;
     }
 
-    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager)
+    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery = true)
     {
         NitroxId itemId = NitroxEntity.GetIdOrGenerateNew(gameObject); // id may not exist, create if missing
         string classId = gameObject.RequireComponent<PrefabIdentifier>().ClassId;
@@ -260,7 +261,7 @@ public class Items
         List<Entity> children = GetPrefabChildren(gameObject, itemId, entityMetadataManager).ToList();
 
         InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), metadata.OrNull(), parentId, children);
-        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId);
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId, allowDefaultBattery);
 
         return inventoryItemEntity;
     }

--- a/NitroxClient/GameLogic/SimulationOwnership.cs
+++ b/NitroxClient/GameLogic/SimulationOwnership.cs
@@ -149,8 +149,9 @@ namespace NitroxClient.GameLogic
             {
                 return false;
             }
-            
+
             MovementReplicator movementReplicator = gameObject.GetComponent<MovementReplicator>();
+
             if (isLocalPlayerNewOwner)
             {
                 if (movementReplicator)
@@ -164,8 +165,13 @@ namespace NitroxClient.GameLogic
             {
                 if (!movementReplicator)
                 {
-                    MovementReplicator.AddReplicatorToObject(gameObject);
+                    movementReplicator = MovementReplicator.AddReplicatorToObject(gameObject);
                 }
+                else
+                {
+                    movementReplicator.ClearBuffer();
+                }
+
                 MovementBroadcaster.UnregisterWatched(entityId);
                 StopSimulatingEntity(entityId);
             }

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/ChatKeyBindingAction.cs
@@ -5,7 +5,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
 public class ChatKeyBindingAction : KeyBinding
 {
-    public ChatKeyBindingAction() : base("Nitrox_Settings_Keybind_OpenChat", "y") { }
+    public ChatKeyBindingAction() : base("Nitrox_Settings_Keybind_OpenChat", "y", "dpad/up") { }
 
     public override void Execute(InputAction.CallbackContext _)
     {

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/DiscordFocusBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/DiscordFocusBindingAction.cs
@@ -6,7 +6,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
 public class DiscordFocusBindingAction : KeyBinding
 {
-    public DiscordFocusBindingAction() : base("Nitrox_Settings_Keybind_FocusDiscord", "i") { }
+    public DiscordFocusBindingAction() : base("Nitrox_Settings_Keybind_FocusDiscord", "i", "dpad/down") { }
 
     public override void Execute(InputAction.CallbackContext _)
     {

--- a/NitroxClient/MonoBehaviours/MovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/MovementBroadcaster.cs
@@ -38,7 +38,7 @@ public class MovementBroadcaster : MonoBehaviour
 
     public void Update()
     {
-        float currentTime = (float)this.Resolve<TimeManager>().RealTimeElapsed;
+        float currentTime = Time.realtimeSinceStartup;
         if (currentTime < latestBroadcastTime + BROADCAST_PERIOD)
         {
             return;

--- a/NitroxClient/MonoBehaviours/MovementReplicator.cs
+++ b/NitroxClient/MonoBehaviours/MovementReplicator.cs
@@ -42,7 +42,7 @@ public abstract class MovementReplicator : MonoBehaviour
     /// <summary>
     /// Current time must be based on real time to avoid effects from time changes/speed.
     /// </summary>
-    private float CurrentTime => (float)this.Resolve<TimeManager>().RealTimeElapsed;
+    private float CurrentTime => Time.realtimeSinceStartup;
 
     public void AddSnapshot(MovementData movementData, float time)
     {
@@ -70,7 +70,7 @@ public abstract class MovementReplicator : MonoBehaviour
             }
         }
 
-        float occurrenceTime = time + INTERPOLATION_TIME + maxAllowedLatency;
+        float occurrenceTime = currentTime + INTERPOLATION_TIME;
 
         // Cleaning any previous value change that would occur later than the newly received snapshot
         while (buffer.Last != null && buffer.Last.Value.IsSnapshotNewer(occurrenceTime))
@@ -142,6 +142,16 @@ public abstract class MovementReplicator : MonoBehaviour
             buffer.RemoveFirst();
         }
 
+        // If we fall badly behind, don't replay hundreds of old vehicle snapshots.
+        // Keep only the latest small interpolation window so remote vehicles recover live instead of performing delayed catch-up.
+        if (buffer.Count > MovementBroadcaster.BROADCAST_FREQUENCY)
+        {
+            while (buffer.Count > 2)
+            {
+                buffer.RemoveFirst();
+            }
+        }
+
         LinkedListNode<Snapshot> firstNode = buffer.First;
         if (firstNode == null)
         {
@@ -177,7 +187,6 @@ public abstract class MovementReplicator : MonoBehaviour
         float t = (currentTime - firstNode.Value.Time) / (nextNode.Value.Time - firstNode.Value.Time);
 
         transform.position = Vector3.Lerp(prevData.Position.ToUnity(), nextData.Position.ToUnity(), t);
-
         transform.rotation = Quaternion.Lerp(prevData.Rotation.ToUnity(), nextData.Rotation.ToUnity(), t);
 
         ApplyNewMovementData(nextData);

--- a/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -9,21 +11,92 @@ using UnityEngine.InputSystem;
 namespace NitroxPatcher.Patches.Persistent;
 
 /// <summary>
-/// Inserts Nitrox's keybinds in the new Subnautica input system
+///     Inserts Nitrox's keybinds in the new Subnautica input system.
+///     Extends GameInput.AllActions so the game creates InputAction entries for Nitrox buttons,
+///     which is required for compatibility with Nautilus when both mods run together.
 /// </summary>
-public partial class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistentPatch
+public class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistentPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((GameInputSystem t) => t.Initialize());
+    private static readonly MethodInfo DEINITIALIZE_METHOD = Reflect.Method((GameInputSystem t) => t.Deinitialize());
+    private static GameInput.Button[] oldAllActions;
 
-    public static void Prefix(GameInputSystem __instance)
+    public override void Patch(Harmony harmony)
     {
-        CachedEnumString<GameInput.Button> actionNames = GameInput.ActionNames;
+        PatchPrefix(harmony, TARGET_METHOD, ((Action<GameInputSystem>)Prefix).Method);
+        PatchTranspiler(harmony, TARGET_METHOD, ((Func<IEnumerable<CodeInstruction>, IEnumerable<CodeInstruction>>)Transpiler).Method);
+        PatchPrefix(harmony, DEINITIALIZE_METHOD, ((Action)DeinitializePrefix).Method);
+    }
 
+    /// <summary>
+    ///     Set the actions callbacks for our own keybindings once they're actually created.
+    ///     If the game didn't create entries (e.g. when AllActions extension doesn't apply to this game version),
+    ///     we create and add the InputActions ourselves, matching Nautilus's approach.
+    /// </summary>
+    private static void RegisterKeybindsActions(GameInputSystem gameInputSystem)
+    {
         int buttonId = KeyBindingManager.NITROX_BASE_ID;
         foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
         {
             GameInput.Button button = (GameInput.Button)buttonId++;
+            if (!gameInputSystem.actions.TryGetValue(button, out InputAction action))
+            {
+                // Game didn't create this action (AllActions may not be used for action creation in this build).
+                // Create and add it ourselves, matching Nautilus's InitializePostfix pattern.
+                string buttonName = GameInput.ActionNames.valueToString.TryGetValue(button, out string name) ? name : button.ToString();
+                action = new InputAction(buttonName, InputActionType.Button);
+                if (!string.IsNullOrEmpty(keyBinding.DefaultKeyboardKey))
+                {
+                    action.AddBinding($"<Keyboard>/{keyBinding.DefaultKeyboardKey}");
+                }
+                if (!string.IsNullOrEmpty(keyBinding.DefaultControllerKey))
+                {
+                    action.AddBinding($"<Gamepad>/{keyBinding.DefaultControllerKey}");
+                }
+                gameInputSystem.actions[button] = action;
+                action.started += gameInputSystem.OnActionStarted;
+                action.Enable();
+            }
+            action.started += keyBinding.Execute;
+        }
+    }
+
+    private static void Prefix(GameInputSystem __instance)
+    {
+        int buttonId = KeyBindingManager.NITROX_BASE_ID;
+        oldAllActions = GameInput.AllActions;
+
+        // Only extend AllActions if Nitrox buttons aren't already present.
+        // AllActions is typically initialized from Enum.GetValues (patched by Enum_GetValues_Patch),
+        // so it may already contain Nitrox buttons. Adding them again would cause duplicate keybinds
+        // in the settings UI since the game builds the binding list from both sources.
+        if (!GameInput.AllActions.Any(b => (int)b >= buttonId && (int)b < buttonId + KeyBindingManager.KeyBindings.Count))
+        {
+            GameInputAccessor.AllActions =
+            [
+                .. GameInput.AllActions,
+                .. Enumerable.Range(buttonId, KeyBindingManager.KeyBindings.Count).Cast<GameInput.Button>()
+            ];
+        }
+
+        CachedEnumString<GameInput.Button> actionNames = GameInput.ActionNames;
+
+        // Access Language.main's internal strings dictionary so we can register "Option{buttonId}"
+        // entries for the binding conflict dialog (the game formats conflict messages using
+        // "Option" + button.ToString(), which yields "Option1000" for Nitrox buttons).
+        Dictionary<string, string> langStrings = null;
+        if (Language.main != null)
+        {
+            langStrings = (Dictionary<string, string>)AccessTools.Field(typeof(Language), "strings").GetValue(Language.main);
+        }
+
+        foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
+        {
+            GameInput.Button button = (GameInput.Button)buttonId++;
             actionNames.valueToString[button] = keyBinding.ButtonLabel;
+
+            // Register the "Option1000" style key so the conflict dialog shows the translated label
+            langStrings?.TryAdd($"Option{(int)button}", Language.main.Get(keyBinding.ButtonLabel));
 
             if (!string.IsNullOrEmpty(keyBinding.DefaultKeyboardKey))
             {
@@ -38,37 +111,38 @@ public partial class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistent
         }
     }
 
+    private static void DeinitializePrefix()
+    {
+        GameInputAccessor.AllActions = oldAllActions;
+    }
+
     /*
      * Modifying the actions must happen before actionMapGameplay.Enable because that line is responsible
      * for activating the actions callback we'll be setting
-     * 
+     *
      * GameInputSystem_Initialize_Patch.RegisterKeybindsActions(this); <--- [INSERTED LINE]
      * this.actionMapGameplay.Enable();
      */
-    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        return new CodeMatcher(instructions).MatchStartForward([
-                                                new(OpCodes.Ldarg_0),
-                                                new(OpCodes.Ldfld),
-                                                new(OpCodes.Callvirt, Reflect.Method((InputActionMap t) => t.Enable()))
-                                            ])
-                                            .Insert([
-                                                new CodeInstruction(OpCodes.Ldarg_0),
-                                                new CodeInstruction(OpCodes.Call, Reflect.Method(() => RegisterKeybindsActions(default)))
-                                            ])
+        return new CodeMatcher(instructions).MatchStartForward(new(OpCodes.Ldarg_0), new(OpCodes.Ldfld), new(OpCodes.Callvirt, Reflect.Method((InputActionMap t) => t.Enable())))
+                                            .Insert(new CodeInstruction(OpCodes.Ldarg_0), new CodeInstruction(OpCodes.Call, Reflect.Method(() => RegisterKeybindsActions(default))))
                                             .InstructionEnumeration();
     }
-    
-    /// <summary>
-    /// Set the actions callbacks for our own keybindings once they're actually created only
-    /// </summary>
-    public static void RegisterKeybindsActions(GameInputSystem gameInputSystem)
+
+    private static class GameInputAccessor
     {
-        int buttonId = KeyBindingManager.NITROX_BASE_ID;
-        foreach (KeyBinding keyBinding in KeyBindingManager.KeyBindings)
+        /// <summary>
+        ///     Required because "GameInput.AllActions" is a read only field.
+        /// </summary>
+        private static readonly FieldInfo allActionsField = Reflect.Field(() => GameInput.AllActions);
+
+        public static GameInput.Button[] AllActions
         {
-            GameInput.Button button = (GameInput.Button)buttonId++;
-            gameInputSystem.actions[button].started += keyBinding.Execute;
+            set
+            {
+                allActionsField.SetValue(null, value);
+            }
         }
     }
 }

--- a/NitroxPatcher/Patches/Persistent/uGUI_TabbedControlsPanel_AddBindingOption_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/uGUI_TabbedControlsPanel_AddBindingOption_Patch.cs
@@ -1,26 +1,45 @@
+using System;
 using System.Reflection;
+using NitroxClient.MonoBehaviours.Gui.Input;
 
 namespace NitroxPatcher.Patches.Persistent;
 
 /// <summary>
-/// Intercepts binding options created by Nitrox to remove the "Option" prefix given by <see cref="GameInputSystem.PopulateBindingSettings"/>
+/// Intercepts binding options created by Nitrox to use the proper label instead of "Option[ButtonID]".
+/// We modify the label by reference so the original method runs once with the correct display text,
+/// avoiding recursive calls to AddBindingOption which would break the uGUI_Bindings component.
 /// </summary>
 public partial class uGUI_TabbedControlsPanel_AddBindingOption_Patch : NitroxPatch, IPersistentPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_TabbedControlsPanel t) => t.AddBindingOption(default, default, default, default));
 
     private const string SUBNAUTICA_OPTION_PREFIX = "Option";
-    private const string DETECT_OPTION_PREFIX = "OptionNitrox";
 
-    public static bool Prefix(uGUI_TabbedControlsPanel __instance, int tabIndex, string label, GameInput.Device device, GameInput.Button button, ref uGUI_Bindings __result)
+    public static void Prefix(ref string label, GameInput.Button button)
     {
-        if (label.StartsWith(DETECT_OPTION_PREFIX))
+        try
         {
-            // Cut "Option" from the label
-            __result = __instance.AddBindingOption(tabIndex, label[SUBNAUTICA_OPTION_PREFIX.Length..], device, button);
-            return false;
-        }
+            // Check if this is a Nitrox button by its ID and translate the label
+            int buttonId = (int)button;
+            if (buttonId >= KeyBindingManager.NITROX_BASE_ID && buttonId < KeyBindingManager.NITROX_BASE_ID + KeyBindingManager.KeyBindings.Count)
+            {
+                if (GameInput.ActionNames.valueToString.TryGetValue(button, out string localizationKey))
+                {
+                    label = Language.main != null ? Language.main.Get(localizationKey) : localizationKey;
+                    return;
+                }
+            }
 
-        return true;
+            // Fallback: check for "OptionNitrox" prefix (label set by the game as "Option" + actionName)
+            if (label.StartsWith(SUBNAUTICA_OPTION_PREFIX + "Nitrox"))
+            {
+                string localizationKey = label[SUBNAUTICA_OPTION_PREFIX.Length..];
+                label = Language.main != null ? Language.main.Get(localizationKey) : localizationKey;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error in uGUI_TabbedControlsPanel_AddBindingOption_Patch");
+        }
     }
 }


### PR DESCRIPTION
## Purpose

This is a temporary integration/testing branch that combines the current active fixes from my fork into one build for anyone who wants to test them together before they are individually merged.

This PR is **not intended to replace the focused PRs**. The focused PRs remain the proper review/merge targets. This branch is only meant to make it easier for users and maintainers to test a practical build that includes the related fixes together.

## Included fixes

### #2749 - Fix Release launcher dependency loading from `lib`

Fixes Release launcher dependency loading so the packaged Release layout resolves assemblies consistently from the launcher-local dependency path.

This addresses Release-only issues such as:

- existing servers not appearing correctly in the launcher;
- new server creation/startup failures;
- runtime missing-method behavior caused by mismatched assembly resolution.

### #2740 - Restore Nautilus GameInput compatibility

Restores compatibility between Nitrox and Nautilus GameInput/keybind handling.

This addresses Nautilus-related issues such as:

- missing or broken keybind labels;
- GameInput/keybind patch conflicts;
- Nitrox/Nautilus compatibility failures that prevented a modded setup from reaching normal working gameplay.

### #2747 - Fix launcher server Stop command

Fixes the launcher Stop button path for external servers.

This addresses cases where the launcher sent the stop/quit command but the external server did not reliably receive or process it, causing the launcher to remain in a closing/stopping state.

### #2750 - Fix UwePrefab probability setter

Fixes the `UwePrefab` probability mutation issue during world/entity spawning.

This addresses server-side world-sync crashes where batch/entity spawning attempted to mutate `Probability` on `UwePrefab`, causing missing-method/runtime failures during multiplayer sync or additional cell/batch loading.

### #2752 - Fix batteryless tool battery duplication

Fixes the exploit where battery-powered tools could generate a new fully charged battery after being dropped and picked back up with no battery installed.

This also preserves correct behavior for:

- newly crafted/generated tools receiving their intended default battery;
- batteryless dropped tools remaining batteryless;
- dropped tools with installed batteries preserving those batteries and charge;
- multiplayer pickup where one player drops a tool with a battery and another player picks it up.

## Why this integration branch exists

Several of these fixes are easier to test together in a real modded Release setup than in isolation.

For example:

- the Release dependency-loading fix makes Release builds usable for server listing and creation;
- the Nautilus compatibility fix is needed for common modded setups;
- the Stop command fix makes the launcher/server loop more reliable during repeated testing;
- the UwePrefab and battery fixes address gameplay/runtime issues that are easier to validate once the Release launcher/server workflow is stable.

This branch gives testers one branch to pull while the individual PRs continue through normal focused review.

## Suggested testing

Recommended coverage:

- Build/run the launcher in Release.
- Confirm existing servers appear correctly.
- Confirm new server creation works.
- Confirm an external server starts from the launcher.
- Confirm the launcher Stop button gracefully shuts down the external server.
- Confirm Nautilus-dependent mods load correctly.
- Confirm GameInput/keybind labels and shortcuts behave correctly.
- Join multiplayer and complete initial sync.
- Travel far enough to trigger additional cell/batch loading without UwePrefab probability errors.
- Remove a battery from a battery-powered tool, drop it, and pick it back up.
- Confirm the batteryless tool remains batteryless.
- Craft a new battery-powered tool and confirm it still receives its intended default battery.
- Drop a tool with an installed battery and confirm another player can pick it up with that battery preserved.

## Notes

This branch is a convenience/testing branch only.

Once the individual PRs are merged into `master`, this integration branch can be deleted or rebased as needed.
