### PR TITLE
Fix batteryless tool battery duplication

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/PickupItemPacketProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/PickupItemPacketProcessor.cs
@@ -5,6 +5,7 @@ using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.GameLogic;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.Packets.Core;
+using System.Linq;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 
@@ -24,12 +25,37 @@ internal sealed class PickupItemPacketProcessor(EntityRegistry entityRegistry, W
             await context.SendToAllAsync(simulationOwnershipChange);
         }
 
+        PreserveExistingInstalledBatteries(id, packet.Item);
+
         StopTrackingExistingWorldEntity(id);
 
         entityRegistry.AddOrUpdate(packet.Item);
 
         // Have other players respawn the item inside the inventory.
         await context.SendToOthersAsync(new SpawnEntities(packet.Item, forceRespawn: true));
+    }
+
+    private void PreserveExistingInstalledBatteries(NitroxId id, InventoryItemEntity pickedUpItem)
+    {
+        Optional<Entity> existingEntity = entityRegistry.GetEntityById(id);
+        if (existingEntity is not { HasValue: true })
+        {
+            return;
+        }
+
+        foreach (InstalledBatteryEntity existingBattery in existingEntity.Value.ChildEntities.OfType<InstalledBatteryEntity>())
+        {
+            bool alreadyIncluded = pickedUpItem.ChildEntities
+                .OfType<InstalledBatteryEntity>()
+                .Any(incomingBattery =>
+                    incomingBattery.Id == existingBattery.Id ||
+                    incomingBattery.ComponentIndex == existingBattery.ComponentIndex);
+
+            if (!alreadyIncluded)
+            {
+                pickedUpItem.ChildEntities.Add(existingBattery);
+            }
+        }
     }
 
     private void StopTrackingExistingWorldEntity(NitroxId id)

--- a/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
+++ b/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
@@ -19,9 +19,10 @@ public static class BatteryChildEntityHelper
 {
     private static readonly Lazy<Entities> entities = new (() => NitroxServiceLocator.LocateService<Entities>());
 
-    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId)
+    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId, bool allowDefaultBattery = true)
     {
-        if (gameObject.TryGetComponent(out EnergyMixin energyMixin))
+        if (gameObject.TryGetComponent(out EnergyMixin energyMixin) &&
+            (allowDefaultBattery || energyMixin.batterySlot?.storedItem != null))
         {
             PopulateInstalledBattery(energyMixin, toPopulate, parentId);
         }

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -236,7 +236,8 @@ public class Items
     /// </summary>
     private InventoryItemEntity ConvertToInventoryEntityUntracked(GameObject gameObject, NitroxId parentId)
     {
-        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager);
+        bool isExistingEntity = gameObject.TryGetNitroxId(out NitroxId existingId) && entities.IsKnownEntity(existingId);
+        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager, !isExistingEntity);
 
         // Some picked up entities are not known by the server for several reasons.  First it can be picked up via a spawn item command.  Another
         // example is that some obects are not 'real' objects until they are clicked and end up spawning a prefab.  For example, the fire extinguisher
@@ -251,7 +252,7 @@ public class Items
         return inventoryItemEntity;
     }
 
-    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager)
+    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery = true)
     {
         NitroxId itemId = NitroxEntity.GetIdOrGenerateNew(gameObject); // id may not exist, create if missing
         string classId = gameObject.RequireComponent<PrefabIdentifier>().ClassId;
@@ -260,7 +261,7 @@ public class Items
         List<Entity> children = GetPrefabChildren(gameObject, itemId, entityMetadataManager).ToList();
 
         InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), metadata.OrNull(), parentId, children);
-        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId);
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId, allowDefaultBattery);
 
         return inventoryItemEntity;
     }


### PR DESCRIPTION
## Summary

Fixes an exploit where battery-powered tools regain a new fully charged battery after being dropped and picked back up with no battery installed.

Closes #2668.

## Background

Issue #2668 reports that battery-powered tools can duplicate batteries when dropped without an installed battery.

The repro is:

1. Use a battery-powered tool, such as a Scanner, Flashlight, Seaglide, etc.
2. Remove its battery.
3. Drop the batteryless tool.
4. Pick the tool back up.
5. The tool incorrectly has a new fully charged battery installed.

This allows players to repeatedly remove the newly created battery, drop the empty tool again, and generate unlimited fully charged batteries.

## Cause

Nitrox already has a dedicated installed-battery sync path. When a battery is installed into an `EnergyMixin`, Nitrox represents that installed battery as an `InstalledBatteryEntity`.

The broken behavior came from treating all battery-powered inventory conversion the same way.

There are actually three different cases that need different behavior:

- newly crafted/generated battery-powered tools should receive their intended default battery;
- existing dropped tools with no installed battery should preserve the empty battery slot;
- existing dropped tools with an installed battery should preserve that installed battery, including when a different player picks the tool up.

The original exploit happened because an existing dropped batteryless tool could be converted back into an inventory item and incorrectly receive a default installed battery.

A later multiplayer edge case also needed to be handled: when Player A drops a tool with a battery and Player B picks it up, Player B's client may not have that battery represented in the local `EnergyMixin.batterySlot.storedItem` at the exact moment the pickup conversion runs. However, the server-side entity state can still contain the correct `InstalledBatteryEntity`.

## What changed

This PR now handles battery state in both the client conversion path and the server pickup path.

### Client-side inventory conversion

`BatteryChildEntityHelper.TryPopulateInstalledBattery(...)` now accepts an `allowDefaultBattery` flag.

When converting newly created/generated items, default battery population is still allowed. This preserves normal crafting behavior.

When converting an already-known existing entity back into inventory, default battery creation is not blindly applied. In that case, the helper only creates a battery child from local slot state when an actual battery is present.

This prevents an existing batteryless dropped tool from being converted into an inventory item with a new default battery.

### Server-side pickup preservation

`PickupItemPacketProcessor` now preserves existing `InstalledBatteryEntity` children from the server's current entity state before replacing the dropped world entity with the picked-up `InventoryItemEntity`.

This protects the multiplayer case where one player drops a tool with an installed battery and another player picks it up. Even if the picking client does not locally serialize that installed battery child, the server carries forward the existing synced installed-battery child state.

## Why this approach

This keeps the fix narrow while preserving intended behavior.

The bug was not general battery charge serialization. Tools with installed batteries already had a sync representation through `InstalledBatteryEntity`.

The missing behavior was distinguishing between:

- a newly generated tool that should receive a default battery;
- an existing dropped tool that was intentionally batteryless;
- an existing dropped tool that already had a synced installed battery child.

By allowing default battery creation only where appropriate and preserving existing installed-battery children server-side during pickup, this avoids both the original battery-duplication exploit and the multiplayer pickup regression.

## Tested

Tested the original exploit path:

- Removed the battery from a battery-powered tool.
- Dropped the batteryless tool.
- Picked the tool back up.
- Confirmed the tool remained batteryless instead of receiving a new fully charged battery.

Regression tested crafting:

- Crafted a new battery-powered tool.
- Confirmed the newly crafted tool still receives its intended default battery.

Regression tested installed batteries:

- Dropped and picked up a tool with a partially charged battery installed.
- Confirmed the installed battery and charge were preserved.
- Dropped and picked up a tool with a full battery installed.
- Confirmed the installed battery remained installed and was not duplicated or replaced.

Regression tested multiplayer pickup:

- Player A dropped a tool with an installed battery.
- Player B picked up the dropped tool.
- Confirmed Player B received the tool with the installed battery preserved.
- Player A dropped a batteryless tool.
- Player B picked up the dropped tool.
- Confirmed Player B received the tool batteryless.
