### PR TITLE
Fix #2698: add circuit breaker to NTP sync to stop offline log spam

### DIFF
--- a/Nitrox.Model/Networking/CircuitBreaker.cs
+++ b/Nitrox.Model/Networking/CircuitBreaker.cs
@@ -1,0 +1,59 @@
+namespace Nitrox.Model.Networking;
+
+/// <summary>
+///     Minimal circuit breaker that counts consecutive failures and "opens" once a threshold is reached,
+///     signalling callers to back off. A single success closes it again.
+/// </summary>
+/// <remarks>
+///     Timing (how long to stay open, when to probe again) is intentionally left to the caller so this type
+///     stays free of timers and trivially testable. Thread-safe so it can be shared across the retry timer
+///     and network callback threads.
+/// </remarks>
+public sealed class CircuitBreaker(int failureThreshold)
+{
+    private readonly object gate = new();
+    private int consecutiveFailures;
+
+    public bool IsOpen
+    {
+        get
+        {
+            lock (gate)
+            {
+                return consecutiveFailures >= failureThreshold;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Resets the failure count, closing the breaker.
+    /// </summary>
+    public void RecordSuccess()
+    {
+        lock (gate)
+        {
+            consecutiveFailures = 0;
+        }
+    }
+
+    /// <summary>
+    ///     Records a failure.
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true" /> only on the failure that opens the breaker (i.e. the threshold is reached
+    ///     exactly now), so callers can react once. Subsequent failures while already open return
+    ///     <see langword="false" />.
+    /// </returns>
+    public bool RecordFailure()
+    {
+        lock (gate)
+        {
+            if (consecutiveFailures >= failureThreshold)
+            {
+                return false;
+            }
+            consecutiveFailures++;
+            return consecutiveFailures >= failureThreshold;
+        }
+    }
+}

--- a/Nitrox.Model/Networking/NtpSyncer.cs
+++ b/Nitrox.Model/Networking/NtpSyncer.cs
@@ -40,6 +40,12 @@ public sealed class NtpSyncer
         }
         DisposeCallback = finishCallback;
 
+        // Reset completion state so the syncer can be reused for retry rounds. Without this, a previous
+        // Complete() leaves IsComplete latched true, so subsequent Complete() calls become no-ops and never
+        // invoke the finish callback (and the old 'ntp' NetManager would leak instead of being disposed).
+        IsComplete = false;
+        OnlineMode = false;
+
         ntp = new(TreatPacket);
 
         timer = new(TIMEOUT_INTERVAL) { AutoReset = false };
@@ -69,7 +75,8 @@ public sealed class NtpSyncer
         }
         catch (Exception ex)
         {
-            logger.LogError($"An error occurred during NTP sync sequence with '{ntp.LatestUsedService}', retrying with another one... ({ex.GetType()}: {ex.Message})");
+            // Failing over to the next service is normal (e.g. offline/LAN servers), so this is not an error.
+            logger.LogDebug($"An error occurred during NTP sync sequence with '{ntp.LatestUsedService}', retrying with another one... ({ex.GetType()}: {ex.Message})");
             timer.Stop();
             RequestNtpService();
         }
@@ -110,7 +117,8 @@ public sealed class NtpSyncer
         }
         else
         {
-            logger.LogError($"NTP request error at {ntp.LatestUsedService}, retrying with another service...");
+            // Failing over to the next service is normal (e.g. offline/LAN servers), so this is not an error.
+            logger.LogDebug($"NTP request error at {ntp.LatestUsedService}, retrying with another service...");
             RequestNtpService();
         }
     }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
@@ -31,6 +31,18 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
     /// </summary>
     private const int NTP_RETRY_INTERVAL_SECONDS = 60;
 
+    /// <summary>
+    ///     Number of consecutive failed retry rounds before the circuit breaker opens and we assume there is
+    ///     no NTP connectivity (e.g. an offline/LAN server).
+    /// </summary>
+    private const int NTP_FAILURE_THRESHOLD = 3;
+
+    /// <summary>
+    ///     Retry interval in seconds used once the circuit breaker has opened. Slows futile attempts right down
+    ///     while still acting as a half-open probe so the server recovers if it later gains connectivity.
+    /// </summary>
+    private const int NTP_OFFLINE_RETRY_INTERVAL_SECONDS = 1800;
+
     private readonly ILogger<TimeService> logger = logger;
     private readonly ILoggerFactory loggerFactory = loggerFactory;
 
@@ -179,6 +191,7 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
 
     private void StartNtpTimer()
     {
+        CircuitBreaker circuitBreaker = new(NTP_FAILURE_THRESHOLD);
         Timer retryTimer = new(TimeSpan.FromSeconds(NTP_RETRY_INTERVAL_SECONDS).TotalMilliseconds)
         {
             AutoReset = true,
@@ -191,7 +204,17 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
             {
                 if (onlineMode)
                 {
+                    circuitBreaker.RecordSuccess();
                     retryTimer.Close();
+                    return;
+                }
+
+                // After enough consecutive failures, assume there's no NTP connectivity (e.g. an offline/LAN
+                // server) and slow the retries right down so we stop wasting resources and log lines.
+                if (circuitBreaker.RecordFailure())
+                {
+                    retryTimer.Interval = TimeSpan.FromSeconds(NTP_OFFLINE_RETRY_INTERVAL_SECONDS).TotalMilliseconds;
+                    logger.ZLogInformation($"Could not reach any NTP server after {NTP_FAILURE_THRESHOLD} attempts; assuming no internet connection and slowing NTP retries to every {NTP_OFFLINE_RETRY_INTERVAL_SECONDS}s. This is expected on offline/LAN servers.");
                 }
             }, loggerFactory.CreateLogger<NtpSyncer>());
             ntpSyncer.RequestNtpService();

--- a/Nitrox.Test/Model/Networking/CircuitBreakerTest.cs
+++ b/Nitrox.Test/Model/Networking/CircuitBreakerTest.cs
@@ -1,0 +1,42 @@
+namespace Nitrox.Model.Networking;
+
+[TestClass]
+public class CircuitBreakerTest
+{
+    [TestMethod]
+    public void OpensExactlyWhenThresholdIsReached()
+    {
+        CircuitBreaker breaker = new(3);
+
+        breaker.IsOpen.Should().BeFalse();
+        breaker.RecordFailure().Should().BeFalse(); // 1
+        breaker.RecordFailure().Should().BeFalse(); // 2
+        breaker.IsOpen.Should().BeFalse();
+        breaker.RecordFailure().Should().BeTrue();  // 3 -> opens
+        breaker.IsOpen.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ReportsTheOpeningTransitionOnlyOnce()
+    {
+        CircuitBreaker breaker = new(1);
+
+        breaker.RecordFailure().Should().BeTrue();  // opens
+        breaker.RecordFailure().Should().BeFalse(); // already open, no second transition
+        breaker.RecordFailure().Should().BeFalse();
+        breaker.IsOpen.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void SuccessClosesTheBreakerAndResetsTheCount()
+    {
+        CircuitBreaker breaker = new(2);
+
+        breaker.RecordFailure().Should().BeFalse(); // 1
+        breaker.RecordSuccess();                    // back to 0
+        breaker.RecordFailure().Should().BeFalse(); // 1 again, still closed
+        breaker.IsOpen.Should().BeFalse();
+        breaker.RecordFailure().Should().BeTrue();  // 2 -> opens
+        breaker.IsOpen.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2698

## Description of Change

When a server runs without internet access (e.g. on a LAN), `NtpSyncer` retried all 6 NTP services every 60 seconds indefinitely, logging an error for each failed service. That spams the server logs forever.

This adds a circuit-breaker policy and fixes the underlying retry behavior. Three related changes:

1. **`NtpSyncer` — failover logs demoted to `Debug`.** Failing over between NTP services is normal operation (especially offline), not an error, so the two per-service `LogError` calls are now `LogDebug`. This removes the spam from production (`Info`+) logs entirely.

2. **`NtpSyncer.Setup` now resets `IsComplete`/`OnlineMode`.** This is the key fix: `Complete()` latched `IsComplete = true`, and `Setup()` never reset it. So after the first sequence completed, every subsequent `Complete()` on a retry round was a no-op — the finish callback was never invoked again, and the previous round's `NetManager` (`ntp`) leaked instead of being disposed. Resetting in `Setup` makes the syncer genuinely reusable across retry rounds (which `TimeService` already relied on).

3. **`TimeService` drives retries through a new `CircuitBreaker`.** After 3 consecutive failed rounds it logs a single informative line and widens the retry interval from 60s to 30min. The long interval doubles as a half-open probe, so the server still recovers automatically if it later gains connectivity — it just stops wasting resources and log lines while offline.

Adds `CircuitBreaker` (`Nitrox.Model.Networking`) — a small, thread-safe, timer-free failure counter — with unit tests.

## Validation

Tested locally on Windows, Nitrox InDev master:

1. Started a server with **no internet connection**.
2. Confirmed the NTP failover lines are now `Debug` level (gone from default `Info` logs).
3. Confirmed that after 3 failed rounds (~3 minutes) a single line appears:
   `Could not reach any NTP server after 3 attempts; assuming no internet connection and slowing NTP retries to every 1800s. This is expected on offline/LAN servers.`
4. Confirmed the retry cadence then drops from every 60s to every 30 min.

`CircuitBreaker` is covered by unit tests (`PatchesTranspilerTest`-style sanity is N/A; see `Nitrox.Test/Model/Networking/CircuitBreakerTest.cs`): opens exactly at the threshold, reports the opening transition once, and resets on success.

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [x] Has tests for the changes (`CircuitBreakerTest`)
- [x] Has a linked issue (#2698)
- [x] Has been tested in-game (server run offline)
- [ ] Has been tested on Windows/Linux/macOS (Windows only)

---

🤖 This code was created with the help of AI.
