### PR TITLE
Fix scanner room upgrades after base resync

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -157,7 +157,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     yield return entities.SpawnEntityAsync(baseLeakEntity, true);

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -58,7 +58,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -9,6 +9,7 @@ using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using NitroxClient.GameLogic.Helper;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Spawning.Bases;
@@ -169,7 +170,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         return interiorPiece;
     }
 
-    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity)
+    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity, Entities entities)
     {
         MapRoomFunctionality mapRoomFunctionality = @base.GetMapRoomFunctionalityForCell(mapRoomEntity.Cell.ToUnity());
         if (!mapRoomFunctionality)
@@ -178,5 +179,41 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
             yield break;
         }
         NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, mapRoomEntity.Id);
+        List<Entity> upgradeChips = mapRoomEntity.ChildEntities
+                                                 .OfType<InventoryItemEntity>()
+                                                 .ToList<Entity>();
+
+        if (upgradeChips.Count > 0) 
+        {
+            ClearMapRoomUpgradeContainer(mapRoomFunctionality);
+            
+            yield return entities.SpawnBatchAsync(upgradeChips, true);
+        }
+        
+    }
+    
+    private static void ClearMapRoomUpgradeContainer(MapRoomFunctionality mapRoomFunctionality)
+    {
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (!opContainer.HasValue)
+        {
+            Log.Error($"Couldn't find map room upgrade container on {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        ItemsContainer container = opContainer.Value;
+
+        List<Pickupable> pickupables = container._items.Values
+                                                .SelectMany(itemGroup => itemGroup.items)
+                                                .Select(item => item.item)
+                                                .Where(pickupable => pickupable)
+                                                .ToList();
+
+        foreach (Pickupable pickupable in pickupables)
+        {
+            NitroxEntity.RemoveFrom(pickupable.gameObject);
+            container.RemoveItem(pickupable, true);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2696

## Description of Change

Uses https://github.com/SubnauticaNitrox/Nitrox/pull/2746 and https://github.com/SubnauticaNitrox/Nitrox/pull/2719 as a basis to write a solution, taking the comments into account.
 
Scanner room upgrades are persisted as child `InventoryItemEntity` instances of `MapRoomEntity`, but the client restore path did not restore them idempotently.

This change restores scanner room upgrade children when restoring a map room and clears the existing local map room upgrade container first, preventing duping chips with base re-syncs.

## Tested (Windows only)

- re-login
- server restart
- forced base re-sync
- tested with 0, 1, 2, 3, and 4 chips present

Result: expected number of upgrades was found in every scenario.