### PR TITLE
Add player ping system with middle mouse button

### DIFF
--- a/Nitrox.Model.Subnautica/Packets/DeathMarkersChanged.cs
+++ b/Nitrox.Model.Subnautica/Packets/DeathMarkersChanged.cs
@@ -1,7 +1,7 @@
 using System;
 using Nitrox.Model.Packets;
 
-namespace NitroxModel.Packets;
+namespace Nitrox.Model.Subnautica.Packets;
 
 [Serializable]
 public class DeathMarkersChanged : Packet

--- a/Nitrox.Model.Subnautica/Packets/PlayerPingCreated.cs
+++ b/Nitrox.Model.Subnautica/Packets/PlayerPingCreated.cs
@@ -4,21 +4,14 @@ using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.Unity;
 using Nitrox.Model.Packets;
 
-namespace NitroxModel.Packets;
+namespace Nitrox.Model.Subnautica.Packets;
 
 [Serializable]
-public class PlayerPingCreated : Packet
+public class PlayerPingCreated(SessionId sessionId, string text, NitroxVector3 position, NitroxId pingId)
+    : Packet
 {
-    public SessionId SessionId { get; }
-    public string PlayerName { get; }
-    public NitroxVector3 Position { get; }
-    public NitroxId PingId { get; }
-
-    public PlayerPingCreated(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
-    {
-        SessionId = sessionId;
-        PlayerName = playerName;
-        Position = position;
-        PingId = pingId;
-    }
+    public SessionId SessionId { get; } = sessionId;
+    public string Text { get; } = text;
+    public NitroxVector3 Position { get; } = position;
+    public NitroxId PingId { get; } = pingId;
 }

--- a/Nitrox.Model.Subnautica/Packets/PlayerPingCreated.cs
+++ b/Nitrox.Model.Subnautica/Packets/PlayerPingCreated.cs
@@ -1,0 +1,24 @@
+using System;
+using Nitrox.Model.Core;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Packets;
+
+namespace NitroxModel.Packets;
+
+[Serializable]
+public class PlayerPingCreated : Packet
+{
+    public SessionId SessionId { get; }
+    public string PlayerName { get; }
+    public NitroxVector3 Position { get; }
+    public NitroxId PingId { get; }
+
+    public PlayerPingCreated(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
+    {
+        SessionId = sessionId;
+        PlayerName = playerName;
+        Position = position;
+        PingId = pingId;
+    }
+}

--- a/Nitrox.Model/Extensions/StringExtensions.cs
+++ b/Nitrox.Model/Extensions/StringExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Nitrox.Model.Extensions;
 
@@ -49,5 +50,40 @@ public static class StringExtensions
         }
 
         public int ToMd5HashedInt32() => BitConverter.ToInt32(self.ToMd5Hash(), 0);
+
+        /// <summary>
+        ///     Returns with title-case words and optionally omitted digits.
+        /// </summary>
+        public string ToSpacedTitleCase(bool keepDigits = true)
+        {
+            char[] chars = self.Trim().ToCharArray();
+            for (int i = 1; i < chars.Length; i++)
+            {
+                ref char previous = ref chars[i - 1];
+                ref char current = ref chars[i];
+
+                if (i == 1 && char.IsLetter(previous))
+                {
+                    previous = char.ToUpperInvariant(previous);
+                    continue;
+                }
+                if (char.IsWhiteSpace(previous) || !char.IsLetter(previous))
+                {
+                    if (char.IsLetter(current))
+                    {
+                        current = char.ToUpperInvariant(current);
+                    }
+                }
+                if (!char.IsLetter(current) && (!keepDigits || !char.IsDigit(current)))
+                {
+                    current = ' ';
+                }
+                if (char.IsWhiteSpace(previous) && char.IsWhiteSpace(current))
+                {
+                    previous = '\0';
+                }
+            }
+            return Regex.Replace(new string(chars), "(?!^)([A-Z])", " $1");;
+        }
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Commands/DeathMarkerCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/DeathMarkerCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Nitrox.Model.DataStructures.GameLogic;
 using Nitrox.Server.Subnautica.Models.Commands.Core;
-using NitroxModel.Packets;
 
 namespace Nitrox.Server.Subnautica.Models.Commands;
 

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/PlayerPingCreatedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/PlayerPingCreatedProcessor.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
+using NitroxModel.Packets;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+internal sealed class PlayerPingCreatedProcessor : IAuthPacketProcessor<PlayerPingCreated>
+{
+    public async Task Process(AuthProcessorContext context, PlayerPingCreated packet)
+    {
+        await context.SendToOthersAsync(packet);
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/PlayerPingCreatedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/PlayerPingCreatedProcessor.cs
@@ -1,6 +1,4 @@
-using System.Threading.Tasks;
 using Nitrox.Server.Subnautica.Models.Packets.Core;
-using NitroxModel.Packets;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 

--- a/NitroxClient/Communication/Packets/Processors/DeathMarkersChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DeathMarkersChangedProcessor.cs
@@ -1,6 +1,6 @@
+using Nitrox.Model.Subnautica.Packets;
 using NitroxClient.Communication.Packets.Processors.Core;
 using NitroxClient.GameLogic;
-using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
 

--- a/NitroxClient/Communication/Packets/Processors/PlayerPingCreatedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerPingCreatedProcessor.cs
@@ -1,8 +1,7 @@
-using System.Threading.Tasks;
+using Nitrox.Model.Subnautica.Packets;
 using NitroxClient.Communication.Packets.Processors.Core;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors;
 
@@ -15,7 +14,7 @@ internal sealed class PlayerPingCreatedProcessor(LocalPlayer localPlayer) : ICli
             return Task.CompletedTask;
         }
 
-        PlayerPingManager.CreateRemotePing(packet.SessionId, packet.PlayerName, packet.Position, packet.PingId);
+        PlayerPingManager.CreateRemotePing(packet.SessionId, packet.Text, packet.Position, packet.PingId);
         
         return Task.CompletedTask;
     }

--- a/NitroxClient/Communication/Packets/Processors/PlayerPingCreatedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerPingCreatedProcessor.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using NitroxModel.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+internal sealed class PlayerPingCreatedProcessor(LocalPlayer localPlayer) : IClientPacketProcessor<PlayerPingCreated>
+{
+    public Task Process(ClientProcessorContext context, PlayerPingCreated packet)
+    {
+        if (localPlayer.SessionId.HasValue && packet.SessionId == localPlayer.SessionId.Value)
+        {
+            return Task.CompletedTask;
+        }
+
+        PlayerPingManager.CreateRemotePing(packet.SessionId, packet.PlayerName, packet.Position, packet.PingId);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/NitroxClient/Extensions/CoroutineExtensions.cs
+++ b/NitroxClient/Extensions/CoroutineExtensions.cs
@@ -5,12 +5,12 @@ namespace NitroxClient.Extensions;
 
 public static class CoroutineExtensions
 {
-    public static IEnumerator OnYieldError(this IEnumerator enumerator, Action<Exception> exceptionCallback)
+    public static IEnumerator OnYieldError(this IEnumerator? enumerator, Action<Exception>? exceptionCallback)
     {
         return enumerator.OnYieldError<Exception>(exceptionCallback);
     }
 
-    public static IEnumerator OnYieldError<T>(this IEnumerator enumerator, Action<T> exceptionCallback = null) where T : Exception
+    public static IEnumerator OnYieldError<T>(this IEnumerator? enumerator, Action<T>? exceptionCallback = null) where T : Exception
     {
         if (enumerator == null)
         {

--- a/NitroxClient/Extensions/GameObjectExtensions.cs
+++ b/NitroxClient/Extensions/GameObjectExtensions.cs
@@ -16,6 +16,53 @@ public static class GameObjectExtensions
         ///     Returns true if game object is the local player, playing on the executing machine.
         /// </summary>
         public bool IsLocalPlayer => self == Player.main.gameObject;
+
+        public string GetFriendlyName()
+        {
+            string? result = TryGetName(self);
+            result ??= self.name.EndsWith("(Clone)", StringComparison.OrdinalIgnoreCase) ? self.name : null;
+            if (result == null)
+            {
+                // Might be collider / model, so we try a parent.
+                Transform current = self.transform;
+                while ((current = current.parent).AliveOrNull())
+                {
+                    if (current.name is "Cube" or "Sphere" or "Model" or "collision")
+                    {
+                        continue;
+                    }
+                    if (!current.name.EndsWith("(Clone)", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    result = TryGetName(current.gameObject) ?? current.name;
+                    break;
+                }
+            }
+            result = result?.Replace("(Clone)", "");
+            if (result.Contains("_doors", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Door";
+            }
+            return (result ?? self.GetFullHierarchyPath()).ToSpacedTitleCase(false);
+
+            static string? TryGetName(GameObject obj)
+            {
+                if (obj.GetComponent<Pickupable>().AliveOrNull() is { } pickupable)
+                {
+                    return pickupable.GetTechName().Replace("Undiscovered", "").Trim();
+                }
+                if (obj.GetComponent<TechTag>().AliveOrNull() is { } techTag)
+                {
+                    return techTag.type.AsString();
+                }
+                if (obj.GetComponent<TerrainChunkPieceCollider>().AliveOrNull() is { } terrainChunk)
+                {
+                    return $"{LargeWorld.main.GetBiome(terrainChunk.transform.position)} Biome";
+                }
+                return null;
+            }
+        }
     }
 
     public static bool TryGetComponentInChildren<T>(this GameObject go, out T component, bool includeInactive = false) where T : Component

--- a/NitroxClient/GameLogic/Helper/RaycastHelper.cs
+++ b/NitroxClient/GameLogic/Helper/RaycastHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Helper;
+
+internal static class RaycastHelper
+{
+    private static readonly IComparer<RaycastHit> rayHitDistanceComparer = Comparer<RaycastHit>.Create((a, b) => a.distance.CompareTo(b.distance));
+    private static Camera? MainCamera => field = field.AliveOrNull() ? field : Camera.main;
+
+    public static RaycastHit? GetClosestHitFromAim(float maxDistance, float minDistance = 3, int hitBufferSize = 64)
+    {
+        if (!MainCamera)
+        {
+            return null;
+        }
+
+        Ray ray = MainCamera.ScreenPointToRay(Input.mousePosition);
+        int layerMask = ~LayerMask.GetMask("UI", "Ignore Raycast");
+        RaycastHit[] hits = ArrayPool<RaycastHit>.Shared.Rent(hitBufferSize);
+        try
+        {
+            int hitAmount = Physics.RaycastNonAlloc(ray, hits, maxDistance, layerMask);
+            if (hitAmount > 0)
+            {
+                Array.Sort(hits, 0, hitAmount, rayHitDistanceComparer);
+                for (int i = 0; i < hitAmount; i++)
+                {
+                    RaycastHit hit = hits[i];
+                    if (hit.collider.isTrigger || hit.distance < minDistance)
+                    {
+                        continue;
+                    }
+                    return hit;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<RaycastHit>.Shared.Return(hits);
+        }
+        return null;
+    }
+}

--- a/NitroxClient/GameLogic/InitialSync/PlayerPreferencesInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPreferencesInitialSyncProcessor.cs
@@ -133,7 +133,12 @@ public sealed class PlayerPreferencesInitialSyncProcessor : InitialSyncProcessor
             pingKey = string.Empty;
             return false;
         }
-
+        // Nitrox-created pings can be ignored.
+        if (pingInstance.name.StartsWith("nitrox_", StringComparison.OrdinalIgnoreCase))
+        {
+            pingKey = string.Empty;
+            return false;
+        }
         Log.Warn($"Couldn't find {nameof(PingInstance)} identifier for {pingInstance.name} under {pingInstance.transform.parent}");
         pingKey = string.Empty;
         return false;

--- a/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
@@ -45,7 +45,7 @@ public class PlayerPing : MonoBehaviour
             pings.OnColor(signal.Id, playerColor);
         }
 
-        FMODEmitterController.PlayEventOneShot("event:/sub/cyclops/sonar", 3, Player.main.transform.position);
+        FMODEmitterController.PlayEventOneShot(PlayerPingManager.PING_OK_SOUND, 3, Player.main.transform.position);
         
         return playerPing;
     }

--- a/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
@@ -44,6 +44,8 @@ public class PlayerPing : MonoBehaviour
         {
             pings.OnColor(signal.Id, playerColor);
         }
+
+        FMODEmitterController.PlayEventOneShot("event:/sub/cyclops/sonar", 3, Player.main.transform.position);
         
         return playerPing;
     }

--- a/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
@@ -1,0 +1,50 @@
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.DataStructures.Unity;
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours.Gui.InGame;
+
+public class PlayerPing : MonoBehaviour
+{
+    private const float DESPAWN_TIME = 10f;
+    
+    private float spawnTime;
+
+    private void Start()
+    {
+        spawnTime = Time.time;
+    }
+
+    private void Update()
+    {
+        if (Time.time - spawnTime >= DESPAWN_TIME)
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public static PlayerPing SpawnPlayerPing(NitroxVector3 location, string playerName, NitroxId pingId, Color playerColor)
+    {
+        GameObject pingObject = new($"PlayerPing_{playerName}_{pingId}");
+        pingObject.transform.position = location.ToUnity();
+        
+        PlayerPing playerPing = pingObject.AddComponent<PlayerPing>();
+
+        PingInstance signal = pingObject.AddComponent<PingInstance>();
+        signal.pingType = PingType.Signal;
+        signal.origin = pingObject.transform;
+        signal.minDist = 5f;
+        signal._label = $"{playerName}'s Ping";
+        signal.displayPingInManager = false;
+        signal.visible = true;
+        signal.Initialize();
+
+        uGUI_Pings pings = Object.FindObjectOfType<uGUI_Pings>();
+        if (pings)
+        {
+            pings.OnColor(signal.Id, playerColor);
+        }
+        
+        return playerPing;
+    }
+}

--- a/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
+++ b/NitroxClient/MonoBehaviours/Gui/InGame/PlayerPing.cs
@@ -23,9 +23,9 @@ public class PlayerPing : MonoBehaviour
         }
     }
 
-    public static PlayerPing SpawnPlayerPing(NitroxVector3 location, string playerName, NitroxId pingId, Color playerColor)
+    public static PlayerPing SpawnPlayerPing(NitroxVector3 location, string labelText, NitroxId pingId, Color playerColor)
     {
-        GameObject pingObject = new($"PlayerPing_{playerName}_{pingId}");
+        GameObject pingObject = new($"Nitrox_PlayerPing_{labelText.Replace(" ", "")}_{pingId}");
         pingObject.transform.position = location.ToUnity();
         
         PlayerPing playerPing = pingObject.AddComponent<PlayerPing>();
@@ -34,12 +34,12 @@ public class PlayerPing : MonoBehaviour
         signal.pingType = PingType.Signal;
         signal.origin = pingObject.transform;
         signal.minDist = 5f;
-        signal._label = $"{playerName}'s Ping";
+        signal._label = labelText;
         signal.displayPingInManager = false;
         signal.visible = true;
         signal.Initialize();
 
-        uGUI_Pings pings = Object.FindObjectOfType<uGUI_Pings>();
+        uGUI_Pings pings = FindObjectOfType<uGUI_Pings>();
         if (pings)
         {
             pings.OnColor(signal.Id, playerColor);

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -172,6 +172,7 @@ namespace NitroxClient.MonoBehaviours
             gameObject.AddComponent<EntityPositionBroadcaster>();
             gameObject.AddComponent<BuildingHandler>();
             gameObject.AddComponent<MovementBroadcaster>();
+            gameObject.AddComponent<PlayerPingManager>();
             VirtualCyclops.Initialize();
         }
 

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using Nitrox.Model.Core;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.DataStructures.Unity;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours.Gui.InGame;
+using NitroxModel.Packets;
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours;
+
+public class PlayerPingManager : MonoBehaviour
+{
+    private const float MAX_PING_DISTANCE = 1000f;
+    private const float MIN_PING_DISTANCE = 3f;
+    private const float MIN_PING_COOLDOWN = 0.5f;
+    private const int MAX_ACTIVE_PINGS = 3;
+    
+    private static PlayerPingManager instance;
+    
+    private IPacketSender packetSender;
+    private LocalPlayer localPlayer;
+    private float lastPingTime;
+    private Camera mainCamera;
+    private readonly Dictionary<SessionId, List<PlayerPing>> playerPings = new();
+    private readonly List<PlayerPing> localPlayerPings = new();
+
+    public void Awake()
+    {
+        instance = this;
+        packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
+        localPlayer = this.Resolve<LocalPlayer>();
+    }
+
+    private void Update()
+    {
+        if (!mainCamera)
+        {
+            mainCamera = Camera.main;
+        }
+
+        if (Input.GetMouseButtonDown(2) && CanCreatePing())
+        {
+            TryCreatePing();
+        }
+    }
+
+    private bool CanCreatePing()
+    {
+        if (Time.time - lastPingTime < MIN_PING_COOLDOWN)
+        {
+            return false;
+        }
+
+        if (!Player.main || !AvatarInputHandler.main.IsEnabled())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void TryCreatePing()
+    {
+        if (!mainCamera)
+        {
+            return;
+        }
+
+        Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+        int layerMask = ~(LayerMask.GetMask("UI", "Ignore Raycast"));
+        RaycastHit[] hits = Physics.RaycastAll(ray, MAX_PING_DISTANCE, layerMask);
+        
+        if (hits.Length > 0)
+        {
+            Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+            
+            foreach (RaycastHit hit in hits)
+            {
+                if (hit.collider.isTrigger || hit.distance < MIN_PING_DISTANCE)
+                {
+                    continue;
+                }
+                
+                Vector3 pingPosition = hit.point + hit.normal * 0.5f;
+                CreatePing(pingPosition);
+                return;
+            }
+        }
+    }
+
+    private void CreatePing(Vector3 position)
+    {
+        lastPingTime = Time.time;
+
+        if (!localPlayer.SessionId.HasValue)
+        {
+            return;
+        }
+
+        localPlayerPings.RemoveAll(ping => !ping);
+
+        if (localPlayerPings.Count >= MAX_ACTIVE_PINGS)
+        {
+            PlayerPing oldestPing = localPlayerPings[0];
+            if (oldestPing)
+            {
+                Destroy(oldestPing.gameObject);
+            }
+            localPlayerPings.RemoveAt(0);
+        }
+
+        NitroxId pingId = new();
+        string playerName = localPlayer.PlayerName;
+        SessionId sessionId = localPlayer.SessionId.Value;
+        Color playerColor = localPlayer.PlayerSettings.PlayerColor.ToUnity();
+
+        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position.ToDto(), playerName, pingId, playerColor);
+        if (newPing)
+        {
+            localPlayerPings.Add(newPing);
+        }
+
+        packetSender.Send(new PlayerPingCreated(sessionId, playerName, position.ToDto(), pingId));
+    }
+
+    public static void CreateRemotePing(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
+    {
+        if (!instance)
+        {
+            return;
+        }
+        
+        instance.CreateRemotePingInternal(sessionId, playerName, position, pingId);
+    }
+    
+    private void CreateRemotePingInternal(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
+    {
+        if (!playerPings.TryGetValue(sessionId, out List<PlayerPing> pings))
+        {
+            pings = new List<PlayerPing>();
+            playerPings[sessionId] = pings;
+        }
+        
+        pings.RemoveAll(ping => !ping);
+        
+        if (pings.Count >= MAX_ACTIVE_PINGS)
+        {
+            PlayerPing oldestPing = pings[0];
+            if (oldestPing)
+            {
+                Destroy(oldestPing.gameObject);
+            }
+            pings.RemoveAt(0);
+        }
+        
+        PlayerManager playerManager = NitroxServiceLocator.LocateService<PlayerManager>();
+        Optional<RemotePlayer> remotePlayerOptional = playerManager.Find(sessionId);
+        
+        Color playerColor = remotePlayerOptional.HasValue 
+            ? remotePlayerOptional.Value.PlayerSettings.PlayerColor.ToUnity() 
+            : Color.yellow;
+        
+        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position, playerName, pingId, playerColor);
+        if (newPing)
+        {
+            pings.Add(newPing);
+        }
+    }
+}

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -1,20 +1,19 @@
-using System;
 using System.Collections.Generic;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Subnautica.Packets;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.MonoBehaviours.Gui.InGame;
-using NitroxModel.Packets;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours;
 
 public class PlayerPingManager : MonoBehaviour
 {
-    private const float MAX_PING_DISTANCE = 1000f;
-    private const float MIN_PING_DISTANCE = 3f;
+    private const float MAX_PING_DISTANCE = 250f;
     private const float MIN_PING_COOLDOWN = 0.5f;
     private const int MAX_ACTIVE_PINGS = 3;
     
@@ -23,9 +22,8 @@ public class PlayerPingManager : MonoBehaviour
     private IPacketSender packetSender;
     private LocalPlayer localPlayer;
     private float lastPingTime;
-    private Camera mainCamera;
     private readonly Dictionary<SessionId, List<PlayerPing>> playerPings = new();
-    private readonly List<PlayerPing> localPlayerPings = new();
+    private readonly List<PlayerPing> localPlayerPings = new(MAX_ACTIVE_PINGS);
 
     public void Awake()
     {
@@ -38,7 +36,7 @@ public class PlayerPingManager : MonoBehaviour
     {
         if (Input.GetMouseButtonDown(2) && CanCreatePing())
         {
-            TryCreatePing();
+            TryCreatePingFromAim();
         }
     }
 
@@ -57,41 +55,15 @@ public class PlayerPingManager : MonoBehaviour
         return true;
     }
 
-    private void TryCreatePing()
+    private void TryCreatePingFromAim()
     {
-        if (!mainCamera)
+        if (RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE) is { } hit)
         {
-            mainCamera = Camera.main;
-        }
-
-        if (!mainCamera)
-        {
-            return;
-        }
-
-        Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
-        int layerMask = ~(LayerMask.GetMask("UI", "Ignore Raycast"));
-        RaycastHit[] hits = Physics.RaycastAll(ray, MAX_PING_DISTANCE, layerMask);
-        
-        if (hits.Length > 0)
-        {
-            Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
-            
-            foreach (RaycastHit hit in hits)
-            {
-                if (hit.collider.isTrigger || hit.distance < MIN_PING_DISTANCE)
-                {
-                    continue;
-                }
-                
-                Vector3 pingPosition = hit.point + hit.normal * 0.5f;
-                CreatePing(pingPosition);
-                return;
-            }
+            CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
         }
     }
 
-    private void CreatePing(Vector3 position)
+    private void CreatePing(Vector3 position, GameObject entityHit)
     {
         lastPingTime = Time.realtimeSinceStartup;
 
@@ -113,30 +85,30 @@ public class PlayerPingManager : MonoBehaviour
         }
 
         NitroxId pingId = new();
-        string playerName = localPlayer.PlayerName;
         SessionId sessionId = localPlayer.SessionId.Value;
         Color playerColor = localPlayer.PlayerSettings.PlayerColor.ToUnity();
+        string label = $"{localPlayer.PlayerName} pinged {entityHit.GetFriendlyName()}";
 
-        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position.ToDto(), playerName, pingId, playerColor);
+        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position.ToDto(), label, pingId, playerColor);
         if (newPing)
         {
             localPlayerPings.Add(newPing);
         }
 
-        packetSender.Send(new PlayerPingCreated(sessionId, playerName, position.ToDto(), pingId));
+        packetSender.Send(new PlayerPingCreated(sessionId, label, position.ToDto(), pingId));
     }
 
-    public static void CreateRemotePing(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
+    public static void CreateRemotePing(SessionId sessionId, string labelText, NitroxVector3 position, NitroxId pingId)
     {
         if (!instance)
         {
             return;
         }
         
-        instance.CreateRemotePingInternal(sessionId, playerName, position, pingId);
+        instance.CreateRemotePingInternal(sessionId, labelText, position, pingId);
     }
     
-    private void CreateRemotePingInternal(SessionId sessionId, string playerName, NitroxVector3 position, NitroxId pingId)
+    private void CreateRemotePingInternal(SessionId sessionId, string labelText, NitroxVector3 position, NitroxId pingId)
     {
         if (!playerPings.TryGetValue(sessionId, out List<PlayerPing> pings))
         {
@@ -163,7 +135,7 @@ public class PlayerPingManager : MonoBehaviour
             ? remotePlayerOptional.Value.PlayerSettings.PlayerColor.ToUnity() 
             : Color.yellow;
         
-        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position, playerName, pingId, playerColor);
+        PlayerPing newPing = PlayerPing.SpawnPlayerPing(position, labelText, pingId, playerColor);
         if (newPing)
         {
             pings.Add(newPing);

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -36,11 +36,6 @@ public class PlayerPingManager : MonoBehaviour
 
     private void Update()
     {
-        if (!mainCamera)
-        {
-            mainCamera = Camera.main;
-        }
-
         if (Input.GetMouseButtonDown(2) && CanCreatePing())
         {
             TryCreatePing();
@@ -49,7 +44,7 @@ public class PlayerPingManager : MonoBehaviour
 
     private bool CanCreatePing()
     {
-        if (Time.time - lastPingTime < MIN_PING_COOLDOWN)
+        if (Time.realtimeSinceStartup - lastPingTime < MIN_PING_COOLDOWN)
         {
             return false;
         }
@@ -64,6 +59,11 @@ public class PlayerPingManager : MonoBehaviour
 
     private void TryCreatePing()
     {
+        if (!mainCamera)
+        {
+            mainCamera = Camera.main;
+        }
+
         if (!mainCamera)
         {
             return;
@@ -93,7 +93,7 @@ public class PlayerPingManager : MonoBehaviour
 
     private void CreatePing(Vector3 position)
     {
-        lastPingTime = Time.time;
+        lastPingTime = Time.realtimeSinceStartup;
 
         if (!localPlayer.SessionId.HasValue)
         {
@@ -156,7 +156,7 @@ public class PlayerPingManager : MonoBehaviour
             pings.RemoveAt(0);
         }
         
-        PlayerManager playerManager = NitroxServiceLocator.LocateService<PlayerManager>();
+        PlayerManager playerManager = this.Resolve<PlayerManager>();
         Optional<RemotePlayer> remotePlayerOptional = playerManager.Find(sessionId);
         
         Color playerColor = remotePlayerOptional.HasValue 

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -18,7 +18,8 @@ public class PlayerPingManager : MonoBehaviour
     private const int MAX_ACTIVE_PINGS = 3;
     
     private static PlayerPingManager instance;
-    
+
+    private RaycastHit? queuedRaycastHit;
     private IPacketSender packetSender;
     private LocalPlayer localPlayer;
     private float lastPingTime;
@@ -34,9 +35,23 @@ public class PlayerPingManager : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetMouseButtonDown(2) && CanCreatePing())
+        if (Input.GetMouseButtonDown(2))
         {
-            TryCreatePingFromAim();
+            if (!CanCreatePing())
+            {
+                // Queue the ping after cooldown.
+                queuedRaycastHit = RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE);
+                return;
+            }
+            if (RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE) is { } hit)
+            {
+                CreatePing(hit);
+            }
+        }
+        else if (queuedRaycastHit is {} hit && CanCreatePing())
+        {
+            queuedRaycastHit = null;
+            CreatePing(hit);
         }
     }
 
@@ -55,12 +70,9 @@ public class PlayerPingManager : MonoBehaviour
         return true;
     }
 
-    private void TryCreatePingFromAim()
+    private void CreatePing(RaycastHit hit)
     {
-        if (RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE) is { } hit)
-        {
-            CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
-        }
+        CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
     }
 
     private void CreatePing(Vector3 position, GameObject entityHit)

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
@@ -11,25 +12,33 @@ using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours;
 
-public class PlayerPingManager : MonoBehaviour
+internal sealed class PlayerPingManager : MonoBehaviour
 {
     private const float MAX_PING_DISTANCE = 250f;
     private const float MIN_PING_COOLDOWN = 0.5f;
     private const int MAX_ACTIVE_PINGS = 3;
-    
-    private static PlayerPingManager instance;
+    public const string PING_OK_SOUND = "event:/sub/cyclops/sonar";
+    public const string PING_FAIL_SOUND = "event:/tools/divereel/breadcrum";
+
+    private static PlayerPingManager instance = null!;
 
     private RaycastHit? queuedRaycastHit;
-    private IPacketSender packetSender;
-    private LocalPlayer localPlayer;
+    private IPacketSender packetSender = null!;
+    private LocalPlayer localPlayer = null!;
     private float lastPingTime;
-    private readonly Dictionary<SessionId, List<PlayerPing>> playerPings = new();
+    private readonly Dictionary<SessionId, List<PlayerPing>> playerPings = [];
     private readonly List<PlayerPing> localPlayerPings = new(MAX_ACTIVE_PINGS);
 
     public void Awake()
     {
+        if (instance)
+        {
+            Log.Error($"Tried to initialize a second instance of singleton {nameof(PlayerPingManager)}:{Environment.NewLine}{Environment.StackTrace}");
+            Destroy(this);
+            return;
+        }
         instance = this;
-        packetSender = NitroxServiceLocator.LocateService<IPacketSender>();
+        packetSender = this.Resolve<IPacketSender>();
         localPlayer = this.Resolve<LocalPlayer>();
     }
 
@@ -37,21 +46,17 @@ public class PlayerPingManager : MonoBehaviour
     {
         if (Input.GetMouseButtonDown(2))
         {
-            if (!CanCreatePing())
+            queuedRaycastHit = RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE);
+            if (queuedRaycastHit == null)
             {
-                // Queue the ping after cooldown.
-                queuedRaycastHit = RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE);
-                return;
-            }
-            if (RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE) is { } hit)
-            {
-                CreatePing(hit);
+                // Invalid ping raycast so we play an error sound.
+                FMODEmitterController.PlayEventOneShot(PING_FAIL_SOUND, 3, Player.main.transform.position);
             }
         }
-        else if (queuedRaycastHit is {} hit && CanCreatePing())
+        if (queuedRaycastHit is { } hit && CanCreatePing())
         {
             queuedRaycastHit = null;
-            CreatePing(hit);
+            CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
         }
     }
 
@@ -61,7 +66,6 @@ public class PlayerPingManager : MonoBehaviour
         {
             return false;
         }
-
         if (!Player.main || !AvatarInputHandler.main.IsEnabled())
         {
             return false;
@@ -70,15 +74,13 @@ public class PlayerPingManager : MonoBehaviour
         return true;
     }
 
-    private void CreatePing(RaycastHit hit)
-    {
-        CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
-    }
-
     private void CreatePing(Vector3 position, GameObject entityHit)
     {
+        if (!entityHit)
+        {
+            return;
+        }
         lastPingTime = Time.realtimeSinceStartup;
-
         if (!localPlayer.SessionId.HasValue)
         {
             return;


### PR DESCRIPTION
Closes #2763

Implements a multiplayer ping system that allows players to mark locations for teammates to see.

## Features
- Middle mouse button creates location pings
- Pings use player's character color
- Auto-despawn after 10 seconds
- Maximum 3 active pings per player
- 0.5s cooldown to prevent spam

## Testing
- [x] Pings created with middle mouse button
- [x] Pings use player colors
- [x] 3 ping limit enforced per player
- [x] Pings auto-despawn after 10 seconds
- [x] Network sync works across players