### PR TITLE
Fix scanner room scan state sync

### DIFF
--- a/Nitrox.Model.Subnautica/Packets/MapRoomScanChanged.cs
+++ b/Nitrox.Model.Subnautica/Packets/MapRoomScanChanged.cs
@@ -1,0 +1,18 @@
+using System;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public class MapRoomScanChanged : Packet
+{
+    public NitroxId MapRoomId { get; }
+    public string TechType { get; }
+
+    public MapRoomScanChanged(NitroxId mapRoomId, string techType)
+    {
+        MapRoomId = mapRoomId;
+        TechType = techType;
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -157,7 +157,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     yield return entities.SpawnEntityAsync(baseLeakEntity, true);

--- a/NitroxClient/Communication/Packets/Processors/MapRoomScanChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/MapRoomScanChangedProcessor.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading.Tasks;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+internal sealed class MapRoomScanChangedProcessor : IClientPacketProcessor<MapRoomScanChanged>
+{
+    public Task Process(ClientProcessorContext context, MapRoomScanChanged packet)
+    {
+        if (!NitroxEntity.TryGetObjectFrom(packet.MapRoomId, out GameObject mapRoomObject))
+        {
+            Log.Warn($"Could not find MapRoomFunctionality for scanner room scan change: {packet.MapRoomId}");
+            return Task.CompletedTask;
+        }
+
+        MapRoomFunctionality mapRoomFunctionality = mapRoomObject.GetComponent<MapRoomFunctionality>();
+        if (!mapRoomFunctionality)
+        {
+            Log.Warn($"Object for scanner room scan change did not have MapRoomFunctionality: {mapRoomObject.GetFullHierarchyPath()}");
+            return Task.CompletedTask;
+        }
+
+        if (!Enum.TryParse(packet.TechType, out TechType techType))
+        {
+            Log.Warn($"Could not parse scanner room scan TechType: {packet.TechType}");
+            return Task.CompletedTask;
+        }
+
+        using (PacketSuppressor<MapRoomScanChanged>.Suppress())
+        {
+            mapRoomFunctionality.StartScanning(techType);
+            RefreshMapRoomScannerUi(mapRoomFunctionality, techType);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void RefreshMapRoomScannerUi(MapRoomFunctionality mapRoomFunctionality, TechType techType)
+    {
+        if (!mapRoomFunctionality.screenRoot)
+        {
+            return;
+        }
+
+        uGUI_MapRoomScanner scannerUi = mapRoomFunctionality.screenRoot.GetComponentInChildren<uGUI_MapRoomScanner>(true);
+        if (!scannerUi)
+        {
+            Log.Warn($"Could not find uGUI_MapRoomScanner for scanner room scan change: {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        scannerUi.UpdateGUIState();
+
+        if (techType != TechType.None)
+        {
+            scannerUi.StartAnimation();
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Bases/BuildUtils.cs
+++ b/NitroxClient/GameLogic/Bases/BuildUtils.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
-using NitroxClient.GameLogic.Settings;
-using NitroxClient.GameLogic.Spawning.Bases;
-using NitroxClient.GameLogic.Spawning.Metadata;
-using NitroxClient.MonoBehaviours;
+using System.Linq;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.Settings;
+using NitroxClient.GameLogic.Spawning.Bases;
+using NitroxClient.GameLogic.Spawning.Metadata;
+using NitroxClient.MonoBehaviours;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases;
@@ -160,14 +162,23 @@ public static class BuildUtils
         if (isMapRoomGhost)
         {
             MapRoomFunctionality mapRoomFunctionality = baseGhost.targetBase.GetMapRoomFunctionalityForCell(face.Value.cell);
+            bool hasParentBase = constructableBase.GetComponentInParent<Base>(true);
+
+            if (!mapRoomFunctionality)
+            {
+                mapRoomFunctionality = FindUnregisteredMapRoomFunctionality(baseGhost.targetBase);
+            }
+
             if (mapRoomFunctionality)
             {
                 // As MapRooms can be built as the first piece of a base, we need to make sure that they receive a new id if they're not in a base
-                NitroxId nitroxId = constructableBase.GetComponentInParent<Base>(true) ? id : id.Increment();
+                NitroxId nitroxId = hasParentBase ? id : id.Increment();         
+                
                 NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, nitroxId);
-                moduleObject = mapRoomFunctionality.gameObject;
+                moduleObject = mapRoomFunctionality.gameObject;                
                 return true;
             }
+
             Log.Error($"Couldn't find MapRoomFunctionality of built MapRoom (cell: {face.Value.cell})");
             moduleObject = null;
             return false;
@@ -223,10 +234,55 @@ public static class BuildUtils
         return baseGhost.targetBase.NormalizeCell(baseGhost.targetBase.WorldToGrid(baseGhost.ghostBase.occupiedBounds.center));
     }
 
-    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId)
+    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId, EntityMetadataManager entityMetadataManager)
     {
         Int3 mapRoomCell = @base.NormalizeCell(@base.WorldToGrid(mapRoomFunctionality.transform.position));
-        return new(id, parentId, mapRoomCell.ToDto());
+        MapRoomEntity mapRoomEntity = new(id, parentId, mapRoomCell.ToDto());
+
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (opContainer.HasValue)
+        {
+            ItemsContainer container = opContainer.Value;
+
+            List<Pickupable> pickupables = container._items.Values
+                                                 .SelectMany(itemGroup => itemGroup.items)
+                                                 .Select(item => item.item)
+                                                 .Where(pickupable => pickupable)
+                                                 .ToList();
+
+            foreach (Pickupable pickupable in pickupables)
+            {
+                mapRoomEntity.ChildEntities.Add(Items.ConvertToInventoryItemEntity(pickupable.gameObject, id, entityMetadataManager));
+            }
+        }
+        else
+        {
+            Log.Warn($"Could not find scanner room upgrade container for {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return mapRoomEntity;
+    }
+
+    private static MapRoomFunctionality FindUnregisteredMapRoomFunctionality(Base targetBase)
+    {
+        List<MapRoomFunctionality> candidates = targetBase.GetComponentsInChildren<MapRoomFunctionality>(true)
+                                                          .Where(mapRoomFunctionality => !mapRoomFunctionality.TryGetNitroxId(out _))
+                                                          .ToList();
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        Log.Warn($"Could not uniquely identify unregistered MapRoomFunctionality under {targetBase.gameObject.GetFullHierarchyPath()}. Found {candidates.Count} candidates.");
+
+        foreach (MapRoomFunctionality candidate in candidates)
+        {
+            Log.Warn($"Unregistered MapRoomFunctionality candidate: {candidate.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return null;
     }
 
     // TODO: Use this for a latter singleplayer save converter
@@ -270,7 +326,7 @@ public static class BuildUtils
                 {
                     continue;
                 }
-                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId));
+                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId, entityMetadataManager));
             }
             else if (transform.TryGetComponent(out IBaseModule baseModule))
             {

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -58,7 +58,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
@@ -169,7 +170,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         return interiorPiece;
     }
 
-    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity)
+    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity, Entities entities)
     {
         MapRoomFunctionality mapRoomFunctionality = @base.GetMapRoomFunctionalityForCell(mapRoomEntity.Cell.ToUnity());
         if (!mapRoomFunctionality)
@@ -177,6 +178,43 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
             Log.Error($"Couldn't find MapRoomFunctionality in base for cell {mapRoomEntity.Cell}");
             yield break;
         }
+
         NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, mapRoomEntity.Id);
+
+        List<Entity> upgradeChips = mapRoomEntity.ChildEntities
+                                                 .OfType<InventoryItemEntity>()
+                                                 .ToList<Entity>();
+
+        if (upgradeChips.Count > 0)
+        {
+            ClearMapRoomUpgradeContainer(mapRoomFunctionality);
+            yield return entities.SpawnBatchAsync(upgradeChips, true);
+        }
     }
+
+    private static void ClearMapRoomUpgradeContainer(MapRoomFunctionality mapRoomFunctionality)
+    {
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (!opContainer.HasValue)
+        {
+            Log.Error($"Couldn't find map room upgrade container on {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        ItemsContainer container = opContainer.Value;
+
+        List<Pickupable> pickupables = container._items.Values
+                                              .SelectMany(itemGroup => itemGroup.items)
+                                              .Select(item => item.item)
+                                              .Where(pickupable => pickupable)
+                                              .ToList();
+
+        foreach (Pickupable pickupable in pickupables)
+        {
+            NitroxEntity.RemoveFrom(pickupable.gameObject);
+            container.RemoveItem(pickupable, true);
+        }
+    }
+
 }

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -160,7 +160,7 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
                 }
                 else if (moduleObject.TryGetComponent(out MapRoomFunctionality mapRoomFunctionality))
                 {
-                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId);
+                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId, Resolve<EntityMetadataManager>());
                 }
             }
 

--- a/NitroxPatcher/Patches/Dynamic/MapRoomFunctionality_StartScanning_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomFunctionality_StartScanning_Patch.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Abstract;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomFunctionality_StartScanning_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomFunctionality t) => t.StartScanning(default));
+
+    public static void Postfix(MapRoomFunctionality __instance, TechType newTypeToScan)
+    {
+        if (PacketSuppressor<MapRoomScanChanged>.IsSuppressed)
+        {
+            return;
+        }
+
+        if (!__instance.TryGetNitroxId(out NitroxId mapRoomId))
+        {
+            Log.Warn($"Could not find NitroxId on scanner room when changing scan target: {__instance.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        Resolve<IPacketSender>().Send(new MapRoomScanChanged(mapRoomId, newTypeToScan.ToString()));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes scanner room scan target/state/UI synchronization.

Depends on #2758.
Contributes to #2410.

This PR does not depend on #2759.

## Problem

Scanner rooms did not synchronize their active scan state between players.

Before this change, selecting a scan target on one client only updated that client's scanner room screen. Other clients could still see their local list or stale scan screen state, even though they were standing in the same physical scanner room.

This meant the scanner room could appear to be scanning different targets on different clients, and the scanner screen UI did not reliably represent the shared room state.

## What changed

Adds a dedicated scanner room scan-state sync path.

When `MapRoomFunctionality.StartScanning(TechType)` runs, the client now sends a `MapRoomScanChanged` packet containing:

- the scanner room's shared `MapRoomFunctionality` Nitrox ID;
- the selected scan target TechType.

Receiving clients resolve the same scanner room by ID, apply the scan target through `MapRoomFunctionality.StartScanning(...)`, and refresh the scanner room UI through the room's `uGUI_MapRoomScanner`.

This keeps the actual scanner room state and the visible scanner screen UI aligned across clients.

## Why this depends on #2758

This PR relies on all clients having the same `MapRoomFunctionality` Nitrox ID for the same physical scanner room.

That scanner room ID consistency is established by #2758. Without that shared scanner room identity, the scan-state packet would not have a reliable target to apply to.

## Behavior after this change

Tested with two players in the same scanner room.

- Both players see the same scan target list.
- Selecting a scan target from either client updates the scanner room state for both clients.
- The holographic scanner map updates for both clients.
- Scanner room scan sounds/graphics/results update for both clients.
- The scanner room screen UI updates for both clients.
- If one player changes the scan target, the other player's scanner screen changes to the new target.
- If either player cancels the scan, the scan stops and both screens return to the list state.

This matches the intended single-room behavior: one physical scanner room can scan one target at a time, while separate scanner rooms can still scan independently.

## Implementation notes

The patch targets `MapRoomFunctionality.StartScanning(TechType)`, which is the existing game method responsible for applying scanner room scan state.

The processor applies remote changes under packet suppression to avoid rebroadcast loops.

The receiving side also refreshes `uGUI_MapRoomScanner` so the physical screen UI mirrors the synchronized room state instead of remaining in a stale local view.
