### PR TITLE
Fix scanner room upgrade sync and persistence

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -157,7 +157,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     yield return entities.SpawnEntityAsync(baseLeakEntity, true);

--- a/NitroxClient/GameLogic/Bases/BuildUtils.cs
+++ b/NitroxClient/GameLogic/Bases/BuildUtils.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
-using NitroxClient.GameLogic.Settings;
-using NitroxClient.GameLogic.Spawning.Bases;
-using NitroxClient.GameLogic.Spawning.Metadata;
-using NitroxClient.MonoBehaviours;
+using System.Linq;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.Settings;
+using NitroxClient.GameLogic.Spawning.Bases;
+using NitroxClient.GameLogic.Spawning.Metadata;
+using NitroxClient.MonoBehaviours;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases;
@@ -160,14 +162,23 @@ public static class BuildUtils
         if (isMapRoomGhost)
         {
             MapRoomFunctionality mapRoomFunctionality = baseGhost.targetBase.GetMapRoomFunctionalityForCell(face.Value.cell);
+            bool hasParentBase = constructableBase.GetComponentInParent<Base>(true);
+
+            if (!mapRoomFunctionality)
+            {
+                mapRoomFunctionality = FindUnregisteredMapRoomFunctionality(baseGhost.targetBase);
+            }
+
             if (mapRoomFunctionality)
             {
                 // As MapRooms can be built as the first piece of a base, we need to make sure that they receive a new id if they're not in a base
-                NitroxId nitroxId = constructableBase.GetComponentInParent<Base>(true) ? id : id.Increment();
+                NitroxId nitroxId = hasParentBase ? id : id.Increment();         
+                
                 NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, nitroxId);
-                moduleObject = mapRoomFunctionality.gameObject;
+                moduleObject = mapRoomFunctionality.gameObject;                
                 return true;
             }
+
             Log.Error($"Couldn't find MapRoomFunctionality of built MapRoom (cell: {face.Value.cell})");
             moduleObject = null;
             return false;
@@ -223,10 +234,55 @@ public static class BuildUtils
         return baseGhost.targetBase.NormalizeCell(baseGhost.targetBase.WorldToGrid(baseGhost.ghostBase.occupiedBounds.center));
     }
 
-    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId)
+    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId, EntityMetadataManager entityMetadataManager)
     {
         Int3 mapRoomCell = @base.NormalizeCell(@base.WorldToGrid(mapRoomFunctionality.transform.position));
-        return new(id, parentId, mapRoomCell.ToDto());
+        MapRoomEntity mapRoomEntity = new(id, parentId, mapRoomCell.ToDto());
+
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (opContainer.HasValue)
+        {
+            ItemsContainer container = opContainer.Value;
+
+            List<Pickupable> pickupables = container._items.Values
+                                                 .SelectMany(itemGroup => itemGroup.items)
+                                                 .Select(item => item.item)
+                                                 .Where(pickupable => pickupable)
+                                                 .ToList();
+
+            foreach (Pickupable pickupable in pickupables)
+            {
+                mapRoomEntity.ChildEntities.Add(Items.ConvertToInventoryItemEntity(pickupable.gameObject, id, entityMetadataManager));
+            }
+        }
+        else
+        {
+            Log.Warn($"Could not find scanner room upgrade container for {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return mapRoomEntity;
+    }
+
+    private static MapRoomFunctionality FindUnregisteredMapRoomFunctionality(Base targetBase)
+    {
+        List<MapRoomFunctionality> candidates = targetBase.GetComponentsInChildren<MapRoomFunctionality>(true)
+                                                          .Where(mapRoomFunctionality => !mapRoomFunctionality.TryGetNitroxId(out _))
+                                                          .ToList();
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        Log.Warn($"Could not uniquely identify unregistered MapRoomFunctionality under {targetBase.gameObject.GetFullHierarchyPath()}. Found {candidates.Count} candidates.");
+
+        foreach (MapRoomFunctionality candidate in candidates)
+        {
+            Log.Warn($"Unregistered MapRoomFunctionality candidate: {candidate.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return null;
     }
 
     // TODO: Use this for a latter singleplayer save converter
@@ -270,7 +326,7 @@ public static class BuildUtils
                 {
                     continue;
                 }
-                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId));
+                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId, entityMetadataManager));
             }
             else if (transform.TryGetComponent(out IBaseModule baseModule))
             {

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -58,7 +58,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
@@ -169,7 +170,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         return interiorPiece;
     }
 
-    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity)
+    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity, Entities entities)
     {
         MapRoomFunctionality mapRoomFunctionality = @base.GetMapRoomFunctionalityForCell(mapRoomEntity.Cell.ToUnity());
         if (!mapRoomFunctionality)
@@ -177,6 +178,43 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
             Log.Error($"Couldn't find MapRoomFunctionality in base for cell {mapRoomEntity.Cell}");
             yield break;
         }
+
         NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, mapRoomEntity.Id);
+
+        List<Entity> upgradeChips = mapRoomEntity.ChildEntities
+                                                 .OfType<InventoryItemEntity>()
+                                                 .ToList<Entity>();
+
+        if (upgradeChips.Count > 0)
+        {
+            ClearMapRoomUpgradeContainer(mapRoomFunctionality);
+            yield return entities.SpawnBatchAsync(upgradeChips, true);
+        }
     }
+
+    private static void ClearMapRoomUpgradeContainer(MapRoomFunctionality mapRoomFunctionality)
+    {
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (!opContainer.HasValue)
+        {
+            Log.Error($"Couldn't find map room upgrade container on {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        ItemsContainer container = opContainer.Value;
+
+        List<Pickupable> pickupables = container._items.Values
+                                              .SelectMany(itemGroup => itemGroup.items)
+                                              .Select(item => item.item)
+                                              .Where(pickupable => pickupable)
+                                              .ToList();
+
+        foreach (Pickupable pickupable in pickupables)
+        {
+            NitroxEntity.RemoveFrom(pickupable.gameObject);
+            container.RemoveItem(pickupable, true);
+        }
+    }
+
 }

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -160,7 +160,7 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
                 }
                 else if (moduleObject.TryGetComponent(out MapRoomFunctionality mapRoomFunctionality))
                 {
-                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId);
+                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId, Resolve<EntityMetadataManager>());
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes scanner room upgrade sync and persistence.

Fixes #2696.
Contributes to #2410.

## Problem

Scanner room upgrade modules were not reliably synced across clients.

There were two related problems:

1. During live scanner room construction, the scanner room `MapRoomFunctionality` could fail to receive the same Nitrox ID on all clients.
2. Scanner room upgrade modules were not reliably persisted/restored as scanner room child entities across server restart/rejoin.

The live-sync failure caused the upgrade reparent packet to target a parent/container ID that did not exist on the other client. The result was that Player 1 could install a scanner room upgrade, but Player 2 would not see it visually or in the scanner room upgrade inventory.

The persistence failure caused installed scanner room upgrades to disappear after server restart/rejoin.

## What changed

This PR fixes both the live-sync and persistence paths.

### Live scanner room ID sync

When a scanner room is built, the client normally tries to find the new `MapRoomFunctionality` by cell. In the live multiplayer build path, that cell lookup can fail on other clients even though the scanner room object exists locally.

This PR adds a fallback for that case:

- if the cell lookup fails,
- and there is exactly one unregistered `MapRoomFunctionality` under the target base,
- assign the shared scanner room Nitrox ID to that object.

That ensures the scanner room upgrade inventory owner/container exists under the same ID on all clients before upgrade reparent packets arrive.

### Upgrade persistence

This PR also persists installed scanner room upgrades as child `InventoryItemEntity` entries on the `MapRoomEntity`.

On restore/resync:

- the scanner room receives its saved Nitrox ID;
- existing local scanner room upgrade container contents are cleared;
- saved upgrade chip child entities are spawned back into the scanner room upgrade container.

This makes installed scanner room upgrades survive restart/rejoin.

## Relationship to #2755

This PR uses the same general restore/resync idea from #2755 for scanner room upgrade chips, but also fixes the live first-time scanner room ID mismatch that caused upgrade reparenting to fail before rejoin/resync.

With this change, scanner room upgrades synced correctly immediately when installed, and also persisted correctly after server restart/rejoin.

## Testing

Tested with two players connected.

### Live sync test

1. Player 1 built a scanner room while Player 2 was present.
2. Player 1 installed a scanner room upgrade.
3. Player 2 immediately saw the installed module.
4. Player 2 could also see the installed module in the scanner room upgrade inventory.

Result: passed.

### Persistence test

1. Scanner room upgrade was left installed.
2. Both players logged out.
3. Server was stopped.
4. Server was restarted.
5. Both players rejoined.

Result: the scanner room upgrade was still installed and visible to both players.

### Additional observation

This fixes scanner room upgrade live sync and persistence. Broader scanner room behavior under #2410 is still not fully synced yet, including scan target/state, scanner room fabricator activity, animations/graphics, and camera-related behavior. Those should be handled separately after the scanner room identity/persistence foundation is correct.
