### PR TITLE
Fix scanner room fabricator sync

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -157,7 +157,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     yield return entities.SpawnEntityAsync(baseLeakEntity, true);

--- a/NitroxClient/GameLogic/Bases/BuildUtils.cs
+++ b/NitroxClient/GameLogic/Bases/BuildUtils.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
-using NitroxClient.GameLogic.Settings;
-using NitroxClient.GameLogic.Spawning.Bases;
-using NitroxClient.GameLogic.Spawning.Metadata;
-using NitroxClient.MonoBehaviours;
+using System.Linq;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.Settings;
+using NitroxClient.GameLogic.Spawning.Bases;
+using NitroxClient.GameLogic.Spawning.Metadata;
+using NitroxClient.MonoBehaviours;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases;
@@ -160,14 +162,23 @@ public static class BuildUtils
         if (isMapRoomGhost)
         {
             MapRoomFunctionality mapRoomFunctionality = baseGhost.targetBase.GetMapRoomFunctionalityForCell(face.Value.cell);
+            bool hasParentBase = constructableBase.GetComponentInParent<Base>(true);
+
+            if (!mapRoomFunctionality)
+            {
+                mapRoomFunctionality = FindUnregisteredMapRoomFunctionality(baseGhost.targetBase);
+            }
+
             if (mapRoomFunctionality)
             {
                 // As MapRooms can be built as the first piece of a base, we need to make sure that they receive a new id if they're not in a base
-                NitroxId nitroxId = constructableBase.GetComponentInParent<Base>(true) ? id : id.Increment();
+                NitroxId nitroxId = hasParentBase ? id : id.Increment();         
+                
                 NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, nitroxId);
-                moduleObject = mapRoomFunctionality.gameObject;
+                moduleObject = mapRoomFunctionality.gameObject;                
                 return true;
             }
+
             Log.Error($"Couldn't find MapRoomFunctionality of built MapRoom (cell: {face.Value.cell})");
             moduleObject = null;
             return false;
@@ -223,10 +234,55 @@ public static class BuildUtils
         return baseGhost.targetBase.NormalizeCell(baseGhost.targetBase.WorldToGrid(baseGhost.ghostBase.occupiedBounds.center));
     }
 
-    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId)
+    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId, EntityMetadataManager entityMetadataManager)
     {
         Int3 mapRoomCell = @base.NormalizeCell(@base.WorldToGrid(mapRoomFunctionality.transform.position));
-        return new(id, parentId, mapRoomCell.ToDto());
+        MapRoomEntity mapRoomEntity = new(id, parentId, mapRoomCell.ToDto());
+
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (opContainer.HasValue)
+        {
+            ItemsContainer container = opContainer.Value;
+
+            List<Pickupable> pickupables = container._items.Values
+                                                 .SelectMany(itemGroup => itemGroup.items)
+                                                 .Select(item => item.item)
+                                                 .Where(pickupable => pickupable)
+                                                 .ToList();
+
+            foreach (Pickupable pickupable in pickupables)
+            {
+                mapRoomEntity.ChildEntities.Add(Items.ConvertToInventoryItemEntity(pickupable.gameObject, id, entityMetadataManager));
+            }
+        }
+        else
+        {
+            Log.Warn($"Could not find scanner room upgrade container for {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return mapRoomEntity;
+    }
+
+    private static MapRoomFunctionality FindUnregisteredMapRoomFunctionality(Base targetBase)
+    {
+        List<MapRoomFunctionality> candidates = targetBase.GetComponentsInChildren<MapRoomFunctionality>(true)
+                                                          .Where(mapRoomFunctionality => !mapRoomFunctionality.TryGetNitroxId(out _))
+                                                          .ToList();
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        Log.Warn($"Could not uniquely identify unregistered MapRoomFunctionality under {targetBase.gameObject.GetFullHierarchyPath()}. Found {candidates.Count} candidates.");
+
+        foreach (MapRoomFunctionality candidate in candidates)
+        {
+            Log.Warn($"Unregistered MapRoomFunctionality candidate: {candidate.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return null;
     }
 
     // TODO: Use this for a latter singleplayer save converter
@@ -270,7 +326,7 @@ public static class BuildUtils
                 {
                     continue;
                 }
-                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId));
+                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId, entityMetadataManager));
             }
             else if (transform.TryGetComponent(out IBaseModule baseModule))
             {

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -58,7 +58,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
@@ -169,7 +170,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         return interiorPiece;
     }
 
-    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity)
+    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity, Entities entities)
     {
         MapRoomFunctionality mapRoomFunctionality = @base.GetMapRoomFunctionalityForCell(mapRoomEntity.Cell.ToUnity());
         if (!mapRoomFunctionality)
@@ -177,6 +178,43 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
             Log.Error($"Couldn't find MapRoomFunctionality in base for cell {mapRoomEntity.Cell}");
             yield break;
         }
+
         NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, mapRoomEntity.Id);
+
+        List<Entity> upgradeChips = mapRoomEntity.ChildEntities
+                                                 .OfType<InventoryItemEntity>()
+                                                 .ToList<Entity>();
+
+        if (upgradeChips.Count > 0)
+        {
+            ClearMapRoomUpgradeContainer(mapRoomFunctionality);
+            yield return entities.SpawnBatchAsync(upgradeChips, true);
+        }
     }
+
+    private static void ClearMapRoomUpgradeContainer(MapRoomFunctionality mapRoomFunctionality)
+    {
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (!opContainer.HasValue)
+        {
+            Log.Error($"Couldn't find map room upgrade container on {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        ItemsContainer container = opContainer.Value;
+
+        List<Pickupable> pickupables = container._items.Values
+                                              .SelectMany(itemGroup => itemGroup.items)
+                                              .Select(item => item.item)
+                                              .Where(pickupable => pickupable)
+                                              .ToList();
+
+        foreach (Pickupable pickupable in pickupables)
+        {
+            NitroxEntity.RemoveFrom(pickupable.gameObject);
+            container.RemoveItem(pickupable, true);
+        }
+    }
+
 }

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -160,7 +160,7 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
                 }
                 else if (moduleObject.TryGetComponent(out MapRoomFunctionality mapRoomFunctionality))
                 {
-                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId);
+                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId, Resolve<EntityMetadataManager>());
                 }
             }
 

--- a/NitroxPatcher/Patches/Dynamic/CrafterLogic_NotifyPickup_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CrafterLogic_NotifyPickup_Patch.cs
@@ -17,7 +17,7 @@ public sealed partial class CrafterLogic_NotifyPickup_Patch : NitroxPatch, IDyna
     public static void Prefix(CrafterLogic __instance)
     {
         // See GhostCrafter_OnCraftingBegin_Patch.Postfix to know why we get NitroxId on CrafterLogic
-        if (__instance.TryGetIdOrWarn(out NitroxId crafterId))
+        if (TryGetCrafterSyncId(__instance, out NitroxId crafterId))
         {
             // Below code is adapted from CrafterLogic.TryPickupAsync
 
@@ -50,5 +50,16 @@ public sealed partial class CrafterLogic_NotifyPickup_Patch : NitroxPatch, IDyna
         }
 
         // The Pickup() item codepath will inform the server that the item was added to the inventory.
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingBegin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingBegin_Patch.cs
@@ -18,7 +18,7 @@ public sealed partial class GhostCrafter_OnCraftingBegin_Patch : NitroxPatch, ID
         // on the CrafterLogic only. On every other crafter type, both CrafterLogic and GhostCrafter are on the same object.
 
         // Also for base upgrade console module, crafterLogic is nullified and never updated, so we use _logic instead for every crafter
-        if (__instance._logic.TryGetIdOrWarn(out NitroxId crafterLogicId))
+        if (TryGetCrafterSyncId(__instance._logic, out NitroxId crafterLogicId))
         {
             Resolve<Entities>().BroadcastMetadataUpdate(crafterLogicId, new CrafterMetadata(techType.ToDto(), DayNightCycle.main.timePassedAsFloat, duration, __instance._logic.numCrafted, __instance._logic.linkedIndex));
 
@@ -26,5 +26,16 @@ public sealed partial class GhostCrafter_OnCraftingBegin_Patch : NitroxPatch, ID
             // but will require redoing our hooks.
             Resolve<SimulationOwnership>().RequestSimulationLock(crafterLogicId, SimulationLockType.EXCLUSIVE);
         }
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingEnd_Patch.cs
@@ -18,7 +18,7 @@ public sealed partial class GhostCrafter_OnCraftingEnd_Patch : NitroxPatch, IDyn
         // the crafting player will intiate a lock request when pushing the craft button - OnCraftingStart().
 
         // See GhostCrafter_OnCraftingBegin_Patch.Postfix to know why we get NitroxId on CrafterLogic
-        if (__instance._logic.TryGetIdOrWarn(out NitroxId id) && Resolve<SimulationOwnership>().HasExclusiveLock(id))
+        if (TryGetCrafterSyncId(__instance._logic, out NitroxId id) && Resolve<SimulationOwnership>().HasExclusiveLock(id))
         {
             // once an item is crafted, we no longer require an exclusive lock.
             Resolve<SimulationOwnership>().RequestSimulationLock(id, SimulationLockType.TRANSIENT);
@@ -27,5 +27,16 @@ public sealed partial class GhostCrafter_OnCraftingEnd_Patch : NitroxPatch, IDyn
         }
 
         return false;
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }


### PR DESCRIPTION
## Summary

Fixes scanner room fabricator sync.

Depends on #2758.
Contributes to #2410.

## Problem

The normal fabricator sync path works because normal fabricators have a shared Nitrox ID that can be used for crafting metadata updates.

The scanner room fabricator did not sync because its `CrafterLogic` did not have a reliable shared Nitrox ID. As a result, crafting from the scanner room fabricator only appeared on the crafting player's client. Other players did not see the crafting animation, the finished product, or visible fabricator activity.

## What changed

Scanner room fabricator crafting now uses the parent scanner room `MapRoomFunctionality` Nitrox ID as its crafter sync ID.

For normal fabricators, behavior is unchanged: they continue to use the `CrafterLogic` object's own Nitrox ID.

For scanner room fabricators:

- the crafter patches detect when the `CrafterLogic` is under a `MapRoomFunctionality`;
- if so, they use the parent scanner room's shared Nitrox ID;
- existing crafter metadata sync then applies the crafting state to the `CrafterLogic` found under that scanner room.

This avoids introducing a separate child entity just for the scanner room fabricator and reuses the scanner room identity established by #2758.

## Why this depends on #2758

This fix relies on all clients having the same `MapRoomFunctionality` Nitrox ID for the scanner room.

That scanner room ID consistency is fixed by #2758. Without that foundation, the scanner room fabricator would not have a reliable shared parent ID to use for metadata sync.

## Testing

Tested with two players connected.

1. Player 1 crafted a scanner room camera from the scanner room fabricator.
2. Player 2 saw the fabricator activity/product.
3. Player 2 crafted from the scanner room fabricator.
4. Player 1 saw the fabricator activity/product.

Result: scanner room fabricator crafting synced correctly from both sides.

## Remaining scanner room work

This PR only fixes scanner room fabricator crafting sync.

Broader scanner room sync work under #2410 still remains.
