### PR TITLE
Fix player SubRootId/ParentId mismatch within escape pods

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlayerEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlayerEntity.cs
@@ -22,7 +22,7 @@ public class PlayerEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public PlayerEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public PlayerEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata? metadata, NitroxId? parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities) {}
 
     public override string ToString()

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.GameLogic;
@@ -11,11 +12,11 @@ using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 namespace Nitrox.Server.Subnautica.Models.Commands;
 
 [RequiresPermission(Perms.ADMIN)]
-internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwnershipData simulationOwnershipData, ILogger<QueryCommand> logger) : ICommandHandler<NitroxId>
+internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwnershipData simulationOwnershipData, PlayerManager playerManager) : ICommandHandler<NitroxId>
 {
     private readonly EntityRegistry entityRegistry = entityRegistry;
+    private readonly PlayerManager playerManager = playerManager;
     private readonly SimulationOwnershipData simulationOwnershipData = simulationOwnershipData;
-    private readonly ILogger<QueryCommand> logger = logger;
 
     [Description("Query the entity associated with the given NitroxId")]
     public async Task Execute(ICommandContext context, [Description("NitroxId of an entity")] NitroxId entityId)
@@ -41,7 +42,8 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
                 builder.AppendLine("   └ Child");
                 builder.AppendLine($"     └ Type: {childEntity.GetType().Name}");
                 builder.AppendLine($"     └ Id: {childEntity.Id}");
-                builder.AppendLine($"     └ Metadata: {childEntity.Metadata?.ToString() ?? "none"}");
+                builder.AppendLine($"     └ TechType: {childEntity.TechType}");
+                builder.AppendLine($"     └ Metadata: {childEntity.Metadata?.ToString() ?? "<null>"}");
                 builder.AppendLine($"     └ Children: {childEntity.ChildEntities.Count}");
             }
         }
@@ -54,6 +56,38 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
             builder.AppendLine($" └ SpawnedByServer: {worldEntity.SpawnedByServer}");
             builder.AppendLine($" └ {worldEntity.Transform}");
             builder.AppendLine($" └ Cell: {(worldEntity is GlobalRootEntity ? "global root" : worldEntity.AbsoluteEntityCell.ToString())}");
+        }
+
+        if (entity is PlayerEntity)
+        {
+            Player? serverPlayer = playerManager.GetAllPlayers().FirstOrDefault(p => p.GameObjectId == entityId);
+            if (serverPlayer is not null)
+            {
+                bool isOnline = playerManager.GetConnectedPlayers().Contains(serverPlayer);
+
+                builder.AppendLine("Player");
+                builder.AppendLine($" └ Name: {serverPlayer.Name}");
+                builder.AppendLine($" └ Online: {isOnline}");
+                builder.AppendLine($" └ Perms: {serverPlayer.Permissions}");
+                builder.AppendLine($" └ GameMode: {serverPlayer.GameMode}");
+                builder.AppendLine($" └ InPrecursor: {serverPlayer.InPrecursor}");
+                builder.AppendLine($" └ Stats: {serverPlayer.Stats}");
+                builder.AppendLine($" └ DisplaySurfaceWater: {serverPlayer.DisplaySurfaceWater}");
+                builder.AppendLine($" └ Position: {serverPlayer.Position}");
+                builder.AppendLine($" └ LastStoredPosition: {serverPlayer.LastStoredPosition?.ToString() ?? "<null>"}");
+                builder.AppendLine($" └ SubRootId: {serverPlayer.SubRootId.OrNull()?.ToString() ?? "<null>"}");
+                builder.AppendLine($" └ LastStoredSubRootID: {serverPlayer.LastStoredSubRootID.OrNull()?.ToString() ?? "<null>"}");
+
+                if (entity.ParentId != serverPlayer.SubRootId.OrNull())
+                {
+                    builder.AppendLine("⚠ ParentId doesn't match SubRootId");
+                }
+            }
+            else
+            {
+                builder.AppendLine("Player");
+                builder.AppendLine("⚠ Unable to find player record for this entity id)");
+            }
         }
 
         bool isLocked = simulationOwnershipData.TryGetLock(entityId, out SimulationOwnershipData.PlayerLock playerLock);

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -63,11 +63,9 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
             Player? serverPlayer = playerManager.GetAllPlayers().FirstOrDefault(p => p.GameObjectId == entityId);
             if (serverPlayer is not null)
             {
-                bool isOnline = playerManager.GetConnectedPlayers().Contains(serverPlayer);
-
                 builder.AppendLine("Player");
                 builder.AppendLine($" └ Name: {serverPlayer.Name}");
-                builder.AppendLine($" └ Online: {isOnline}");
+                builder.AppendLine($" └ Online: {serverPlayer.IsOnline}");
                 builder.AppendLine($" └ Perms: {serverPlayer.Permissions}");
                 builder.AppendLine($" └ GameMode: {serverPlayer.GameMode}");
                 builder.AppendLine($" └ InPrecursor: {serverPlayer.InPrecursor}");

--- a/Nitrox.Server.Subnautica/Models/Commands/WhoisCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/WhoisCommand.cs
@@ -12,13 +12,16 @@ internal sealed class WhoisCommand : ICommandHandler<Player>
     public async Task Execute(ICommandContext context, Player targetPlayer)
     {
         StringBuilder builder = new($"==== {targetPlayer.Name} ====\n");
+        builder.AppendLine($"Id: {targetPlayer.Entity.Id}");
         builder.AppendLine($"SessionId: {targetPlayer.SessionId}");
         builder.AppendLine($"Role: {targetPlayer.Permissions}");
+        builder.AppendLine($"Gamemode: {targetPlayer.GameMode}");
         builder.AppendLine($"Position: {targetPlayer.Position.X}, {targetPlayer.Position.Y}, {targetPlayer.Position.Z}");
         builder.AppendLine($"Oxygen: {targetPlayer.Stats.Oxygen}/{targetPlayer.Stats.MaxOxygen}");
         builder.AppendLine($"Food: {targetPlayer.Stats.Food}");
         builder.AppendLine($"Water: {targetPlayer.Stats.Water}");
         builder.AppendLine($"Infection: {targetPlayer.Stats.InfectionAmount}");
+        builder.AppendLine($"In precursor: {targetPlayer.InPrecursor}");
 
         await context.ReplyAsync(builder.ToString());
     }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
@@ -178,12 +178,11 @@ internal sealed class JoiningManager(
 
         player.Entity = wasBrandNewPlayer ? SetupNewPlayerEntity(player) : RespawnExistingEntity(player);
 
-        entityRegistry.ReparentEntity(player.Entity, player.SubRootId.OrNull());
-
         List<GlobalRootEntity> globalRootEntities = worldEntityManager.GetGlobalRootEntities(true);
         bool isFirstPlayer = playerManager.GetConnectedPlayers().Count == 1;
 
-        InitialPlayerSync initialPlayerSync = new(player.GameObjectId,
+        InitialPlayerSync initialPlayerSync = new(
+            player.GameObjectId,
             wasBrandNewPlayer,
             assignedEscapePodId,
             player.EquippedItems,
@@ -223,7 +222,7 @@ internal sealed class JoiningManager(
         {
             NitroxTransform transform = new(player.Position, player.Rotation, NitroxVector3.One);
 
-            PlayerEntity playerEntity = new(transform, 0, null, false, player.GameObjectId, NitroxTechType.None, null, null, new List<Entity>());
+            PlayerEntity playerEntity = new(transform, 0, null, false, player.GameObjectId, NitroxTechType.None, null, player.SubRootId.OrNull(), []);
             entityRegistry.AddOrUpdate(playerEntity);
             worldEntityManager.TrackEntityInTheWorld(playerEntity);
             return playerEntity;

--- a/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
@@ -178,6 +178,8 @@ internal sealed class JoiningManager(
 
         player.Entity = wasBrandNewPlayer ? SetupNewPlayerEntity(player) : RespawnExistingEntity(player);
 
+        entityRegistry.ReparentEntity(player.Entity, player.SubRootId.OrNull());
+
         List<GlobalRootEntity> globalRootEntities = worldEntityManager.GetGlobalRootEntities(true);
         bool isFirstPlayer = playerManager.GetConnectedPlayers().Count == 1;
 

--- a/Nitrox.Server.Subnautica/Models/GameLogic/PlayerManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/PlayerManager.cs
@@ -245,6 +245,7 @@ internal sealed partial class PlayerManager(SessionManager sessionManager, IOpti
         }
 
         assetsBySessionId.Remove(player.SessionId);
+        player.IsOnline = false;
         return Task.CompletedTask;
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/EscapePodChangedPacketProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/EscapePodChangedPacketProcessor.cs
@@ -1,11 +1,13 @@
-﻿using Nitrox.Server.Subnautica.Models.Packets.Core;
+﻿using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 
-internal sealed class EscapePodChangedPacketProcessor : IAuthPacketProcessor<EscapePodChanged>
+internal sealed class EscapePodChangedPacketProcessor(EntityRegistry entityRegistry) : IAuthPacketProcessor<EscapePodChanged>
 {
     public async Task Process(AuthProcessorContext context, EscapePodChanged packet)
     {
+        entityRegistry.ReparentEntity(context.Sender.GameObjectId, packet.EscapePodId.OrNull());
         context.Sender.SubRootId = packet.EscapePodId;
         await context.SendToOthersAsync(packet);
     }

--- a/Nitrox.Server.Subnautica/Models/Player.cs
+++ b/Nitrox.Server.Subnautica/Models/Player.cs
@@ -12,14 +12,37 @@ namespace Nitrox.Server.Subnautica.Models
 {
     internal sealed class Player
     {
+        private const ushort OFFLINE_SESSION_ID = 0;
+
         private readonly ThreadSafeSet<AbsoluteEntityCell> visibleCells;
+
+        private ushort sessionId;
 
         public ThreadSafeList<NitroxTechType> UsedItems { get; }
         public Optional<NitroxId>[] QuickSlotsBindingIds { get; set; }
 
         public PlayerContext? PlayerContext { get; set; }
         public PeerId Id { get; init; }
-        public SessionId SessionId { get; set; }
+
+        public SessionId SessionId
+        {
+            get => Interlocked.CompareExchange(ref sessionId, OFFLINE_SESSION_ID, OFFLINE_SESSION_ID);
+            set => Interlocked.Exchange(ref sessionId, value);
+        }
+
+        public bool IsOnline
+        {
+            get => SessionId != OFFLINE_SESSION_ID;
+            set
+            {
+                if (value)
+                {
+                    throw new InvalidOperationException($"{nameof(Player)} cannot be put in an online state without a {nameof(SessionId)}!");
+                }
+                SessionId = OFFLINE_SESSION_ID;
+            }
+        }
+
         public string Name { get; }
         public bool IsPermaDeath { get; set; }
         public NitroxVector3 Position { get; set; }
@@ -156,11 +179,6 @@ namespace Nitrox.Server.Subnautica.Models
             return $"[Player - SessionId: {Id}, Name: {Name}, Perms: {Permissions}, Position: {Position}]";
         }
 
-        private bool Equals(Player other)
-        {
-            return Id == other.Id;
-        }
-
         /// <summary>
         ///     Returns a <b>new</b> list from the original set. To use the original set, use <see cref="AddCells" />,
         ///     <see cref="RemoveCells" /> and <see cref="HasCellLoaded" />.
@@ -168,6 +186,11 @@ namespace Nitrox.Server.Subnautica.Models
         internal List<AbsoluteEntityCell> GetVisibleCells()
         {
             return [.. visibleCells];
+        }
+
+        private bool Equals(Player other)
+        {
+            return Id == other.Id;
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
<!-- Fixes #<ISSUE_NUMBER> -->


Hi! 

I read in the [newsletter](https://nitroxblog.rux.gg/2025/10/08/nitrox-1-8-0-0/) that the mac version is lacking, so i thought i would try to help!

-------

On mac, i had an issue where the player nr 2 glitches though the floor on joining + cannot see other users.   (See video)


https://github.com/user-attachments/assets/9685c212-dce7-4e2d-8a42-d2e27b6b6737

## Description of Change

I assume this doesnt happen on windows/linux, and something special on mac.

<!-- Describe what this PR changes and why -->

With extra logging, on player pos, i got a string like: 
```
[20:27:14.510] PlayerMovement session=1 pos=[-38.17284, 1.902705, -311.7547] bodyActive=True bodyInHierarchy=True parent=<none>
```
Where the parent was none, when it should have been the pod. 

I tried a fix where i delayed messages from/to the client when a user was joining, but that did not fix the issue.
I assume there are multiple similar issues (like the issue where a person is holding an item when a user joins), but i am not familiar enough with the code and could not find a root cause.

So i then tried a simpler fix to reparent the user, and it worked.


## Validation

Validated by running it multiple times, and trying to get the fault again.

Tested on my mac m4 pro 48gb

Video:
https://github.com/user-attachments/assets/0019d505-54d7-43bd-8130-4d64f450a841



## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

Dont have a windows/linux pc available ;/

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This code was created with the help of AI.

I am unfamiliar with the codebase and used claude as a pair programmer while debugging to try to figure out the fault.
