### PR TITLE
Implement Scanner Room Camera Multiplayer System

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Bases/MapRoomCameraRegistryEntry.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Bases/MapRoomCameraRegistryEntry.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.Serialization;
+using Nitrox.Model.DataStructures;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
+
+[Serializable, DataContract]
+public class MapRoomCameraRegistryEntry
+{
+    [DataMember(Order = 1)]
+    public NitroxId CameraId { get; set; }
+
+    [DataMember(Order = 2)]
+    public int CameraNumber { get; set; }
+
+    [DataMember(Order = 3)]
+    public NitroxId MapRoomId { get; set; }
+
+    [DataMember(Order = 4)]
+    public int DockingIndex { get; set; } = -1;
+
+    public MapRoomCameraRegistryEntry()
+    {
+        // Constructor for serialization.
+    }
+
+    public MapRoomCameraRegistryEntry(NitroxId cameraId, int cameraNumber, NitroxId mapRoomId = null, int dockingIndex = -1)
+    {
+        CameraId = cameraId;
+        CameraNumber = cameraNumber;
+        MapRoomId = mapRoomId;
+        DockingIndex = dockingIndex;
+    }
+
+    public bool IsDocked => MapRoomId != null && DockingIndex >= 0;
+}

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MapRoomEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MapRoomEntity.cs
@@ -14,17 +14,25 @@ public class MapRoomEntity : GlobalRootEntity
     [DataMember(Order = 1)]
     public NitroxInt3 Cell { get; set; }
 
+    [DataMember(Order = 2)]
+    public List<bool> CameraDockingStates { get; set; } = [];
+
+    [DataMember(Order = 3)]
+    public List<NitroxId> CameraDockingIds { get; set; } = [];
+
     [IgnoreConstructor]
     protected MapRoomEntity()
     {
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public MapRoomEntity(NitroxId id, NitroxId parentId, NitroxInt3 cell)
+    public MapRoomEntity(NitroxId id, NitroxId parentId, NitroxInt3 cell, List<bool>? cameraDockingStates = null, List<NitroxId>? cameraDockingIds = null)
     {
         Id = id;
         ParentId = parentId;
         Cell = cell;
+        CameraDockingStates = cameraDockingStates ?? [];
+        CameraDockingIds = cameraDockingIds ?? [];
 
         Transform = new();
     }
@@ -33,10 +41,12 @@ public class MapRoomEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public MapRoomEntity(NitroxInt3 cell, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public MapRoomEntity(NitroxInt3 cell, List<bool>? cameraDockingStates, List<NitroxId>? cameraDockingIds, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         Cell = cell;
+        CameraDockingStates = cameraDockingStates ?? [];
+        CameraDockingIds = cameraDockingIds ?? [];
     }
 
     public override string ToString()

--- a/Nitrox.Model.Subnautica/Packets/MapRoomCameraDockingChanged.cs
+++ b/Nitrox.Model.Subnautica/Packets/MapRoomCameraDockingChanged.cs
@@ -1,0 +1,30 @@
+using System;
+using BinaryPack.Attributes;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public sealed class MapRoomCameraDockingChanged : Packet
+{
+    public NitroxId MapRoomId { get; }
+    public int DockingIndex { get; }
+    public bool CameraDocked { get; }
+    public NitroxId CameraId { get; }
+
+    [IgnoreConstructor]
+    private MapRoomCameraDockingChanged()
+    {
+        // Constructor for serialization.
+    }
+
+    public MapRoomCameraDockingChanged(NitroxId mapRoomId, int dockingIndex, bool cameraDocked, NitroxId cameraId = null)
+    {
+        MapRoomId = mapRoomId;
+        DockingIndex = dockingIndex;
+        CameraDocked = cameraDocked;
+        CameraId = cameraId;
+    }
+}

--- a/Nitrox.Model.Subnautica/Packets/MapRoomCameraLightChanged.cs
+++ b/Nitrox.Model.Subnautica/Packets/MapRoomCameraLightChanged.cs
@@ -1,0 +1,25 @@
+using System;
+using BinaryPack.Attributes;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public sealed class MapRoomCameraLightChanged : Packet
+{
+    public NitroxId CameraId { get; }
+    public bool LightState { get; }
+
+    [IgnoreConstructor]
+    private MapRoomCameraLightChanged()
+    {
+        // Constructor for serialization.
+    }
+
+    public MapRoomCameraLightChanged(NitroxId cameraId, bool lightState)
+    {
+        CameraId = cameraId;
+        LightState = lightState;
+    }
+}

--- a/Nitrox.Model.Subnautica/Packets/MapRoomCameraNumberChanged.cs
+++ b/Nitrox.Model.Subnautica/Packets/MapRoomCameraNumberChanged.cs
@@ -1,0 +1,29 @@
+using System;
+using BinaryPack.Attributes;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public sealed class MapRoomCameraNumberChanged : Packet
+{
+    public NitroxId CameraId { get; }
+    public int CameraNumber { get; }
+    public NitroxId MapRoomId { get; }
+    public int DockingIndex { get; }
+
+    [IgnoreConstructor]
+    private MapRoomCameraNumberChanged()
+    {
+        // Constructor for serialization.
+    }
+
+    public MapRoomCameraNumberChanged(NitroxId cameraId, int cameraNumber, NitroxId mapRoomId = null, int dockingIndex = -1)
+    {
+        CameraId = cameraId;
+        CameraNumber = cameraNumber;
+        MapRoomId = mapRoomId;
+        DockingIndex = dockingIndex;
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Bases/MapRoomCameraRegistry.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Bases/MapRoomCameraRegistry.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
+using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+
+namespace Nitrox.Server.Subnautica.Models.GameLogic.Bases;
+
+internal static class MapRoomCameraRegistry
+{
+    private static readonly Dictionary<NitroxId, MapRoomCameraRegistryEntry> cameraEntriesById = [];
+
+    public static MapRoomCameraRegistryEntry RegisterOrUpdateCamera(NitroxId cameraId, NitroxId mapRoomId = null, int dockingIndex = -1)
+    {
+        if (!cameraEntriesById.TryGetValue(cameraId, out MapRoomCameraRegistryEntry entry))
+        {
+            entry = new MapRoomCameraRegistryEntry(cameraId, GetLowestAvailableNumber(), mapRoomId, dockingIndex);
+            cameraEntriesById[cameraId] = entry;
+            return entry;
+        }
+
+        if (mapRoomId != null && dockingIndex >= 0)
+        {
+            entry.MapRoomId = mapRoomId;
+            entry.DockingIndex = dockingIndex;
+        }
+
+        return entry;
+    }
+
+    public static MapRoomCameraRegistryEntry RegisterDockedCamera(NitroxId cameraId, NitroxId mapRoomId, int dockingIndex)
+    {
+        return RegisterOrUpdateCamera(cameraId, mapRoomId, dockingIndex);
+    }
+
+    public static MapRoomCameraRegistryEntry MarkCameraUndocked(NitroxId cameraId)
+    {
+        MapRoomCameraRegistryEntry entry = RegisterOrUpdateCamera(cameraId);
+        entry.MapRoomId = null;
+        entry.DockingIndex = -1;
+        return entry;
+    }
+
+    public static void DeregisterCamera(NitroxId cameraId)
+    {
+        cameraEntriesById.Remove(cameraId);
+    }
+
+    public static List<MapRoomCameraRegistryEntry> GetSaveData()
+    {
+        return cameraEntriesById.Values
+                                .OrderBy(entry => entry.CameraNumber)
+                                .Select(entry => new MapRoomCameraRegistryEntry(entry.CameraId, entry.CameraNumber, entry.MapRoomId, entry.DockingIndex))
+                                .ToList();
+    }
+
+    public static void LoadFromSave(IEnumerable<MapRoomCameraRegistryEntry> savedEntries, EntityRegistry entityRegistry)
+    {
+        cameraEntriesById.Clear();
+
+        if (savedEntries == null)
+        {
+            return;
+        }
+
+        foreach (MapRoomCameraRegistryEntry savedEntry in savedEntries.OrderBy(entry => entry.CameraNumber))
+        {
+            if (savedEntry.CameraId == null || savedEntry.CameraNumber <= 0)
+            {
+                continue;
+            }
+
+            // Do not reserve a number for a camera entity that no longer exists in the server save.
+            if (!entityRegistry.TryGetEntityById<Entity>(savedEntry.CameraId, out _))
+            {
+                continue;
+            }
+
+            if (cameraEntriesById.ContainsKey(savedEntry.CameraId))
+            {
+                continue;
+            }
+
+            if (cameraEntriesById.Values.Any(entry => entry.CameraNumber == savedEntry.CameraNumber))
+            {
+                continue;
+            }
+
+            cameraEntriesById[savedEntry.CameraId] = new MapRoomCameraRegistryEntry(
+                savedEntry.CameraId,
+                savedEntry.CameraNumber,
+                savedEntry.MapRoomId,
+                savedEntry.DockingIndex);
+        }
+    }
+
+    public static string GetDebugText()
+    {
+        return string.Join(", ",
+            cameraEntriesById.Values
+                             .OrderBy(entry => entry.CameraNumber)
+                             .Select(entry => $"{entry.CameraNumber}:{entry.CameraId}:mapRoom={entry.MapRoomId}:dock={entry.DockingIndex}"));
+    }
+
+    private static int GetLowestAvailableNumber()
+    {
+        int number = 1;
+        HashSet<int> usedNumbers = new(cameraEntriesById.Values
+                                                        .Where(entry => entry.CameraNumber > 0)
+                                                        .Select(entry => entry.CameraNumber));
+
+        while (usedNumbers.Contains(number))
+        {
+            number++;
+        }
+
+        return number;
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/GameLogic/GameData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/GameData.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
+using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
 using Nitrox.Server.Subnautica.Models.GameLogic.Unlockables;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic
@@ -16,13 +19,17 @@ namespace Nitrox.Server.Subnautica.Models.GameLogic
         [DataMember(Order = 3)]
         public StoryTimingData StoryTiming { get; set; }
 
+        [DataMember(Order = 4)]
+        public List<MapRoomCameraRegistryEntry> MapRoomCameraRegistry { get; set; } = [];
+
         public static GameData From(PdaManager pdaManager, StoryGoalData storyGoals, StoryScheduler storyScheduler, StoryManager storyManager, TimeService timeService)
         {
             return new GameData
             {
                 PDAState = pdaManager.GetPdaStateCopy(),
                 StoryGoals = StoryGoalData.From(storyGoals, storyScheduler),
-                StoryTiming = StoryTimingData.From(storyManager, timeService)
+                StoryTiming = StoryTimingData.From(storyManager, timeService),
+                MapRoomCameraRegistry = GameLogic.Bases.MapRoomCameraRegistry.GetSaveData()
             };
         }
     }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
@@ -5,8 +5,10 @@ using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.GameLogic;
 using Nitrox.Model.DataStructures.Unity;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.MultiplayerSession;
+using Nitrox.Model.Subnautica.Packets;
 using Nitrox.Server.Subnautica.Models.AppEvents;
 using Nitrox.Server.Subnautica.Models.Communication;
 using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
@@ -211,6 +213,7 @@ internal sealed class JoiningManager(
         );
 
         await packetSender.SendPacketAsync(initialPlayerSync, player.SessionId);
+        await ReplayMapRoomCameraRegistryAsync(player.SessionId);
 
         IEnumerable<PlayerContext> GetOtherPlayers(Player player)
         {
@@ -235,6 +238,31 @@ internal sealed class JoiningManager(
             }
             logger.ZLogError($"Unable to find player entity for {player.Name}. Re-creating one");
             return SetupNewPlayerEntity(player);
+        }
+    }
+
+    private async Task ReplayMapRoomCameraRegistryAsync(SessionId sessionId)
+    {
+        List<MapRoomCameraRegistryEntry> cameraRegistryEntries = MapRoomCameraRegistry.GetSaveData();
+
+        logger.ZLogInformation(
+            $"Replaying scanner camera registry to joining session {sessionId}: " +
+            $"count={cameraRegistryEntries.Count}, registry=[{MapRoomCameraRegistry.GetDebugText()}]");
+
+        foreach (MapRoomCameraRegistryEntry entry in cameraRegistryEntries.OrderBy(entry => entry.CameraNumber))
+        {
+            if (entry.CameraId == null || entry.CameraNumber <= 0)
+            {
+                continue;
+            }
+
+            await packetSender.SendPacketAsync(
+                new MapRoomCameraNumberChanged(
+                    entry.CameraId,
+                    entry.CameraNumber,
+                    entry.MapRoomId,
+                    entry.DockingIndex),
+                sessionId);
         }
     }
 

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraDockingChangedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraDockingChangedProcessor.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using Nitrox.Model.Subnautica.Packets;
+using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
+using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+internal sealed class MapRoomCameraDockingChangedProcessor(EntityRegistry entityRegistry, WorldEntityManager worldEntityManager, ILogger<MapRoomCameraDockingChangedProcessor> logger) : IAuthPacketProcessor<MapRoomCameraDockingChanged>
+{
+    private const string MAP_ROOM_CAMERA_PREFAB_CLASS_ID = "733fd479-0760-4bc2-a03e-281cbf02bfa4";
+    private readonly EntityRegistry entityRegistry = entityRegistry;
+    private readonly WorldEntityManager worldEntityManager = worldEntityManager;
+    private readonly ILogger<MapRoomCameraDockingChangedProcessor> logger = logger;
+
+    public async Task Process(AuthProcessorContext context, MapRoomCameraDockingChanged packet)
+    {
+        if (!entityRegistry.TryGetEntityById(packet.MapRoomId, out MapRoomEntity mapRoomEntity))
+        {
+            logger.ZLogError($"Unable to find scanner room {packet.MapRoomId} for camera docking update");
+            return;
+        }
+
+        if (packet.DockingIndex < 0)
+        {
+            logger.ZLogWarning($"Ignoring scanner room camera docking update with invalid index {packet.DockingIndex} for {packet.MapRoomId}");
+            return;
+        }
+
+        while (mapRoomEntity.CameraDockingStates.Count <= packet.DockingIndex)
+        {
+            mapRoomEntity.CameraDockingStates.Add(true);
+        }
+
+        while (mapRoomEntity.CameraDockingIds.Count <= packet.DockingIndex)
+        {
+            mapRoomEntity.CameraDockingIds.Add(null);
+        }
+
+        mapRoomEntity.CameraDockingStates[packet.DockingIndex] = packet.CameraDocked;
+        mapRoomEntity.CameraDockingIds[packet.DockingIndex] = packet.CameraDocked ? packet.CameraId : null;
+
+        if (packet.CameraId != null)
+        {
+            if (packet.CameraDocked)
+            {
+                MapRoomCameraRegistry.RegisterDockedCamera(packet.CameraId, packet.MapRoomId, packet.DockingIndex);
+            }
+            else
+            {
+                MapRoomCameraRegistry.MarkCameraUndocked(packet.CameraId);
+                EnsureUndockedMapRoomCameraWorldEntityExists(packet.CameraId, mapRoomEntity);
+            }
+        }
+
+        logger.ZLogInformation($"Scanner room camera docking state updated: mapRoom={packet.MapRoomId}, index={packet.DockingIndex}, docked={packet.CameraDocked}, cameraId={packet.CameraId}, states=[{string.Join(", ", mapRoomEntity.CameraDockingStates)}], cameraIds=[{string.Join(", ", mapRoomEntity.CameraDockingIds)}]");
+
+        await context.SendToOthersAsync(packet);
+    }
+
+    private void EnsureUndockedMapRoomCameraWorldEntityExists(NitroxId cameraId, MapRoomEntity mapRoomEntity)
+    {
+        if (cameraId == null)
+        {
+            return;
+        }
+
+        if (entityRegistry.TryGetEntityById<WorldEntity>(cameraId, out WorldEntity existingWorldEntity))
+        {
+            logger.ZLogInformation($"Scanner room camera already registered as WorldEntity on undock: cameraId={cameraId}, entityType={existingWorldEntity.GetType().Name}, classId={existingWorldEntity.ClassId}, techType={existingWorldEntity.TechType}, level={existingWorldEntity.Level}, parentId={existingWorldEntity.ParentId}");
+            return;
+        }
+
+        if (entityRegistry.TryGetEntityById<Entity>(cameraId, out Entity existingEntity))
+        {
+            logger.ZLogWarning($"Scanner room camera id exists in entity registry but is not a WorldEntity; registering world entity anyway: cameraId={cameraId}, existingType={existingEntity.GetType().Name}");
+        }
+
+        NitroxTransform transform = mapRoomEntity.Transform;
+
+        GlobalRootEntity cameraEntity = new(
+            transform,
+            GlobalRootEntity.GLOBAL_ROOT_LEVEL,
+            MAP_ROOM_CAMERA_PREFAB_CLASS_ID,
+            true,
+            cameraId,
+            TechType.MapRoomCamera.ToDto(),
+            null,
+            null,
+            new List<Entity>());
+
+        logger.ZLogInformation($"Registering legacy undocked scanner room camera world entity before AddOrUpdateGlobalRootEntity: cameraId={cameraId}, mapRoom={mapRoomEntity.Id}, classId={MAP_ROOM_CAMERA_PREFAB_CLASS_ID}, level={GlobalRootEntity.GLOBAL_ROOT_LEVEL}");
+
+        worldEntityManager.AddOrUpdateGlobalRootEntity(cameraEntity);
+
+        logger.ZLogInformation($"Registered legacy undocked scanner room camera world entity: cameraId={cameraId}, mapRoom={mapRoomEntity.Id}, classId={MAP_ROOM_CAMERA_PREFAB_CLASS_ID}, level={GlobalRootEntity.GLOBAL_ROOT_LEVEL}");
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraLightChangedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraLightChangedProcessor.cs
@@ -1,0 +1,12 @@
+using Nitrox.Model.Subnautica.Packets;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+internal sealed class MapRoomCameraLightChangedProcessor : IAuthPacketProcessor<MapRoomCameraLightChanged>
+{
+    public async Task Process(AuthProcessorContext context, MapRoomCameraLightChanged packet)
+    {
+        await context.SendToOthersAsync(packet);
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraNumberChangedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/MapRoomCameraNumberChangedProcessor.cs
@@ -1,0 +1,39 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
+using Nitrox.Model.Subnautica.Packets;
+using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+internal sealed class MapRoomCameraNumberChangedProcessor(ILogger<MapRoomCameraNumberChangedProcessor> logger) : IAuthPacketProcessor<MapRoomCameraNumberChanged>
+{
+    private readonly ILogger<MapRoomCameraNumberChangedProcessor> logger = logger;
+
+    public async Task Process(AuthProcessorContext context, MapRoomCameraNumberChanged packet)
+    {
+        if (packet.CameraId == null)
+        {
+            return;
+        }
+
+        if (packet.CameraNumber == 0)
+        {
+            MapRoomCameraRegistry.DeregisterCamera(packet.CameraId);
+
+            logger.ZLogInformation($"Scanner camera registry released: cameraId={packet.CameraId}, registry=[{MapRoomCameraRegistry.GetDebugText()}]");
+
+            await context.SendToAllAsync(new MapRoomCameraNumberChanged(packet.CameraId, 0));
+            return;
+        }
+
+        MapRoomCameraRegistryEntry entry = MapRoomCameraRegistry.RegisterOrUpdateCamera(packet.CameraId, packet.MapRoomId, packet.DockingIndex);
+
+        logger.ZLogInformation($"Scanner camera registry assigned: cameraId={entry.CameraId}, number={entry.CameraNumber}, mapRoom={entry.MapRoomId}, dockingIndex={entry.DockingIndex}, registry=[{MapRoomCameraRegistry.GetDebugText()}]");
+
+        await context.SendToAllAsync(new MapRoomCameraNumberChanged(
+            entry.CameraId,
+            entry.CameraNumber,
+            entry.MapRoomId,
+            entry.DockingIndex));
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Serialization/World/WorldService.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/WorldService.cs
@@ -8,7 +8,9 @@ using Nitrox.Model.Serialization;
 using Nitrox.Model.Server;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
 using Nitrox.Server.Subnautica.Models.GameLogic;
+using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities.Spawning;
 using Nitrox.Server.Subnautica.Models.GameLogic.Players;
@@ -40,6 +42,9 @@ internal class WorldService : IHostedService
     private readonly WorldEntityManager worldEntityManager;
     public IServerSerializer Serializer { get; private set; }
     private string FileEnding => Serializer?.FileEnding ?? "";
+
+    private const string LEGACY_MAP_ROOM_CAMERA_CLASS_ID = "MapRoomCamera";
+    private const string MAP_ROOM_CAMERA_PREFAB_CLASS_ID = "733fd479-0760-4bc2-a03e-281cbf02bfa4";
 
     public WorldService(
         SubnauticaServerProtoBufSerializer protoBufSerializer,
@@ -319,8 +324,17 @@ internal class WorldService : IHostedService
         // Time
         timeService.ActiveTime = TimeSpan.FromSeconds(pWorldData.WorldData.GameData.StoryTiming.RealTimeElapsed);
         // Entities
+        // Entities
+        // Entities
+        NormalizeLooseMapRoomCameraWorldEntities(pWorldData);
+        PurgeLegacyBrokenMapRoomCameraEntities(pWorldData);
+
         entityRegistry.AddEntities(pWorldData.EntityData.Entities);
         entityRegistry.AddEntitiesIgnoringDuplicate(pWorldData.GlobalRootData.Entities.OfType<Entity>().ToList());
+
+        SanitizeLegacyMapRoomCameraDockingState(entityRegistry);
+        MapRoomCameraRegistry.LoadFromSave(pWorldData.WorldData.GameData?.MapRoomCameraRegistry, entityRegistry);
+
         await escapePodManager.AddKnownPodsAsync(entityRegistry.GetEntities<EscapePodEntity>());
 
         // TODO: hacky code - see WorldEntityManager for more information.
@@ -347,6 +361,220 @@ internal class WorldService : IHostedService
         storyManager.AuroraRealExplosionTime = TimeSpan.FromSeconds(pWorldData.WorldData.GameData.StoryTiming.AuroraRealExplosionTime ?? storyManager.AuroraCountdownTimeMs * 0.001 + 27 - TimeService.DEFAULT_STARTING_GAME_TIME_SECONDS);
 
         logger.ZLogInformation($"World finished loading");
+    }
+
+    private void NormalizeLooseMapRoomCameraWorldEntities(PersistedWorldData pWorldData)
+    {
+        List<WorldEntity> looseCameraEntities = pWorldData.EntityData.Entities
+                                                              .Where(entity => entity != null)
+                                                              .Cast<Entity>()
+                                                              .Concat(pWorldData.GlobalRootData.Entities
+                                                                                          .Where(entity => entity != null)
+                                                                                          .Cast<Entity>())
+                                                              .OfType<WorldEntity>()
+                                                              .Where(entity => entity.ParentId == null)
+                                                              .Where(IsLooseMapRoomCameraWorldEntity)
+                                                              .ToList();
+
+        foreach (WorldEntity worldEntity in looseCameraEntities)
+        {
+            string oldClassId = worldEntity.ClassId ?? "";
+            string oldTechType = worldEntity.TechType?.ToString() ?? "";
+            int oldLevel = worldEntity.Level;
+
+            worldEntity.ClassId = MAP_ROOM_CAMERA_PREFAB_CLASS_ID;
+            worldEntity.TechType = TechType.MapRoomCamera.ToDto();
+
+            if (worldEntity is GlobalRootEntity)
+            {
+                worldEntity.Level = GlobalRootEntity.GLOBAL_ROOT_LEVEL;
+            }
+
+            logger.ZLogWarning($"Normalized loose scanner room camera world entity: id={worldEntity.Id}, oldClassId={oldClassId}, newClassId={worldEntity.ClassId}, oldTechType={oldTechType}, newTechType={worldEntity.TechType}, oldLevel={oldLevel}, newLevel={worldEntity.Level}, entityType={worldEntity.GetType().Name}, position={worldEntity.Transform?.Position}");
+        }
+    }
+
+    private static bool IsLooseMapRoomCameraWorldEntity(WorldEntity worldEntity)
+    {
+        string techType = worldEntity.TechType?.ToString() ?? "";
+        string classId = worldEntity.ClassId ?? "";
+        string entityText = worldEntity.ToString();
+
+        return techType == "MapRoomCamera" ||
+               classId == LEGACY_MAP_ROOM_CAMERA_CLASS_ID ||
+               classId == MAP_ROOM_CAMERA_PREFAB_CLASS_ID ||
+               classId.Contains("MapRoomCamera") ||
+               entityText.Contains("MapRoomCamera");
+    }
+
+    private void PurgeLegacyBrokenMapRoomCameraEntities(PersistedWorldData pWorldData)
+    {
+        HashSet<NitroxId> validDockedCameraIds = pWorldData.GlobalRootData.Entities
+                                                           .OfType<MapRoomEntity>()
+                                                           .Where(mapRoomEntity => mapRoomEntity.CameraDockingIds != null)
+                                                           .SelectMany(mapRoomEntity => mapRoomEntity.CameraDockingIds)
+                                                           .Where(cameraId => cameraId != null)
+                                                           .ToHashSet();
+
+        HashSet<NitroxId> validRegistryCameraIds = pWorldData.WorldData.GameData?.MapRoomCameraRegistry?
+                                                            .Where(entry => entry.CameraId != null)
+                                                            .Select(entry => entry.CameraId)
+                                                            .ToHashSet() ?? [];
+
+        List<Entity> allEntities = pWorldData.EntityData.Entities
+                                     .Where(entity => entity != null)
+                                     .Cast<Entity>()
+                                     .Concat(pWorldData.GlobalRootData.Entities
+                                                           .Where(entity => entity != null)
+                                                           .Cast<Entity>())
+                                     .ToList();
+
+        HashSet<NitroxId> validLooseCameraIds = allEntities
+                                                .OfType<WorldEntity>()
+                                                .Where(entity => entity.Id != null)
+                                                .Where(entity => entity.ParentId == null)
+                                                .Where(IsLooseMapRoomCameraWorldEntity)
+                                                .Select(entity => entity.Id)
+                                                .ToHashSet();
+
+        HashSet<NitroxId> validCameraIds = validDockedCameraIds;
+        validCameraIds.UnionWith(validRegistryCameraIds);
+        validCameraIds.UnionWith(validLooseCameraIds);
+
+        Dictionary<NitroxId, Entity> allEntitiesById = allEntities
+                                                       .Where(entity => entity.Id != null)
+                                                       .GroupBy(entity => entity.Id)
+                                                       .ToDictionary(group => group.Key, group => group.First());
+
+        HashSet<NitroxId> batteryParentIds = allEntities
+                                             .Where(IsBatteryChildEntity)
+                                             .Where(entity => entity.ParentId != null)
+                                             .Select(entity => entity.ParentId)
+                                             .ToHashSet();
+
+        HashSet<NitroxId> legacyCameraIdsToRemove = allEntities
+                                                    .Where(entity => entity.Id != null)
+                                                    .Where(entity => !validCameraIds.Contains(entity.Id))
+                                                    .Where(entity => IsLegacyScannerCameraRootCandidate(entity, batteryParentIds))
+                                                    .Select(entity => entity.Id)
+                                                    .ToHashSet();
+
+        // Extra safety: if the save has battery children whose parent is one of the known bad scanner-camera-like roots,
+        // include the parent root too. This catches old camera roots whose TechType is null or not MapRoomCamera.
+        foreach (NitroxId batteryParentId in batteryParentIds)
+        {
+            if (batteryParentId == null || validCameraIds.Contains(batteryParentId))
+            {
+                continue;
+            }
+
+            if (!allEntitiesById.TryGetValue(batteryParentId, out Entity parentEntity))
+            {
+                continue;
+            }
+
+            if (IsLegacyScannerCameraRootCandidate(parentEntity, batteryParentIds))
+            {
+                legacyCameraIdsToRemove.Add(batteryParentId);
+            }
+        }
+
+        if (legacyCameraIdsToRemove.Count == 0)
+        {
+            logger.ZLogWarning($"No legacy broken scanner room camera root entities matched purge. Battery parents=[{string.Join(", ", batteryParentIds)}], validCameraIds=[{string.Join(", ", validCameraIds)}]");
+            return;
+        }
+
+        int removedEntityCount = RemoveEntitiesAndChildren(pWorldData.EntityData.Entities, legacyCameraIdsToRemove);
+        int removedGlobalRootCount = RemoveEntitiesAndChildren(pWorldData.GlobalRootData.Entities, legacyCameraIdsToRemove);
+
+        pWorldData.WorldData.GameData?.MapRoomCameraRegistry?.RemoveAll(entry => entry.CameraId != null && legacyCameraIdsToRemove.Contains(entry.CameraId));
+
+        logger.ZLogWarning($"Purged legacy broken scanner room camera roots [{string.Join(", ", legacyCameraIdsToRemove)}] and {removedEntityCount + removedGlobalRootCount} total related entities from saved world data.");
+    }
+
+    private static bool IsLegacyScannerCameraRootCandidate(Entity entity, HashSet<NitroxId> batteryParentIds)
+    {
+        if (entity is not WorldEntity worldEntity)
+        {
+            return false;
+        }
+
+        if (worldEntity.ParentId != null)
+        {
+            return false;
+        }
+
+        if (!batteryParentIds.Contains(worldEntity.Id))
+        {
+            return false;
+        }
+
+        string techType = worldEntity.TechType?.ToString() ?? "";
+        string classId = worldEntity.ClassId ?? "";
+        string entityText = worldEntity.ToString();
+
+        return techType == "MapRoomCamera" ||
+               classId.Contains("MapRoomCamera") ||
+               entityText.Contains("MapRoomCamera");
+    }
+
+    private static bool IsBatteryChildEntity(Entity entity)
+    {
+        return entity is PrefabChildEntity childEntity &&
+               childEntity.TechType.ToString() == "Battery";
+    }
+
+    private static int RemoveEntitiesAndChildren<T>(List<T> entities, HashSet<NitroxId> rootIdsToRemove) where T : Entity
+    {
+        HashSet<NitroxId> idsToRemove = new(rootIdsToRemove);
+        bool foundNewChild;
+
+        do
+        {
+            foundNewChild = false;
+
+            foreach (Entity entity in entities.Where(entity => entity != null))
+            {
+                if (entity.ParentId != null &&
+                    entity.Id != null &&
+                    idsToRemove.Contains(entity.ParentId) &&
+                    idsToRemove.Add(entity.Id))
+                {
+                    foundNewChild = true;
+                }
+            }
+        }
+        while (foundNewChild);
+
+        return entities.RemoveAll(entity => entity?.Id != null && idsToRemove.Contains(entity.Id));
+    }
+
+    private void SanitizeLegacyMapRoomCameraDockingState(EntityRegistry entityRegistry)
+    {
+        foreach (MapRoomEntity mapRoomEntity in entityRegistry.GetEntities<MapRoomEntity>())
+        {
+            if (mapRoomEntity.CameraDockingStates == null)
+            {
+                continue;
+            }
+
+            mapRoomEntity.CameraDockingIds ??= [];
+
+            while (mapRoomEntity.CameraDockingIds.Count < mapRoomEntity.CameraDockingStates.Count)
+            {
+                mapRoomEntity.CameraDockingIds.Add(null);
+            }
+
+            for (int i = 0; i < mapRoomEntity.CameraDockingStates.Count; i++)
+            {
+                if (mapRoomEntity.CameraDockingStates[i] && mapRoomEntity.CameraDockingIds[i] == null)
+                {
+                    logger.ZLogWarning($"Clearing legacy scanner room docking state with no camera id. mapRoom={mapRoomEntity.Id}, dockingIndex={i}");
+                    mapRoomEntity.CameraDockingStates[i] = false;
+                }
+            }
+        }
     }
 
     private async Task<bool> LoadWorldFromSavePathAsync(string saveDir)

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -157,7 +157,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     yield return entities.SpawnEntityAsync(baseLeakEntity, true);

--- a/NitroxClient/Communication/Packets/Processors/MapRoomCameraDockingChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/MapRoomCameraDockingChangedProcessor.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.MonoBehaviours;
+using NitroxClient.GameLogic.Bases;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public sealed class MapRoomCameraDockingChangedProcessor : IClientPacketProcessor<MapRoomCameraDockingChanged>
+{
+    public Task Process(ClientProcessorContext context, MapRoomCameraDockingChanged packet)
+    {
+        if (!NitroxEntity.TryGetObjectFrom(packet.MapRoomId, out GameObject mapRoomObject))
+        {
+            Log.Warn($"Could not find scanner room for camera docking update: {packet.MapRoomId}");
+            return Task.CompletedTask;
+        }
+
+        MapRoomFunctionality mapRoomFunctionality = mapRoomObject.GetComponent<MapRoomFunctionality>();
+        if (!mapRoomFunctionality)
+        {
+            Log.Warn($"Could not find MapRoomFunctionality on scanner room docking update target: {mapRoomObject.GetFullHierarchyPath()}");
+            return Task.CompletedTask;
+        }
+
+        List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                  .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                                                  .ToList();
+
+        if (packet.DockingIndex < 0 || packet.DockingIndex >= dockings.Count)
+        {
+            Log.Warn($"Scanner room camera docking index out of range: {packet.DockingIndex}, count={dockings.Count}");
+            return Task.CompletedTask;
+        }
+
+        using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+        {
+            ApplyDockingState(dockings[packet.DockingIndex], packet);
+        }
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+
+        return Task.CompletedTask;
+    }
+
+    private static void ApplyDockingState(MapRoomCameraDocking docking, MapRoomCameraDockingChanged packet)
+    {
+        if (!packet.CameraDocked)
+        {
+            ApplyLiveUndockState(docking, packet);
+            return;
+        }
+
+        if (packet.CameraId == null)
+        {
+            docking.cameraDocked = true;
+            return;
+        }
+
+        if (!NitroxEntity.TryGetObjectFrom(packet.CameraId, out GameObject cameraObject))
+        {
+            Log.Warn($"Could not find scanner room camera {packet.CameraId} for docking update");
+            docking.cameraDocked = true;
+            return;
+        }
+
+        MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+        if (!camera)
+        {
+            Log.Warn($"Scanner room camera docking update target did not have MapRoomCamera: {cameraObject.GetFullHierarchyPath()}");
+            docking.cameraDocked = true;
+            return;
+        }
+
+        using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+        {
+            if (docking.camera && docking.camera != camera)
+            {
+                ClearDockingSlot(docking);
+            }
+
+            if (docking.camera != camera)
+            {
+                docking.DockCamera(camera);
+            }
+
+            NormalizeDockedMapRoomCamera(camera, docking);
+        }
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+    }
+
+    private static void NormalizeDockedMapRoomCamera(MapRoomCamera camera, MapRoomCameraDocking docking)
+    {
+        camera.transform.SetPositionAndRotation(docking.transform.position, docking.transform.rotation);
+
+        camera.SetDocked(docking);
+
+        camera.readyForControl = true;
+        camera.justStartedControl = false;
+
+        if (camera.rigidBody)
+        {
+            camera.rigidBody.velocity = Vector3.zero;
+            camera.rigidBody.angularVelocity = Vector3.zero;
+            camera.rigidBody.isKinematic = true;
+            camera.rigidBody.position = docking.transform.position;
+            camera.rigidBody.rotation = docking.transform.rotation;
+        }
+    }
+
+    private static void ApplyLiveUndockState(MapRoomCameraDocking docking, MapRoomCameraDockingChanged packet)
+    {
+        // Old/restore-style empty slot update with no specific camera id:
+        // clear any local placeholder/default dock camera.
+        if (packet.CameraId == null)
+        {
+            ClearDockingSlot(docking);
+            return;
+        }
+
+        if (!NitroxEntity.TryGetObjectFrom(packet.CameraId, out GameObject cameraObject))
+        {
+            Log.Warn($"Could not find scanner room camera {packet.CameraId} for undocking update");
+            docking.camera = null;
+            docking.cameraDocked = false;
+            return;
+        }
+
+        MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+        if (!camera)
+        {
+            Log.Warn($"Scanner room camera undocking update target did not have MapRoomCamera: {cameraObject.GetFullHierarchyPath()}");
+            docking.camera = null;
+            docking.cameraDocked = false;
+            return;
+        }
+
+        using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+        {
+            if (docking.camera == camera)
+            {
+                docking.UndockCamera();
+            }
+            else
+            {
+                camera.transform.position = docking.undockTransform.position;
+                camera.transform.rotation = docking.undockTransform.rotation;
+                camera.SetDocked(null);
+
+                docking.camera = null;
+                docking.cameraDocked = false;
+            }
+        }
+
+        if (camera.rigidBody)
+        {
+            camera.rigidBody.isKinematic = false;
+            camera.rigidBody.velocity = Vector3.zero;
+            camera.rigidBody.angularVelocity = Vector3.zero;
+        }
+    }
+
+    private static void ClearDockingSlot(MapRoomCameraDocking docking)
+    {
+        if (docking.camera)
+        {
+            NitroxEntity.RemoveFrom(docking.camera.gameObject);
+            Object.Destroy(docking.camera.gameObject);
+        }
+
+        docking.camera = null;
+        docking.cameraDocked = false;
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/MapRoomCameraLightChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/MapRoomCameraLightChangedProcessor.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.MonoBehaviours;
+using Nitrox.Model.Subnautica.Packets;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public sealed class MapRoomCameraLightChangedProcessor : IClientPacketProcessor<MapRoomCameraLightChanged>
+{
+    public Task Process(ClientProcessorContext context, MapRoomCameraLightChanged packet)
+    {
+        if (!NitroxEntity.TryGetObjectFrom(packet.CameraId, out GameObject cameraObject))
+        {
+            Log.Warn($"Could not find scanner room camera for light update: {packet.CameraId}");
+            return Task.CompletedTask;
+        }
+
+        MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+        if (!camera)
+        {
+            Log.Warn($"Light update target did not have MapRoomCamera: {cameraObject.GetFullHierarchyPath()}");
+            return Task.CompletedTask;
+        }
+
+        using (PacketSuppressor<MapRoomCameraLightChanged>.Suppress())
+        {
+            camera.lightState = packet.LightState;
+            camera.lightsParent.SetActive(packet.LightState);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/MapRoomCameraNumberChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/MapRoomCameraNumberChangedProcessor.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.GameLogic.Spawning.WorldEntities;
+using NitroxClient.MonoBehaviours;
+using UWE;
+using UnityEngine;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public sealed class MapRoomCameraNumberChangedProcessor : IClientPacketProcessor<MapRoomCameraNumberChanged>
+{
+    private static readonly HashSet<NitroxId> batteryEnsureInProgress = [];
+
+    public Task Process(ClientProcessorContext context, MapRoomCameraNumberChanged packet)
+    {
+        MapRoomCameraIdentity.ApplyCameraNumber(packet.CameraId, packet.CameraNumber);
+
+        if (packet.CameraId != null && packet.CameraNumber > 0)
+        {
+            CoroutineHost.StartCoroutine(ApplyCameraNumberWhenCameraExists(packet));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static IEnumerator ApplyCameraNumberWhenCameraExists(MapRoomCameraNumberChanged packet)
+    {
+        for (int attempt = 0; attempt < 300; attempt++)
+        {
+            if (TryApplyLiveCameraNumber(packet, attempt))
+            {
+                yield break;
+            }
+
+            yield return null;
+        }
+
+        Log.Warn($"SCANNER_CAMERA_NUMBER_APPLY_TIMEOUT cameraId={packet.CameraId} number={packet.CameraNumber} cameraListCount={MapRoomCamera.cameras.Count}");
+    }
+
+    private static bool TryApplyLiveCameraNumber(MapRoomCameraNumberChanged packet, int attempt)
+    {
+        if (packet.CameraId == null || packet.CameraNumber <= 0)
+        {
+            return true;
+        }
+
+        if (!NitroxEntity.TryGetObjectFrom(packet.CameraId, out GameObject cameraObject) || !cameraObject)
+        {
+            return false;
+        }
+
+        MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+        if (!camera)
+        {
+            Log.Warn($"SCANNER_CAMERA_NUMBER_TARGET_NOT_CAMERA cameraId={packet.CameraId} object={cameraObject.GetFullHierarchyPath()} number={packet.CameraNumber}");
+            return true;
+        }
+
+        if (!IsActiveWorldCamera(camera))
+        {
+            return false;
+        }
+
+        MapRoomCamera.cameras.RemoveAll(candidate => !candidate);
+
+        if (!MapRoomCamera.cameras.Contains(camera))
+        {
+            MapRoomCamera.cameras.Add(camera);
+        }
+
+        if (camera.cameraNumber != packet.CameraNumber)
+        {
+            camera.cameraNumber = packet.CameraNumber;
+            camera.UpdatePingLabel();
+        }
+
+        camera.readyForControl = true;
+
+        if (!batteryEnsureInProgress.Contains(packet.CameraId))
+        {
+            batteryEnsureInProgress.Add(packet.CameraId);
+            CoroutineHost.StartCoroutine(EnsureMapRoomCameraHasBattery(camera, packet.CameraId));
+        }
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+
+        return true;
+    }
+
+    private static NitroxId GetMapRoomCameraBatteryId(NitroxId cameraId)
+    {
+        using MD5 md5 = MD5.Create();
+
+        byte[] inputBytes = Encoding.UTF8.GetBytes($"map-room-camera-battery:{cameraId}");
+        byte[] hashBytes = md5.ComputeHash(inputBytes);
+
+        byte[] guidBytes = new byte[16];
+        Array.Copy(hashBytes, guidBytes, guidBytes.Length);
+
+        return new NitroxId(new Guid(guidBytes));
+    }
+
+    private static IEnumerator EnsureMapRoomCameraHasBattery(MapRoomCamera camera, NitroxId cameraId)
+    {
+        try
+        {
+            if (!camera)
+            {
+                yield break;
+            }
+
+            EnergyMixin energyMixin = camera.GetComponent<EnergyMixin>();
+            if (!energyMixin)
+            {
+                Log.Warn($"SCANNER_CAMERA_NUMBER_BATTERY_SKIP reason=missingEnergyMixin cameraId={cameraId} camera={camera.gameObject.GetFullHierarchyPath()}");
+                yield break;
+            }
+
+            if (energyMixin.battery != null)
+            {
+                if (energyMixin.capacity > 0f)
+                {
+                    energyMixin.AddEnergy(energyMixin.capacity);
+                }
+
+                yield break;
+            }
+
+            TechType batteryTechType = energyMixin.defaultBattery != TechType.None
+                ? energyMixin.defaultBattery
+                : TechType.Battery;
+
+            GameObject batteryPrefab;
+            if (!DefaultWorldEntitySpawner.TryGetCachedPrefab(out batteryPrefab, batteryTechType))
+            {
+                TaskResult<GameObject> prefabResult = new();
+                yield return DefaultWorldEntitySpawner.RequestPrefab(batteryTechType, prefabResult);
+
+                batteryPrefab = prefabResult.Get();
+                if (!batteryPrefab)
+                {
+                    Log.Warn($"SCANNER_CAMERA_NUMBER_BATTERY_SKIP reason=missingBatteryPrefab cameraId={cameraId} techType={batteryTechType} camera={camera.gameObject.GetFullHierarchyPath()}");
+                    yield break;
+                }
+            }
+
+            GameObject batteryObject = UnityEngine.Object.Instantiate(batteryPrefab);
+            batteryObject.SetActive(true);
+
+            if (cameraId != null)
+            {
+                NitroxEntity.SetNewId(batteryObject, GetMapRoomCameraBatteryId(cameraId));
+            }
+
+            Pickupable pickupable = batteryObject.GetComponent<Pickupable>();
+            Battery battery = batteryObject.GetComponent<Battery>();
+
+            if (!pickupable || !battery)
+            {
+                Log.Warn($"SCANNER_CAMERA_NUMBER_BATTERY_SKIP reason=spawnedBatteryMissingComponents cameraId={cameraId} techType={batteryTechType} camera={camera.gameObject.GetFullHierarchyPath()}");
+
+                UnityEngine.Object.Destroy(batteryObject);
+                yield break;
+            }
+
+            energyMixin.batterySlot.AddItem(new InventoryItem(pickupable));
+
+            if (energyMixin.capacity > 0f)
+            {
+                energyMixin.AddEnergy(energyMixin.capacity);
+            }
+            else if (battery.capacity > 0f)
+            {
+                battery.charge = battery.capacity;
+            }
+
+            camera.readyForControl = true;
+        }
+        finally
+        {
+            batteryEnsureInProgress.Remove(cameraId);
+        }
+    }
+
+    private static bool IsActiveWorldCamera(MapRoomCamera camera)
+    {
+        if (!camera)
+        {
+            return false;
+        }
+
+        if (camera.pickupAble && camera.pickupAble.attached)
+        {
+            return false;
+        }
+
+        return camera.isActiveAndEnabled &&
+               !camera.gameObject.GetFullHierarchyPath().Contains("/Inventory/");
+    }
+}

--- a/NitroxClient/GameLogic/Bases/BuildUtils.cs
+++ b/NitroxClient/GameLogic/Bases/BuildUtils.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
-using NitroxClient.GameLogic.Settings;
-using NitroxClient.GameLogic.Spawning.Bases;
-using NitroxClient.GameLogic.Spawning.Metadata;
-using NitroxClient.MonoBehaviours;
+using System.Linq;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Bases;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.Settings;
+using NitroxClient.GameLogic.Spawning.Bases;
+using NitroxClient.GameLogic.Spawning.Metadata;
+using NitroxClient.MonoBehaviours;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Bases;
@@ -160,14 +162,23 @@ public static class BuildUtils
         if (isMapRoomGhost)
         {
             MapRoomFunctionality mapRoomFunctionality = baseGhost.targetBase.GetMapRoomFunctionalityForCell(face.Value.cell);
+            bool hasParentBase = constructableBase.GetComponentInParent<Base>(true);
+
+            if (!mapRoomFunctionality)
+            {
+                mapRoomFunctionality = FindUnregisteredMapRoomFunctionality(baseGhost.targetBase);
+            }
+
             if (mapRoomFunctionality)
             {
                 // As MapRooms can be built as the first piece of a base, we need to make sure that they receive a new id if they're not in a base
-                NitroxId nitroxId = constructableBase.GetComponentInParent<Base>(true) ? id : id.Increment();
+                NitroxId nitroxId = hasParentBase ? id : id.Increment();         
+                
                 NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, nitroxId);
-                moduleObject = mapRoomFunctionality.gameObject;
+                moduleObject = mapRoomFunctionality.gameObject;                
                 return true;
             }
+
             Log.Error($"Couldn't find MapRoomFunctionality of built MapRoom (cell: {face.Value.cell})");
             moduleObject = null;
             return false;
@@ -223,10 +234,79 @@ public static class BuildUtils
         return baseGhost.targetBase.NormalizeCell(baseGhost.targetBase.WorldToGrid(baseGhost.ghostBase.occupiedBounds.center));
     }
 
-    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId)
+    public static MapRoomEntity CreateMapRoomEntityFrom(MapRoomFunctionality mapRoomFunctionality, Base @base, NitroxId id, NitroxId parentId, EntityMetadataManager entityMetadataManager)
     {
         Int3 mapRoomCell = @base.NormalizeCell(@base.WorldToGrid(mapRoomFunctionality.transform.position));
-        return new(id, parentId, mapRoomCell.ToDto());
+        MapRoomEntity mapRoomEntity = new(id, parentId, mapRoomCell.ToDto(), GetMapRoomCameraDockingStates(mapRoomFunctionality), GetMapRoomCameraDockingIds(mapRoomFunctionality));
+
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (opContainer.HasValue)
+        {
+            ItemsContainer container = opContainer.Value;
+
+            List<Pickupable> pickupables = container._items.Values
+                                                 .SelectMany(itemGroup => itemGroup.items)
+                                                 .Select(item => item.item)
+                                                 .Where(pickupable => pickupable)
+                                                 .ToList();
+
+            foreach (Pickupable pickupable in pickupables)
+            {
+                mapRoomEntity.ChildEntities.Add(Items.ConvertToInventoryItemEntity(pickupable.gameObject, id, entityMetadataManager));
+            }
+        }
+        else
+        {
+            Log.Warn($"Could not find scanner room upgrade container for {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return mapRoomEntity;
+    }
+
+    private static List<bool> GetMapRoomCameraDockingStates(MapRoomFunctionality mapRoomFunctionality)
+    {
+        return mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                   .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                   .Select(docking => docking.cameraDocked)
+                                   .ToList();
+    }
+
+    private static List<NitroxId> GetMapRoomCameraDockingIds(MapRoomFunctionality mapRoomFunctionality)
+    {
+        return mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                   .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                   .Select(docking =>
+                                   {
+                                       if (docking.camera && docking.camera.TryGetNitroxId(out NitroxId cameraId))
+                                       {
+                                           return cameraId;
+                                       }
+
+                                       return null;
+                                   })
+                                   .ToList();
+    }
+
+    private static MapRoomFunctionality FindUnregisteredMapRoomFunctionality(Base targetBase)
+    {
+        List<MapRoomFunctionality> candidates = targetBase.GetComponentsInChildren<MapRoomFunctionality>(true)
+                                                          .Where(mapRoomFunctionality => !mapRoomFunctionality.TryGetNitroxId(out _))
+                                                          .ToList();
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        Log.Warn($"Could not uniquely identify unregistered MapRoomFunctionality under {targetBase.gameObject.GetFullHierarchyPath()}. Found {candidates.Count} candidates.");
+
+        foreach (MapRoomFunctionality candidate in candidates)
+        {
+            Log.Warn($"Unregistered MapRoomFunctionality candidate: {candidate.gameObject.GetFullHierarchyPath()}");
+        }
+
+        return null;
     }
 
     // TODO: Use this for a latter singleplayer save converter
@@ -270,7 +350,7 @@ public static class BuildUtils
                 {
                     continue;
                 }
-                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId));
+                AddChild(CreateMapRoomEntityFrom(mapRoomFunctionality, targetBase, mapRoomId, baseId, entityMetadataManager));
             }
             else if (transform.TryGetComponent(out IBaseModule baseModule))
             {

--- a/NitroxClient/GameLogic/Bases/MapRoomCameraIdentity.cs
+++ b/NitroxClient/GameLogic/Bases/MapRoomCameraIdentity.cs
@@ -1,0 +1,350 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Nitrox.Model.Core;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Bases;
+
+public static class MapRoomCameraIdentity
+{
+    private static readonly Dictionary<NitroxId, int> cameraNumbersById = [];
+
+    public static void ApplyCameraNumber(NitroxId cameraId, int cameraNumber)
+    {
+        if (cameraId == null)
+        {
+            return;
+        }
+
+        if (cameraNumber <= 0)
+        {
+            cameraNumbersById.Remove(cameraId);
+            RemoveCameraFromScannerRegistry(cameraId);
+            return;
+        }
+
+        cameraNumbersById[cameraId] = cameraNumber;
+
+        ApplyCameraNumberToLiveCamera(cameraId, cameraNumber);
+        NormalizeCameraNumbers();
+    }
+
+    private static void ApplyCameraNumberToLiveCamera(NitroxId cameraId, int cameraNumber)
+    {
+        if (!NitroxEntity.TryGetObjectFrom(cameraId, out GameObject cameraObject) || !cameraObject)
+        {
+            return;
+        }
+
+        MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+        if (!camera || !IsActiveWorldCamera(camera))
+        {
+            return;
+        }
+
+        MapRoomCamera.cameras.RemoveAll(candidate => !candidate);
+
+        if (!MapRoomCamera.cameras.Contains(camera))
+        {
+            MapRoomCamera.cameras.Add(camera);
+        }
+
+        if (camera.cameraNumber != cameraNumber)
+        {
+            camera.cameraNumber = cameraNumber;
+            camera.UpdatePingLabel();
+        }
+    }
+
+    private static void RemoveCameraFromScannerRegistry(NitroxId cameraId)
+    {
+        MapRoomCamera camera = MapRoomCamera.cameras
+            .FirstOrDefault(candidate => candidate &&
+                                         candidate.TryGetNitroxId(out NitroxId candidateId) &&
+                                         candidateId == cameraId);
+
+        if (!camera)
+        {
+            return;
+        }
+
+        MapRoomCamera.cameras.Remove(camera);
+
+        if (camera.dockingPoint && camera.dockingPoint.camera == camera)
+        {
+            camera.dockingPoint.camera = null;
+            camera.dockingPoint.cameraDocked = false;
+        }
+
+        camera.SetDocked(null);
+        camera.UpdatePingLabel();
+    }
+
+    public static void AssignCameraNumber(MapRoomCamera camera, int cameraNumber)
+    {
+        if (!camera || cameraNumber <= 0)
+        {
+            return;
+        }
+
+        if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return;
+        }
+
+        cameraNumbersById[cameraId] = cameraNumber;
+
+        if (camera.cameraNumber != cameraNumber)
+        {
+            camera.cameraNumber = cameraNumber;
+            camera.UpdatePingLabel();
+        }
+
+        NormalizeCameraNumbers();
+    }
+
+    public static void RequestCameraNumber(MapRoomCamera camera, NitroxId mapRoomId = null, int dockingIndex = -1)
+    {
+        if (!IsActiveWorldCamera(camera))
+        {
+            return;
+        }
+
+        if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return;
+        }
+
+        NitroxServiceLocator.LocateService<IPacketSender>()
+                            .Send(new MapRoomCameraNumberChanged(cameraId, -1, mapRoomId, dockingIndex));
+    }
+
+    public static void ReleaseCameraNumber(MapRoomCamera camera)
+    {
+        if (!camera || !camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return;
+        }
+
+        cameraNumbersById.Remove(cameraId);
+        RemoveCameraFromScannerRegistry(cameraId);
+
+        if (camera.cameraNumber != 0)
+        {
+            camera.cameraNumber = 0;
+            camera.UpdatePingLabel();
+        }
+
+        NitroxServiceLocator.LocateService<IPacketSender>()
+                            .Send(new MapRoomCameraNumberChanged(cameraId, 0));
+
+        NormalizeCameraNumbers();
+    }
+
+    public static IEnumerator RequestCameraNumberWhenReady(MapRoomCamera camera)
+    {
+        for (int attempt = 0; attempt < 180; attempt++)
+        {
+            if (!camera)
+            {
+                yield break;
+            }
+
+            if (IsActiveWorldCamera(camera) && camera.TryGetNitroxId(out NitroxId cameraId) && cameraId != null)
+            {
+                cameraNumbersById.Remove(cameraId);
+                NitroxServiceLocator.LocateService<IPacketSender>()
+                                    .Send(new MapRoomCameraNumberChanged(cameraId, -1));
+                yield break;
+            }
+
+            yield return null;
+        }
+    }
+
+    public static void NormalizeCameraNumbers()
+    {
+        Dictionary<NitroxId, MapRoomCamera> camerasById = [];
+
+        foreach (MapRoomCamera camera in MapRoomCamera.cameras.ToList())
+        {
+            if (!camera || !IsActiveWorldCamera(camera))
+            {
+                continue;
+            }
+
+            if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+            {
+                continue;
+            }
+
+            if (!cameraNumbersById.TryGetValue(cameraId, out int assignedNumber) || assignedNumber <= 0)
+            {
+                continue;
+            }
+
+            if (!camerasById.TryGetValue(cameraId, out MapRoomCamera existingCamera) ||
+                ShouldPreferCamera(camera, existingCamera))
+            {
+                camerasById[cameraId] = camera;
+            }
+        }
+
+        MapRoomCamera.cameras.Clear();
+        MapRoomCamera.cameras.AddRange(camerasById.Values);
+
+        foreach (MapRoomCamera camera in MapRoomCamera.cameras)
+        {
+            if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+            {
+                continue;
+            }
+
+            if (!cameraNumbersById.TryGetValue(cameraId, out int assignedNumber) || assignedNumber <= 0)
+            {
+                continue;
+            }
+
+            if (camera.cameraNumber != assignedNumber)
+            {
+                camera.cameraNumber = assignedNumber;
+                camera.UpdatePingLabel();
+            }
+        }
+
+        MapRoomCamera.cameras.Sort(CompareCamerasByServerNumber);
+    }
+
+    public static void NotifyCameraPickedUp(MapRoomCamera camera)
+    {
+        if (!camera)
+        {
+            return;
+        }
+
+        NotifyDockingSlotClearedForPickedUpCamera(camera);
+        ReleaseCameraNumber(camera);
+    }
+
+    private static void NotifyDockingSlotClearedForPickedUpCamera(MapRoomCamera camera)
+    {
+        if (!camera.TryGetNitroxId(out NitroxId cameraId))
+        {
+            cameraId = null;
+        }
+
+        MapRoomCameraDocking docking = camera.dockingPoint;
+        if (!docking)
+        {
+            return;
+        }
+
+        MapRoomFunctionality mapRoomFunctionality = docking.GetComponentInParent<MapRoomFunctionality>(true);
+        if (!mapRoomFunctionality)
+        {
+            return;
+        }
+
+        if (!mapRoomFunctionality.TryGetNitroxId(out NitroxId mapRoomId) || mapRoomId == null)
+        {
+            return;
+        }
+
+        List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                  .OrderBy(candidate => candidate.gameObject.GetFullHierarchyPath())
+                                                                  .ToList();
+
+        int dockingIndex = dockings.IndexOf(docking);
+        if (dockingIndex < 0)
+        {
+            return;
+        }
+
+        NitroxServiceLocator.LocateService<IPacketSender>()
+                            .Send(new MapRoomCameraDockingChanged(mapRoomId, dockingIndex, false, cameraId));
+    }
+
+    private static bool ShouldPreferCamera(MapRoomCamera candidate, MapRoomCamera existing)
+    {
+        if (!existing)
+        {
+            return true;
+        }
+
+        if (!candidate)
+        {
+            return false;
+        }
+
+        bool candidateDocked = candidate.dockingPoint && candidate.dockingPoint.camera == candidate;
+        bool existingDocked = existing.dockingPoint && existing.dockingPoint.camera == existing;
+
+        if (candidateDocked != existingDocked)
+        {
+            return candidateDocked;
+        }
+
+        if (candidate.isActiveAndEnabled != existing.isActiveAndEnabled)
+        {
+            return candidate.isActiveAndEnabled;
+        }
+
+        return false;
+    }
+
+    private static int CompareCamerasByServerNumber(MapRoomCamera left, MapRoomCamera right)
+    {
+        int leftNumber = GetAssignedCameraNumberOrMax(left);
+        int rightNumber = GetAssignedCameraNumberOrMax(right);
+
+        int numberComparison = leftNumber.CompareTo(rightNumber);
+        if (numberComparison != 0)
+        {
+            return numberComparison;
+        }
+
+        return string.CompareOrdinal(TryGetCameraIdText(left), TryGetCameraIdText(right));
+    }
+
+    private static int GetAssignedCameraNumberOrMax(MapRoomCamera camera)
+    {
+        if (!camera || !camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return int.MaxValue;
+        }
+
+        return cameraNumbersById.TryGetValue(cameraId, out int cameraNumber) && cameraNumber > 0
+            ? cameraNumber
+            : int.MaxValue;
+    }
+
+    private static string TryGetCameraIdText(MapRoomCamera camera)
+    {
+        if (!camera || !camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return string.Empty;
+        }
+
+        return cameraId.ToString();
+    }
+
+    private static bool IsActiveWorldCamera(MapRoomCamera camera)
+    {
+        if (!camera)
+        {
+            return false;
+        }
+
+        if (camera.pickupAble && camera.pickupAble.attached)
+        {
+            return false;
+        }
+
+        return camera.isActiveAndEnabled;
+    }
+}

--- a/NitroxClient/GameLogic/Bases/MapRoomCameraPlayerAnchor.cs
+++ b/NitroxClient/GameLogic/Bases/MapRoomCameraPlayerAnchor.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Bases;
+
+public static class MapRoomCameraPlayerAnchor
+{
+    private static bool active;
+    private static Vector3 position;
+    private static Vector3 velocity;
+    private static Quaternion bodyRotation;
+    private static Quaternion aimingRotation;
+
+    public static bool Active => active;
+
+    public static void Begin(Vector3 currentPosition, Quaternion currentBodyRotation, Quaternion currentAimingRotation)
+    {
+        if (active)
+        {
+            return;
+        }
+
+        active = true;
+        position = currentPosition;
+        velocity = Vector3.zero;
+        bodyRotation = currentBodyRotation;
+        aimingRotation = currentAimingRotation;
+    }
+
+    public static void End()
+    {
+        if (!active)
+        {
+            return;
+        }
+
+        active = false;
+    }
+
+    public static bool TryGet(out Vector3 anchoredPosition, out Vector3 anchoredVelocity, out Quaternion anchoredBodyRotation, out Quaternion anchoredAimingRotation)
+    {
+        anchoredPosition = position;
+        anchoredVelocity = velocity;
+        anchoredBodyRotation = bodyRotation;
+        anchoredAimingRotation = aimingRotation;
+
+        return active;
+    }
+}

--- a/NitroxClient/GameLogic/Bases/MapRoomCameraStatusOverlay.cs
+++ b/NitroxClient/GameLogic/Bases/MapRoomCameraStatusOverlay.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Bases;
+
+public static class MapRoomCameraStatusOverlay
+{
+    private const float DEFAULT_DURATION_SECONDS = 3f;
+
+    private static OverlayBehaviour overlay;
+
+    public static void ShowAvailable(float durationSeconds = DEFAULT_DURATION_SECONDS)
+    {
+        Show("AVAILABLE", new Color(0.2f, 1f, 0.2f, 1f), durationSeconds);
+    }
+
+    public static void ShowInUse(float durationSeconds = DEFAULT_DURATION_SECONDS)
+    {
+        Show("IN USE", new Color(1f, 0.15f, 0.15f, 1f), durationSeconds);
+    }
+
+    private static void Show(string text, Color color, float durationSeconds)
+    {
+        EnsureOverlay();
+        overlay.Show(text, color, durationSeconds);
+    }
+
+    private static void EnsureOverlay()
+    {
+        if (overlay)
+        {
+            return;
+        }
+
+        GameObject overlayObject = new("[Nitrox] MapRoomCameraStatusOverlay");
+        UnityEngine.Object.DontDestroyOnLoad(overlayObject);
+        overlay = overlayObject.AddComponent<OverlayBehaviour>();
+    }
+
+    private sealed class OverlayBehaviour : MonoBehaviour
+    {
+        private const float X = 24f;
+        private const float Y = 24f;
+        private const float WIDTH = 420f;
+        private const float HEIGHT = 64f;
+
+        private string text;
+        private Color color;
+        private float hideAtTime;
+        private GUIStyle style;
+
+        public void Show(string statusText, Color statusColor, float durationSeconds)
+        {
+            text = statusText;
+            color = statusColor;
+            hideAtTime = Time.realtimeSinceStartup + durationSeconds;
+        }
+
+        private void OnGUI()
+        {
+            if (string.IsNullOrEmpty(text) || Time.realtimeSinceStartup > hideAtTime)
+            {
+                return;
+            }
+
+            style ??= new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 30,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.UpperLeft
+            };
+
+            style.normal.textColor = color;
+
+            GUI.depth = -1000;
+            GUI.Label(new Rect(X, Y, WIDTH, HEIGHT), text, style);
+        }
+    }
+}

--- a/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
+++ b/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
@@ -19,9 +19,10 @@ public static class BatteryChildEntityHelper
 {
     private static readonly Lazy<Entities> entities = new (() => NitroxServiceLocator.LocateService<Entities>());
 
-    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId)
+    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId, bool allowDefaultBattery = true)
     {
-        if (gameObject.TryGetComponent(out EnergyMixin energyMixin))
+        if (gameObject.TryGetComponent(out EnergyMixin energyMixin) &&
+            (allowDefaultBattery || energyMixin.batterySlot?.storedItem != null))
         {
             PopulateInstalledBattery(energyMixin, toPopulate, parentId);
         }

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -118,6 +118,12 @@ public class Items
         WorldEntity droppedItem;
         List<Entity> childrenEntities = GetPrefabChildren(gameObject, id, entityMetadataManager).ToList();
 
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(
+            gameObject,
+            childrenEntities,
+            id,
+            allowDefaultBattery: false);
+
         // If the item is dropped in a WaterPark we need to handle it differently
         NitroxId parentId = null;
         if (IsGlobalRootObject(gameObject) || (gameObject.GetComponent<Pickupable>() && TryGetParentWaterParkId(gameObject.transform.parent, out parentId)))
@@ -236,7 +242,8 @@ public class Items
     /// </summary>
     private InventoryItemEntity ConvertToInventoryEntityUntracked(GameObject gameObject, NitroxId parentId)
     {
-        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager);
+        bool isExistingEntity = gameObject.TryGetNitroxId(out NitroxId existingId) && entities.IsKnownEntity(existingId);
+        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager, !isExistingEntity);
 
         // Some picked up entities are not known by the server for several reasons.  First it can be picked up via a spawn item command.  Another
         // example is that some obects are not 'real' objects until they are clicked and end up spawning a prefab.  For example, the fire extinguisher
@@ -251,7 +258,7 @@ public class Items
         return inventoryItemEntity;
     }
 
-    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager)
+    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery = true)
     {
         NitroxId itemId = NitroxEntity.GetIdOrGenerateNew(gameObject); // id may not exist, create if missing
         string classId = gameObject.RequireComponent<PrefabIdentifier>().ClassId;
@@ -260,7 +267,7 @@ public class Items
         List<Entity> children = GetPrefabChildren(gameObject, itemId, entityMetadataManager).ToList();
 
         InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), metadata.OrNull(), parentId, children);
-        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId);
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId, allowDefaultBattery);
 
         return inventoryItemEntity;
     }

--- a/NitroxClient/GameLogic/Simulation/MapRoomCameraControl.cs
+++ b/NitroxClient/GameLogic/Simulation/MapRoomCameraControl.cs
@@ -1,0 +1,9 @@
+namespace NitroxClient.GameLogic.Simulation;
+
+public sealed class MapRoomCameraControl(MapRoomCamera camera, MapRoomScreen screen, string reason, bool showStatus) : LockRequestContext
+{
+    public MapRoomCamera Camera { get; } = camera;
+    public MapRoomScreen Screen { get; } = screen;
+    public string Reason { get; } = reason;
+    public bool ShowStatus { get; } = showStatus;
+}

--- a/NitroxClient/GameLogic/Simulation/MapRoomCameraUndock.cs
+++ b/NitroxClient/GameLogic/Simulation/MapRoomCameraUndock.cs
@@ -1,0 +1,6 @@
+namespace NitroxClient.GameLogic.Simulation;
+
+public sealed class MapRoomCameraUndock(MapRoomCamera camera) : LockRequestContext
+{
+    public MapRoomCamera Camera { get; } = camera;
+}

--- a/NitroxClient/GameLogic/SimulationOwnership.cs
+++ b/NitroxClient/GameLogic/SimulationOwnership.cs
@@ -59,8 +59,11 @@ namespace NitroxClient.GameLogic
 
             if (lockAquired)
             {
-                SimulateEntity(id, lockType);
-                TreatVehicleEntity(id, true, lockType);
+                if (!TreatMapRoomCameraEntity(id, true, lockType) &&
+                    !TreatVehicleEntity(id, true, lockType))
+                {
+                    SimulateEntity(id, lockType);
+                }
             }
 
             if (lockRequestsById.TryGetValue(id, out LockRequestBase lockRequest))
@@ -84,7 +87,8 @@ namespace NitroxClient.GameLogic
         {
             bool isLocalPlayerNewOwner = multiplayerSession.Reservation.SessionId == simulatedEntity.SessionId;
 
-            if (TreatVehicleEntity(simulatedEntity.Id, isLocalPlayerNewOwner, simulatedEntity.LockType) ||
+            if (TreatMapRoomCameraEntity(simulatedEntity.Id, isLocalPlayerNewOwner, simulatedEntity.LockType) ||
+                TreatVehicleEntity(simulatedEntity.Id, isLocalPlayerNewOwner, simulatedEntity.LockType) ||
                 newerSimulationById.ContainsKey(simulatedEntity.Id))
             {
                 return;
@@ -143,13 +147,52 @@ namespace NitroxClient.GameLogic
             return simulatedIdsByLockType.TryGetValue(nitroxId, out simulationLockType);
         }
 
+        public bool TreatMapRoomCameraEntity(NitroxId entityId, bool isLocalPlayerNewOwner, SimulationLockType simulationLockType)
+        {
+            if (!NitroxEntity.TryGetObjectFrom(entityId, out GameObject gameObject) ||
+                !gameObject.GetComponent<MapRoomCamera>())
+            {
+                return false;
+            }
+
+            MovementReplicator movementReplicator = gameObject.GetComponent<MovementReplicator>();
+
+            if (isLocalPlayerNewOwner)
+            {
+                if (movementReplicator)
+                {
+                    Object.Destroy(movementReplicator);
+                }
+
+                EntityPositionBroadcaster.StopWatchingEntity(entityId);
+                MovementBroadcaster.RegisterWatched(gameObject, entityId);
+                SimulateEntity(entityId, simulationLockType);
+            }
+            else
+            {
+                if (!movementReplicator)
+                {
+                    movementReplicator = MovementReplicator.AddReplicatorToObject(gameObject);
+                }
+                else
+                {
+                    movementReplicator.ClearBuffer();
+                }
+
+                MovementBroadcaster.UnregisterWatched(entityId);
+                EntityPositionBroadcaster.StopWatchingEntity(entityId);
+                StopSimulatingEntity(entityId);
+            }
+
+            return true;
+        }
+
         public bool TreatVehicleEntity(NitroxId entityId, bool isLocalPlayerNewOwner, SimulationLockType simulationLockType)
         {
             if (!NitroxEntity.TryGetObjectFrom(entityId, out GameObject gameObject) || !IsVehicle(gameObject))
             {
                 return false;
             }
-            
             MovementReplicator movementReplicator = gameObject.GetComponent<MovementReplicator>();
             if (isLocalPlayerNewOwner)
             {
@@ -164,8 +207,13 @@ namespace NitroxClient.GameLogic
             {
                 if (!movementReplicator)
                 {
-                    MovementReplicator.AddReplicatorToObject(gameObject);
+                    movementReplicator = MovementReplicator.AddReplicatorToObject(gameObject);
                 }
+                else
+                {
+                    movementReplicator.ClearBuffer();
+                }
+
                 MovementBroadcaster.UnregisterWatched(entityId);
                 StopSimulatingEntity(entityId);
             }

--- a/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BuildEntitySpawner.cs
@@ -58,7 +58,7 @@ public class BuildEntitySpawner : EntitySpawner<BuildEntity>
             switch (childEntity)
             {
                 case MapRoomEntity mapRoomEntity:
-                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity);
+                    yield return InteriorPieceEntitySpawner.RestoreMapRoom(@base, mapRoomEntity, entities);
                     break;
                 case BaseLeakEntity baseLeakEntity:
                     atLeastOneLeak = true;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -1,14 +1,23 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using NitroxClient.GameLogic.Spawning.Abstract;
-using NitroxClient.GameLogic.Spawning.Metadata;
-using NitroxClient.GameLogic.Spawning.WorldEntities;
-using NitroxClient.MonoBehaviours;
+using System.Security.Cryptography;
+using System.Text;
+using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.GameLogic.Spawning.Abstract;
+using NitroxClient.GameLogic.Spawning.Metadata;
+using NitroxClient.GameLogic.Spawning.WorldEntities;
+using NitroxClient.MonoBehaviours;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Spawning.Bases;
@@ -169,7 +178,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         return interiorPiece;
     }
 
-    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity)
+    public static IEnumerator RestoreMapRoom(Base @base, MapRoomEntity mapRoomEntity, Entities entities)
     {
         MapRoomFunctionality mapRoomFunctionality = @base.GetMapRoomFunctionalityForCell(mapRoomEntity.Cell.ToUnity());
         if (!mapRoomFunctionality)
@@ -177,6 +186,488 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
             Log.Error($"Couldn't find MapRoomFunctionality in base for cell {mapRoomEntity.Cell}");
             yield break;
         }
+
         NitroxEntity.SetNewId(mapRoomFunctionality.gameObject, mapRoomEntity.Id);
+
+        yield return RestoreMapRoomCameraDockingStates(mapRoomFunctionality, mapRoomEntity);
+
+        mapRoomFunctionality.StartCoroutine(AdoptExistingDockedMapRoomCamerasWhenReady(mapRoomFunctionality, mapRoomEntity.Id));
+
+        List<Entity> upgradeChips = mapRoomEntity.ChildEntities
+                                                 .OfType<InventoryItemEntity>()
+                                                 .ToList<Entity>();
+
+        if (upgradeChips.Count > 0)
+        {
+            ClearMapRoomUpgradeContainer(mapRoomFunctionality);
+            yield return entities.SpawnBatchAsync(upgradeChips, true);
+        }
     }
+
+    private static IEnumerator AdoptExistingDockedMapRoomCamerasWhenReady(MapRoomFunctionality mapRoomFunctionality, NitroxId mapRoomId)
+    {
+        for (int attempt = 0; attempt < 900; attempt++)
+        {
+            if (!mapRoomFunctionality)
+            {
+                Log.Warn($"SCANNER_CAMERA_ADOPT_ABORT mapRoom={mapRoomId} reason=mapRoomFunctionalityMissing attempt={attempt}");
+                yield break;
+            }
+
+            List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                      .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                                                      .ToList();
+
+            bool adoptedAnyCamera = false;
+
+            for (int dockingIndex = 0; dockingIndex < dockings.Count; dockingIndex++)
+            {
+                MapRoomCameraDocking docking = dockings[dockingIndex];
+                MapRoomCamera camera = docking.camera;
+
+                if (!CanAdoptExistingDockedMapRoomCamera(docking, camera, out string rejectReason))
+                {
+                    continue;
+                }
+
+                if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+                {
+                    cameraId = GetLegacyDockedMapRoomCameraId(mapRoomId, dockingIndex);
+                    NitroxEntity.SetNewId(camera.gameObject, cameraId);
+
+                    Log.Warn($"SCANNER_CAMERA_ADOPT_ASSIGNED_LEGACY_ID mapRoom={mapRoomId} attempt={attempt} index={dockingIndex} cameraId={cameraId} camera={camera.gameObject.GetFullHierarchyPath()}");
+                }
+
+                using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+                {
+                    docking.camera = null;
+                    docking.cameraDocked = false;
+
+                    if (camera.dockingPoint == docking)
+                    {
+                        camera.dockingPoint = null;
+                    }
+
+                    docking.DockCamera(camera);
+                    NormalizeRestoredDockedMapRoomCamera(camera, docking);
+                }
+
+                yield return EnsureLegacyDockedCameraHasBattery(camera);
+
+                NormalizeRestoredDockedMapRoomCamera(camera, docking);
+
+                if (!MapRoomCamera.cameras.Contains(camera))
+                {
+                    MapRoomCamera.cameras.Add(camera);
+                }
+
+                NitroxServiceLocator.LocateService<IPacketSender>()
+                                    .Send(new MapRoomCameraDockingChanged(mapRoomId, dockingIndex, true, cameraId));
+
+                MapRoomCameraIdentity.RequestCameraNumber(camera, mapRoomId, dockingIndex);
+                MapRoomCameraIdentity.NormalizeCameraNumbers();
+
+                camera.UpdatePingLabel();
+                adoptedAnyCamera = true;
+            }
+
+            if (adoptedAnyCamera)
+            {
+                yield break;
+            }
+
+            yield return null;
+        }
+
+        Log.Warn($"SCANNER_CAMERA_ADOPT_TIMEOUT mapRoom={mapRoomId}");
+    }
+
+    private static IEnumerator EnsureLegacyDockedCameraHasBattery(MapRoomCamera camera)
+    {
+        if (!camera)
+        {
+            yield break;
+        }
+
+        EnergyMixin energyMixin = camera.GetComponent<EnergyMixin>();
+        if (!energyMixin)
+        {
+            Log.Warn($"SCANNER_CAMERA_BATTERY_SKIP reason=missingEnergyMixin camera={camera.gameObject.GetFullHierarchyPath()}");
+            yield break;
+        }
+
+        if (energyMixin.battery != null)
+        {
+            yield break;
+        }
+
+        TechType batteryTechType = energyMixin.defaultBattery != TechType.None
+            ? energyMixin.defaultBattery
+            : TechType.Battery;
+
+        GameObject batteryPrefab;
+        if (!DefaultWorldEntitySpawner.TryGetCachedPrefab(out batteryPrefab, batteryTechType))
+        {
+            TaskResult<GameObject> prefabResult = new();
+            yield return DefaultWorldEntitySpawner.RequestPrefab(batteryTechType, prefabResult);
+
+            batteryPrefab = prefabResult.Get();
+            if (!batteryPrefab)
+            {
+                Log.Warn($"SCANNER_CAMERA_BATTERY_SKIP reason=missingBatteryPrefab techType={batteryTechType} camera={camera.gameObject.GetFullHierarchyPath()}");
+                yield break;
+            }
+        }
+
+        GameObject batteryObject = UnityEngine.Object.Instantiate(batteryPrefab);
+        batteryObject.SetActive(true);
+
+        if (camera.TryGetNitroxId(out NitroxId cameraId) && cameraId != null)
+        {
+            NitroxEntity.SetNewId(batteryObject, GetMapRoomCameraBatteryId(cameraId));
+        }
+
+        Pickupable pickupable = batteryObject.GetComponent<Pickupable>();
+        Battery battery = batteryObject.GetComponent<Battery>();
+
+        if (!pickupable || !battery)
+        {
+            Log.Warn($"SCANNER_CAMERA_BATTERY_SKIP reason=spawnedBatteryMissingComponents techType={batteryTechType} camera={camera.gameObject.GetFullHierarchyPath()}");
+            UnityEngine.Object.Destroy(batteryObject);
+            yield break;
+        }
+
+        energyMixin.batterySlot.AddItem(new InventoryItem(pickupable));
+
+        if (energyMixin.capacity > 0f)
+        {
+            energyMixin.AddEnergy(energyMixin.capacity);
+        }
+        else if (battery.capacity > 0f)
+        {
+            battery.charge = battery.capacity;
+        }
+    }
+
+    private static bool CanAdoptExistingDockedMapRoomCamera(MapRoomCameraDocking docking, MapRoomCamera camera, out string rejectReason)
+    {
+        if (!docking)
+        {
+            rejectReason = "dockingMissing";
+            return false;
+        }
+
+        if (!camera)
+        {
+            rejectReason = "cameraMissing";
+            return false;
+        }
+
+        if (docking.camera != camera)
+        {
+            rejectReason = "dockingCameraMismatch";
+            return false;
+        }
+
+        if (camera.dockingPoint != docking)
+        {
+            rejectReason = "cameraDockingPointMismatch";
+            return false;
+        }
+
+        EnergyMixin energyMixin = camera.GetComponent<EnergyMixin>();
+        if (!energyMixin)
+        {
+            rejectReason = "missingEnergyMixin";
+            return false;
+        }
+
+        Pickupable pickupable = camera.GetComponent<Pickupable>();
+        if (!pickupable)
+        {
+            rejectReason = "missingPickupable";
+            return false;
+        }
+
+        rejectReason = "";
+        return true;
+    }
+
+    private static NitroxId GetMapRoomCameraBatteryId(NitroxId cameraId)
+    {
+        using MD5 md5 = MD5.Create();
+
+        byte[] inputBytes = Encoding.UTF8.GetBytes($"map-room-camera-battery:{cameraId}");
+        byte[] hashBytes = md5.ComputeHash(inputBytes);
+
+        byte[] guidBytes = new byte[16];
+        Array.Copy(hashBytes, guidBytes, guidBytes.Length);
+
+        return new NitroxId(new Guid(guidBytes));
+    }
+
+    private static NitroxId GetLegacyDockedMapRoomCameraId(NitroxId mapRoomId, int dockingIndex)
+    {
+        using MD5 md5 = MD5.Create();
+
+        byte[] inputBytes = Encoding.UTF8.GetBytes($"legacy-map-room-camera:{mapRoomId}:{dockingIndex}");
+        byte[] hashBytes = md5.ComputeHash(inputBytes);
+
+        byte[] guidBytes = new byte[16];
+        Array.Copy(hashBytes, guidBytes, guidBytes.Length);
+
+        return new NitroxId(new Guid(guidBytes));
+    }
+
+    private static IEnumerator RestoreMapRoomCameraDockingStates(MapRoomFunctionality mapRoomFunctionality, MapRoomEntity mapRoomEntity)
+    {
+        if ((mapRoomEntity.CameraDockingIds == null || mapRoomEntity.CameraDockingIds.Count == 0) &&
+            (mapRoomEntity.CameraDockingStates == null || mapRoomEntity.CameraDockingStates.Count == 0))
+        {
+            yield break;
+        }
+
+        List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                  .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                                                  .ToList();
+
+        int count = System.Math.Min(
+            dockings.Count,
+            System.Math.Max(mapRoomEntity.CameraDockingIds?.Count ?? 0, mapRoomEntity.CameraDockingStates?.Count ?? 0));
+
+        for (int dockingIndex = 0; dockingIndex < count; dockingIndex++)
+        {
+            MapRoomCameraDocking docking = dockings[dockingIndex];
+
+            bool cameraDocked = mapRoomEntity.CameraDockingStates != null &&
+                                dockingIndex < mapRoomEntity.CameraDockingStates.Count &&
+                                mapRoomEntity.CameraDockingStates[dockingIndex];
+
+            NitroxId cameraId = mapRoomEntity.CameraDockingIds != null &&
+                                dockingIndex < mapRoomEntity.CameraDockingIds.Count
+                ? mapRoomEntity.CameraDockingIds[dockingIndex]
+                : null;
+
+            if (!cameraDocked)
+            {
+                NitroxId legacyUndockedCameraId = GetLegacyDockedMapRoomCameraId(mapRoomEntity.Id, dockingIndex);
+
+                if (TryPromoteLegacyUndockedMapRoomCameraFromDockSlot(
+                        docking,
+                        legacyUndockedCameraId,
+                        mapRoomEntity.Id,
+                        dockingIndex))
+                {
+                    continue;
+                }
+
+                ClearMapRoomCameraDockingSlot(docking);
+                continue;
+            }
+
+            if (cameraId == null)
+            {
+                Log.Warn($"Clearing legacy scanner room docked camera with no persisted camera id. mapRoom={mapRoomEntity.Id}, dockingIndex={dockingIndex}, slot={docking.gameObject.GetFullHierarchyPath()}");
+                ClearMapRoomCameraDockingSlot(docking);
+                continue;
+            }
+
+            yield return RestoreSingleDockedMapRoomCamera(docking, cameraId, mapRoomEntity.Id, dockingIndex);
+        }
+    }
+
+    private static IEnumerator RestoreSingleDockedMapRoomCamera(MapRoomCameraDocking docking, NitroxId cameraId, NitroxId mapRoomId, int dockingIndex)
+    {
+        if (cameraId == null)
+        {
+            ClearMapRoomCameraDockingSlot(docking);
+            yield break;
+        }
+
+        docking.StartCoroutine(DockPersistedMapRoomCameraWhenAvailable(docking, cameraId, mapRoomId, dockingIndex));
+        yield break;
+    }
+
+    private static IEnumerator DockPersistedMapRoomCameraWhenAvailable(MapRoomCameraDocking docking, NitroxId cameraId, NitroxId mapRoomId, int dockingIndex)
+    {
+        GameObject cameraObject = null;
+
+        // This runs as its own coroutine so it does not block the base/entity restore pipeline.
+        // Persisted camera world entities can appear several seconds after the map room itself.
+        for (int attempt = 0; attempt < 3600; attempt++)
+        {
+            if (!docking)
+            {
+                yield break;
+            }
+
+            if (NitroxEntity.TryGetObjectFrom(cameraId, out cameraObject) && cameraObject)
+            {
+                MapRoomCamera camera = cameraObject.GetComponent<MapRoomCamera>();
+                if (!camera)
+                {
+                    Log.Warn($"Persisted scanner room camera {cameraId} did not have MapRoomCamera: {cameraObject.GetFullHierarchyPath()}");
+                    yield break;
+                }
+
+                ClearMapRoomCameraDockingSlot(docking);
+
+                using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+                {
+                    docking.DockCamera(camera);
+                    NormalizeRestoredDockedMapRoomCamera(camera, docking);
+                }
+
+                MapRoomCameraIdentity.RequestCameraNumber(camera, mapRoomId, dockingIndex);
+
+                Log.Info($"Restored persisted scanner room camera {cameraId} into docking slot {docking.gameObject.GetFullHierarchyPath()}");
+                yield break;
+            }
+
+            MapRoomCamera legacyDockedCamera = docking.camera;
+            if (legacyDockedCamera &&
+                legacyDockedCamera.gameObject &&
+                !legacyDockedCamera.TryGetNitroxId(out _) &&
+                cameraId.Equals(GetLegacyDockedMapRoomCameraId(mapRoomId, dockingIndex)))
+            {
+                NitroxEntity.SetNewId(legacyDockedCamera.gameObject, cameraId);
+                NormalizeRestoredDockedMapRoomCamera(legacyDockedCamera, docking);
+                MapRoomCameraIdentity.RequestCameraNumber(legacyDockedCamera, mapRoomId, dockingIndex);
+
+                Log.Info($"Restored persisted legacy scanner room camera {cameraId} by assigning saved id to existing docked camera in slot {docking.gameObject.GetFullHierarchyPath()}");
+                yield break;
+            }
+
+            yield return null;
+        }
+
+        Log.Warn($"Could not find persisted scanner room camera {cameraId} while restoring docking slot {docking.gameObject.GetFullHierarchyPath()} after deferred retry");
+    }
+
+    private static void NormalizeRestoredDockedMapRoomCamera(MapRoomCamera camera, MapRoomCameraDocking docking)
+    {
+        camera.transform.SetPositionAndRotation(docking.transform.position, docking.transform.rotation);
+
+        camera.SetDocked(docking);
+
+        camera.readyForControl = true;
+        camera.justStartedControl = false;
+
+        if (camera.rigidBody)
+        {
+            camera.rigidBody.velocity = Vector3.zero;
+            camera.rigidBody.angularVelocity = Vector3.zero;
+            camera.rigidBody.isKinematic = true;
+            camera.rigidBody.position = docking.transform.position;
+            camera.rigidBody.rotation = docking.transform.rotation;
+        }
+    }
+
+    private static bool TryPromoteLegacyUndockedMapRoomCameraFromDockSlot(
+    MapRoomCameraDocking docking,
+    NitroxId cameraId,
+    NitroxId mapRoomId,
+    int dockingIndex)
+    {
+        if (!docking)
+        {
+            return false;
+        }
+
+        MapRoomCamera camera = docking.camera;
+        if (!camera || !camera.gameObject)
+        {
+            return false;
+        }
+
+        if (NitroxEntity.TryGetObjectFrom(cameraId, out GameObject existingObject) &&
+            existingObject &&
+            existingObject != camera.gameObject)
+        {
+            Log.Warn($"SCANNER_CAMERA_UNDOCKED_LEGACY_PROMOTE_REPLACE_EXISTING mapRoom={mapRoomId} dock={dockingIndex} cameraId={cameraId} existing={existingObject.GetFullHierarchyPath()} replacement={camera.gameObject.GetFullHierarchyPath()}");
+
+            NitroxEntity.RemoveFrom(existingObject);
+            UnityEngine.Object.Destroy(existingObject);
+        }
+
+        NitroxEntity.SetNewId(camera.gameObject, cameraId);
+
+        using (PacketSuppressor<MapRoomCameraDockingChanged>.Suppress())
+        {
+            docking.UndockCamera();
+
+            if (camera.dockingPoint == docking)
+            {
+                camera.dockingPoint = null;
+            }
+
+            docking.camera = null;
+            docking.cameraDocked = false;
+            camera.SetDocked(null);
+        }
+
+        camera.readyForControl = true;
+        camera.justStartedControl = false;
+
+        if (camera.rigidBody)
+        {
+            camera.rigidBody.isKinematic = false;
+            camera.rigidBody.velocity = Vector3.zero;
+            camera.rigidBody.angularVelocity = Vector3.zero;
+            camera.rigidBody.WakeUp();
+        }
+
+        if (!MapRoomCamera.cameras.Contains(camera))
+        {
+            MapRoomCamera.cameras.Add(camera);
+        }
+
+        MapRoomCameraIdentity.RequestCameraNumber(camera, null, -1);
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+        camera.UpdatePingLabel();
+
+        Log.Warn($"SCANNER_CAMERA_UNDOCKED_LEGACY_PROMOTED_FROM_DOCK_SLOT mapRoom={mapRoomId} dock={dockingIndex} cameraId={cameraId} camera={camera.gameObject.GetFullHierarchyPath()} position={camera.transform.position} ready={camera.IsReady()} readyForControl={camera.readyForControl} cameraListCount={MapRoomCamera.cameras.Count}");
+
+        return true;
+    }
+
+    private static void ClearMapRoomCameraDockingSlot(MapRoomCameraDocking docking)
+    {
+        if (docking.camera)
+        {
+            Log.Info($"Clearing scanner room docking slot camera {docking.camera.gameObject.GetFullHierarchyPath()} number={docking.camera.GetCameraNumber()}");
+
+            NitroxEntity.RemoveFrom(docking.camera.gameObject);
+            UnityEngine.Object.Destroy(docking.camera.gameObject);
+        }
+
+        docking.camera = null;
+        docking.cameraDocked = false;
+    }
+
+    private static void ClearMapRoomUpgradeContainer(MapRoomFunctionality mapRoomFunctionality)
+    {
+        Optional<ItemsContainer> opContainer = InventoryContainerHelper.TryGetContainerByOwner(mapRoomFunctionality.gameObject);
+
+        if (!opContainer.HasValue)
+        {
+            Log.Error($"Couldn't find map room upgrade container on {mapRoomFunctionality.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        ItemsContainer container = opContainer.Value;
+
+        List<Pickupable> pickupables = container._items.Values
+                                              .SelectMany(itemGroup => itemGroup.items)
+                                              .Select(item => item.item)
+                                              .Where(pickupable => pickupable)
+                                              .ToList();
+
+        foreach (Pickupable pickupable in pickupables)
+        {
+            NitroxEntity.RemoveFrom(pickupable.gameObject);
+            container.RemoveItem(pickupable, true);
+        }
+    }
+
 }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
@@ -48,6 +48,8 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
         gameObject.transform.localRotation = entity.Transform.LocalRotation.ToUnity();
         gameObject.transform.localScale = entity.Transform.LocalScale.ToUnity();
 
+        RepairLooseMapRoomCameraVisibility(gameObject);
+
         if (entity.ParentId != null && NitroxEntity.TryGetComponentFrom(entity.ParentId, out Transform parentTransform))
         {
             // WaterParks have a child named "items_root" where the fish are put
@@ -75,6 +77,40 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
         {
             PlacedWorldEntitySpawner.AdditionalSpawningSteps(gameObject);
         }
+    }
+
+    private static void RepairLooseMapRoomCameraVisibility(GameObject gameObject)
+    {
+        MapRoomCamera camera = gameObject.GetComponent<MapRoomCamera>();
+        if (!camera)
+        {
+            return;
+        }
+
+        gameObject.SetActive(true);
+
+        Pickupable pickupable = gameObject.GetComponent<Pickupable>();
+        if (pickupable)
+        {
+            pickupable.Activate(true);
+            pickupable.SetVisible(true);
+        }
+
+        Renderer[] renderers = gameObject.GetComponentsInChildren<Renderer>(true);
+        Collider[] colliders = gameObject.GetComponentsInChildren<Collider>(true);
+
+        foreach (Renderer renderer in renderers)
+        {
+            renderer.enabled = true;
+        }
+
+        foreach (Collider collider in colliders)
+        {
+            collider.enabled = true;
+        }
+
+        camera.readyForControl = true;
+        camera.justStartedControl = false;
     }
 
     public static void SetupObjectInWaterPark(GameObject gameObject, LargeWorldEntity largeWorldEntity, WaterPark waterPark)

--- a/NitroxClient/MonoBehaviours/MapRoomCameraMovementReplicator.cs
+++ b/NitroxClient/MonoBehaviours/MapRoomCameraMovementReplicator.cs
@@ -1,0 +1,12 @@
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxClient.MonoBehaviours;
+
+public sealed class MapRoomCameraMovementReplicator : MovementReplicator
+{
+    public override void ApplyNewMovementData(MovementData newMovementData)
+    {
+        // MapRoomCamera does not need steering wheel / IK / animation side effects.
+        // Base MovementReplicator handles buffered position + rotation interpolation.
+    }
+}

--- a/NitroxClient/MonoBehaviours/MovementReplicator.cs
+++ b/NitroxClient/MonoBehaviours/MovementReplicator.cs
@@ -42,7 +42,7 @@ public abstract class MovementReplicator : MonoBehaviour
     /// <summary>
     /// Current time must be based on real time to avoid effects from time changes/speed.
     /// </summary>
-    private float CurrentTime => (float)this.Resolve<TimeManager>().RealTimeElapsed;
+    private float CurrentTime => Time.realtimeSinceStartup;
 
     public void AddSnapshot(MovementData movementData, float time)
     {
@@ -70,7 +70,7 @@ public abstract class MovementReplicator : MonoBehaviour
             }
         }
 
-        float occurrenceTime = time + INTERPOLATION_TIME + maxAllowedLatency;
+        float occurrenceTime = currentTime + INTERPOLATION_TIME;
 
         // Cleaning any previous value change that would occur later than the newly received snapshot
         while (buffer.Last != null && buffer.Last.Value.IsSnapshotNewer(occurrenceTime))
@@ -142,6 +142,16 @@ public abstract class MovementReplicator : MonoBehaviour
             buffer.RemoveFirst();
         }
 
+        // If we fall badly behind, don't replay hundreds of old vehicle snapshots.
+        // Keep only the latest small interpolation window so remote vehicles recover live instead of performing delayed catch-up.
+        if (buffer.Count > MovementBroadcaster.BROADCAST_FREQUENCY)
+        {
+            while (buffer.Count > 2)
+            {
+                buffer.RemoveFirst();
+            }
+        }
+
         LinkedListNode<Snapshot> firstNode = buffer.First;
         if (firstNode == null)
         {
@@ -196,6 +206,10 @@ public abstract class MovementReplicator : MonoBehaviour
 
     public static MovementReplicator AddReplicatorToObject(GameObject gameObject)
     {
+        if (gameObject.GetComponent<MapRoomCamera>())
+        {
+            return gameObject.AddComponent<MapRoomCameraMovementReplicator>();
+        }
         if (gameObject.GetComponent<SeaMoth>())
         {
             return gameObject.AddComponent<SeamothMovementReplicator>();

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -1,9 +1,10 @@
-using NitroxClient.Communication.Abstract;
-using NitroxClient.GameLogic;
-using NitroxClient.MonoBehaviours.Cyclops;
 using Nitrox.Model.Packets;
 using Nitrox.Model.Subnautica.DataStructures;
 using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.MonoBehaviours.Cyclops;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours;
@@ -26,9 +27,16 @@ public class PlayerMovementBroadcaster : MonoBehaviour
             return;
         }
 
+        bool hasMapRoomCameraAnchor = MapRoomCameraPlayerAnchor.TryGet(out Vector3 anchoredPosition,
+                                                                       out Vector3 anchoredVelocity,
+                                                                       out Quaternion anchoredBodyRotation,
+                                                                       out Quaternion anchoredAimingRotation);
+
         // Freecam does disable main camera control
         // But it's also disabled when driving the cyclops through a cyclops camera (content.activeSelf is only true when controlling through a cyclops camera)
-        if (!MainCameraControl.main.isActiveAndEnabled &&
+        // Scanner room camera control can also disable normal camera control, but we still need to broadcast the anchored player body transform.
+        if (!hasMapRoomCameraAnchor &&
+            !MainCameraControl.main.isActiveAndEnabled &&
             !uGUI_CameraCyclops.main.content.activeSelf)
         {
             return;
@@ -39,7 +47,7 @@ public class PlayerMovementBroadcaster : MonoBehaviour
             return;
         }
 
-        if (Player.main.isPiloting)
+        if (!hasMapRoomCameraAnchor && Player.main.isPiloting)
         {
             return;
         }
@@ -50,6 +58,14 @@ public class PlayerMovementBroadcaster : MonoBehaviour
         // IDEA: possibly only CameraRotation is of interest, because bodyrotation is extracted from that.
         Quaternion bodyRotation = MainCameraControl.main.viewModel.transform.rotation;
         Quaternion aimingRotation = Player.main.camRoot.GetAimingTransform().rotation;
+
+        if (hasMapRoomCameraAnchor)
+        {
+            currentPosition = anchoredPosition;
+            playerVelocity = anchoredVelocity;
+            bodyRotation = anchoredBodyRotation;
+            aimingRotation = anchoredAimingRotation;
+        }
 
         SubRoot subRoot = Player.main.GetCurrentSub();
 

--- a/NitroxClient/MonoBehaviours/Vehicles/WatchedEntry.cs
+++ b/NitroxClient/MonoBehaviours/Vehicles/WatchedEntry.cs
@@ -26,6 +26,7 @@ public class WatchedEntry
     private readonly Transform transform;
     private readonly Vehicle vehicle;
     private readonly SubControl subControl;
+    private readonly MapRoomCamera mapRoomCamera;
 
     private float latestBroadcastTime;
     private Vector3 latestLocalPositionSent;
@@ -37,6 +38,7 @@ public class WatchedEntry
         this.transform = transform;
         vehicle = transform.GetComponent<Vehicle>();
         subControl = transform.GetComponent<SubControl>();
+        mapRoomCamera = transform.GetComponent<MapRoomCamera>();
     }
 
     private bool IsDrivenVehicle()
@@ -98,12 +100,25 @@ public class WatchedEntry
 
     public void OnBroadcastPosition()
     {
+        if (mapRoomCamera)
+        {
+            latestLocalPositionSent = transform.position;
+            latestLocalRotationSent = transform.rotation;
+            return;
+        }
+
         latestLocalPositionSent = transform.localPosition;
         latestLocalRotationSent = transform.localRotation;
     }
 
     private bool HasVehicleMoved()
     {
+        if (mapRoomCamera)
+        {
+            return Vector3.Distance(latestLocalPositionSent, transform.position) > MINIMAL_MOVEMENT_TRESHOLD ||
+                   Quaternion.Angle(latestLocalRotationSent, transform.rotation) > MINIMAL_ROTATION_TRESHOLD;
+        }
+
         return Vector3.Distance(latestLocalPositionSent, transform.localPosition) > MINIMAL_MOVEMENT_TRESHOLD ||
                Quaternion.Angle(latestLocalRotationSent, transform.localRotation) > MINIMAL_ROTATION_TRESHOLD;
     }

--- a/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Constructable_Construct_Patch.cs
@@ -160,7 +160,7 @@ public sealed partial class Constructable_Construct_Patch : NitroxPatch, IDynami
                 }
                 else if (moduleObject.TryGetComponent(out MapRoomFunctionality mapRoomFunctionality))
                 {
-                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId);
+                    builtPiece = BuildUtils.CreateMapRoomEntityFrom(mapRoomFunctionality, parentBase, entityId, parentId, Resolve<EntityMetadataManager>());
                 }
             }
 

--- a/NitroxPatcher/Patches/Dynamic/CrafterLogic_NotifyPickup_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CrafterLogic_NotifyPickup_Patch.cs
@@ -17,7 +17,7 @@ public sealed partial class CrafterLogic_NotifyPickup_Patch : NitroxPatch, IDyna
     public static void Prefix(CrafterLogic __instance)
     {
         // See GhostCrafter_OnCraftingBegin_Patch.Postfix to know why we get NitroxId on CrafterLogic
-        if (__instance.TryGetIdOrWarn(out NitroxId crafterId))
+        if (TryGetCrafterSyncId(__instance, out NitroxId crafterId))
         {
             // Below code is adapted from CrafterLogic.TryPickupAsync
 
@@ -50,5 +50,16 @@ public sealed partial class CrafterLogic_NotifyPickup_Patch : NitroxPatch, IDyna
         }
 
         // The Pickup() item codepath will inform the server that the item was added to the inventory.
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingBegin_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingBegin_Patch.cs
@@ -18,7 +18,7 @@ public sealed partial class GhostCrafter_OnCraftingBegin_Patch : NitroxPatch, ID
         // on the CrafterLogic only. On every other crafter type, both CrafterLogic and GhostCrafter are on the same object.
 
         // Also for base upgrade console module, crafterLogic is nullified and never updated, so we use _logic instead for every crafter
-        if (__instance._logic.TryGetIdOrWarn(out NitroxId crafterLogicId))
+        if (TryGetCrafterSyncId(__instance._logic, out NitroxId crafterLogicId))
         {
             Resolve<Entities>().BroadcastMetadataUpdate(crafterLogicId, new CrafterMetadata(techType.ToDto(), DayNightCycle.main.timePassedAsFloat, duration, __instance._logic.numCrafted, __instance._logic.linkedIndex));
 
@@ -26,5 +26,16 @@ public sealed partial class GhostCrafter_OnCraftingBegin_Patch : NitroxPatch, ID
             // but will require redoing our hooks.
             Resolve<SimulationOwnership>().RequestSimulationLock(crafterLogicId, SimulationLockType.EXCLUSIVE);
         }
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingEnd_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/GhostCrafter_OnCraftingEnd_Patch.cs
@@ -18,7 +18,7 @@ public sealed partial class GhostCrafter_OnCraftingEnd_Patch : NitroxPatch, IDyn
         // the crafting player will intiate a lock request when pushing the craft button - OnCraftingStart().
 
         // See GhostCrafter_OnCraftingBegin_Patch.Postfix to know why we get NitroxId on CrafterLogic
-        if (__instance._logic.TryGetIdOrWarn(out NitroxId id) && Resolve<SimulationOwnership>().HasExclusiveLock(id))
+        if (TryGetCrafterSyncId(__instance._logic, out NitroxId id) && Resolve<SimulationOwnership>().HasExclusiveLock(id))
         {
             // once an item is crafted, we no longer require an exclusive lock.
             Resolve<SimulationOwnership>().RequestSimulationLock(id, SimulationLockType.TRANSIENT);
@@ -27,5 +27,16 @@ public sealed partial class GhostCrafter_OnCraftingEnd_Patch : NitroxPatch, IDyn
         }
 
         return false;
+    }
+
+    private static bool TryGetCrafterSyncId(CrafterLogic crafterLogic, out NitroxId crafterId)
+    {
+        MapRoomFunctionality mapRoomFunctionality = crafterLogic.GetComponentInParent<MapRoomFunctionality>(true);
+        if (mapRoomFunctionality && mapRoomFunctionality.TryGetNitroxId(out crafterId))
+        {
+            return true;
+        }
+
+        return crafterLogic.TryGetIdOrWarn(out crafterId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_DockCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_DockCamera_Patch.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.MonoBehaviours;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCameraDocking_DockCamera_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCameraDocking t) => t.DockCamera(default));
+
+    public static void Postfix(MapRoomCameraDocking __instance, MapRoomCamera camera)
+    {
+        if (PacketSuppressor<MapRoomCameraDockingChanged>.IsSuppressed)
+        {
+            return;
+        }
+
+        MapRoomFunctionality mapRoomFunctionality = __instance.GetComponentInParent<MapRoomFunctionality>(true);
+        if (!mapRoomFunctionality)
+        {
+            return;
+        }
+
+        if (!mapRoomFunctionality.TryGetNitroxId(out NitroxId mapRoomId))
+        {
+            return;
+        }
+
+        List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                  .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                                                  .ToList();
+
+        int dockingIndex = dockings.IndexOf(__instance);
+        if (dockingIndex < 0)
+        {
+            return;
+        }
+
+        NitroxId cameraId = null;
+        camera.TryGetNitroxId(out cameraId);
+
+        Resolve<IPacketSender>().Send(new MapRoomCameraDockingChanged(mapRoomId, dockingIndex, true, cameraId));
+
+        if (cameraId != null)
+        {
+            MapRoomCameraIdentity.RequestCameraNumber(camera, mapRoomId, dockingIndex);
+        }
+
+        // Do not release movement ownership here.
+        // Vanilla keeps the player connected to the docked camera after docking and performs its own
+        // docked-camera view behavior. Releasing ownership here causes HandleInput to treat the local
+        // player as view-only and restore the camera transform every frame, freezing the view at the dock.
+        // Ownership is released by MapRoomCamera_ExitLockedMode_Patch when the player actually exits.
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_UndockCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCameraDocking_UndockCamera_Patch.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCameraDocking_UndockCamera_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCameraDocking t) => t.UndockCamera());
+
+    private static MapRoomCamera undockedCamera;
+
+    public static void Prefix(MapRoomCameraDocking __instance)
+    {
+        undockedCamera = __instance.camera;
+    }
+
+    public static void Postfix(MapRoomCameraDocking __instance)
+    {
+        if (PacketSuppressor<MapRoomCameraDockingChanged>.IsSuppressed)
+        {
+            return;
+        }
+
+        MapRoomFunctionality mapRoomFunctionality = __instance.GetComponentInParent<MapRoomFunctionality>(true);
+        if (!mapRoomFunctionality)
+        {
+            return;
+        }
+
+        if (!mapRoomFunctionality.TryGetNitroxId(out NitroxId mapRoomId))
+        {
+            return;
+        }
+
+        List<MapRoomCameraDocking> dockings = mapRoomFunctionality.GetComponentsInChildren<MapRoomCameraDocking>(true)
+                                                                  .OrderBy(docking => docking.gameObject.GetFullHierarchyPath())
+                                                                  .ToList();
+
+        int dockingIndex = dockings.IndexOf(__instance);
+        if (dockingIndex < 0)
+        {
+            return;
+        }
+
+        NitroxId cameraId = null;
+
+        if (undockedCamera)
+        {
+            undockedCamera.TryGetNitroxId(out cameraId);
+        }
+
+        Resolve<IPacketSender>().Send(new MapRoomCameraDockingChanged(mapRoomId, dockingIndex, false, cameraId));
+
+        if (undockedCamera)
+        {
+            MapRoomCameraIdentity.RequestCameraNumber(undockedCamera);
+        }
+
+        if (cameraId != null && undockedCamera)
+        {
+            SimulationOwnership simulationOwnership = Resolve<SimulationOwnership>();
+
+            if (simulationOwnership.HasExclusiveLock(cameraId))
+            {
+                // The local player was already controlling this camera before it undocked.
+                // Keep broadcasting so stalker theft / forced undock does not steal control away.
+                EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+                MovementBroadcaster.RegisterWatched(undockedCamera.gameObject, cameraId);
+
+                Log.Info($"SCANNER_CAMERA_UNDOCK_KEEP_EXISTING_CONTROL cameraId={cameraId} number={undockedCamera.cameraNumber} camera={undockedCamera.gameObject.GetFullHierarchyPath()}");
+            }
+            else
+            {
+                // Do not claim EXCLUSIVE control just because vanilla/stalker undocked the camera.
+                // But this client is the one currently simulating the loose camera, so it needs a
+                // TRANSIENT lock so the server will accept movement packets and late joiners get
+                // the real world position instead of a stale copy.
+                EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+                MovementBroadcaster.UnregisterWatched(cameraId);
+
+                // Do not start MovementBroadcaster yet.
+                // The server rejects VehicleMovements until the TRANSIENT lock is granted.
+                // SimulationOwnership.TreatMapRoomCameraEntity(...) will register MovementBroadcaster
+                // after the lock response is accepted.
+                Resolve<SimulationOwnership>().RequestSimulationLock(cameraId, SimulationLockType.TRANSIENT);
+
+                Log.Info($"SCANNER_CAMERA_UNDOCK_PASSIVE_TRANSIENT_REQUESTED cameraId={cameraId} number={undockedCamera.cameraNumber} camera={undockedCamera.gameObject.GetFullHierarchyPath()}");
+            }
+        }
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+
+        undockedCamera = null;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_ControlCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_ControlCamera_Patch.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Nitrox.Model.DataStructures;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.GameLogic.Simulation;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCamera_ControlCamera_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.ControlCamera(default));
+
+    private const float CONTROL_REQUEST_RETRY_SECONDS = 0.75f;
+    private const float STATUS_MESSAGE_DURATION_SECONDS = 3f;
+    private const float MOVEMENT_DENIED_STATUS_DURATION_SECONDS = 2.5f;
+
+    private static readonly HashSet<NitroxId> pendingControlLocks = [];
+    private static readonly Dictionary<NitroxId, float> lastControlRequestTimes = [];
+
+    public static bool Prefix(MapRoomCamera __instance, MapRoomScreen screen)
+    {
+        MapRoomCameraPlayerAnchor.Begin(
+            Player.main.transform.position,
+            MainCameraControl.main.viewModel.transform.rotation,
+            Player.main.camRoot.GetAimingTransform().rotation);
+
+        RequestControl(__instance, screen, "ControlCamera", true);
+
+        // Do not block vanilla camera entry.
+        // Blocking here caused fake-box / broken-HUD / connecting-to-camera failures.
+        // Movement authority is enforced in MapRoomCamera_HandleInput_Patch.
+        return true;
+    }
+
+    public static void RequestControl(MapRoomCamera camera, MapRoomScreen screen, string reason, bool showStatus)
+    {
+        if (!camera)
+        {
+            return;
+        }
+
+        if (!camera.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            Log.Warn($"SCANNER_CAMERA_CONTROL_REQUEST_SKIP reason=noNitroxId source={reason} camera={camera.gameObject.GetFullHierarchyPath()}");
+            return;
+        }
+
+        SimulationOwnership simulationOwnership = Resolve<SimulationOwnership>();
+
+        if (simulationOwnership.HasExclusiveLock(cameraId))
+        {
+            EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+            MovementBroadcaster.RegisterWatched(camera.gameObject, cameraId);
+
+            if (showStatus)
+            {
+                ShowAvailableStatus();
+            }
+
+            return;
+        }
+
+        if (pendingControlLocks.Contains(cameraId))
+        {
+            return;
+        }
+
+        float now = Time.realtimeSinceStartup;
+        if (lastControlRequestTimes.TryGetValue(cameraId, out float lastRequestTime) &&
+            now - lastRequestTime < CONTROL_REQUEST_RETRY_SECONDS)
+        {
+            return;
+        }
+
+        lastControlRequestTimes[cameraId] = now;
+        pendingControlLocks.Add(cameraId);
+
+        LockRequest<MapRoomCameraControl> lockRequest = new(
+            cameraId,
+            SimulationLockType.EXCLUSIVE,
+            OnCameraControlLockResponse,
+            new MapRoomCameraControl(camera, screen, reason, showStatus));
+
+        simulationOwnership.RequestSimulationLock(lockRequest);
+
+        if (ShouldLogControlEvent(reason))
+        {
+            Log.Info(
+                $"SCANNER_CAMERA_CONTROL_REQUEST cameraId={cameraId} " +
+                $"number={camera.cameraNumber} reason={reason} " +
+                $"camera={camera.gameObject.GetFullHierarchyPath()} " +
+                $"pendingCount={pendingControlLocks.Count}");
+        }
+    }
+
+    public static void ShowInUseStatus()
+    {
+        MapRoomCameraStatusOverlay.ShowInUse(MOVEMENT_DENIED_STATUS_DURATION_SECONDS);
+    }
+
+    private static void ShowAvailableStatus()
+    {
+        MapRoomCameraStatusOverlay.ShowAvailable(STATUS_MESSAGE_DURATION_SECONDS);
+    }
+
+    private static void OnCameraControlLockResponse(NitroxId cameraId, bool lockAcquired, MapRoomCameraControl context)
+    {
+        pendingControlLocks.Remove(cameraId);
+
+        if (!context.Camera)
+        {
+            Log.Info($"SCANNER_CAMERA_CONTROL_RESPONSE_IGNORED cameraId={cameraId} acquired={lockAcquired} reason={context.Reason} cause=missingCamera");
+            return;
+        }
+
+        if (!lockAcquired)
+        {
+            EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+            MovementBroadcaster.UnregisterWatched(cameraId);
+
+            if (ShouldLogControlEvent(context.Reason))
+            {
+                Log.Info(
+                    $"SCANNER_CAMERA_CONTROL_DENIED cameraId={cameraId} " +
+                    $"number={context.Camera.cameraNumber} reason={context.Reason} " +
+                    $"camera={context.Camera.gameObject.GetFullHierarchyPath()}");
+            }
+
+            if (context.ShowStatus)
+            {
+                MapRoomCameraStatusOverlay.ShowInUse(STATUS_MESSAGE_DURATION_SECONDS);
+            }
+
+            return;
+        }
+
+        EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+        MovementBroadcaster.RegisterWatched(context.Camera.gameObject, cameraId);
+
+        if (ShouldLogControlEvent(context.Reason))
+        {
+            Log.Info(
+                $"SCANNER_CAMERA_CONTROL_GRANTED cameraId={cameraId} " +
+                $"number={context.Camera.cameraNumber} reason={context.Reason} " +
+                $"camera={context.Camera.gameObject.GetFullHierarchyPath()}");
+        }
+
+        // Show AVAILABLE when the player initially switches to a free camera, and also when
+        // a viewer's background retry succeeds after the previous controller releases control.
+        if (context.ShowStatus || context.Reason == "HandleInputViewerRetry")
+        {
+            ShowAvailableStatus();
+        }
+    }
+
+    private static bool ShouldLogControlEvent(string reason)
+    {
+        return reason != "HandleInputViewerRetry";
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_ExitLockedMode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_ExitLockedMode_Patch.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
+using NitroxClient.MonoBehaviours;
+using Nitrox.Model.DataStructures;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCamera_ExitLockedMode_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.ExitLockedMode(default));
+
+    public static void Postfix(MapRoomCamera __instance)
+    {
+        MapRoomCameraPlayerAnchor.End();
+
+        if (!__instance.TryGetNitroxId(out NitroxId cameraId))
+        {
+            return;
+        }
+
+        EntityPositionBroadcaster.StopWatchingEntity(cameraId);
+        MovementBroadcaster.UnregisterWatched(cameraId);
+        Resolve<SimulationOwnership>().RequestSimulationLock(cameraId, SimulationLockType.TRANSIENT);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_HandleInput_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_HandleInput_Patch.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCamera_HandleInput_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.HandleInput());
+
+    private static readonly Dictionary<NitroxId, CameraFrameState> preInputStatesByCameraId = [];
+
+    private static bool previousLightState;
+
+    public static bool Prefix(MapRoomCamera __instance)
+    {
+        previousLightState = __instance.lightsParent && __instance.lightsParent.activeInHierarchy;
+
+        if (!__instance.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return true;
+        }
+
+        if (Resolve<SimulationOwnership>().HasExclusiveLock(cameraId))
+        {
+            preInputStatesByCameraId.Remove(cameraId);
+            return true;
+        }
+
+        // No movement ownership:
+        // - allow passive viewer input such as mouse-wheel camera switching
+        // - block only actual camera-driving input so the viewer cannot visually drift/snap back
+        if (HasBlockedControlInput())
+        {
+            MapRoomCamera_ControlCamera_Patch.ShowInUseStatus();
+
+            // Keep trying to acquire ownership in the background.
+            MapRoomCamera_ControlCamera_Patch.RequestControl(__instance, null, "HandleInputViewerRetry", false);
+
+            return false;
+        }
+
+        preInputStatesByCameraId[cameraId] = new CameraFrameState(__instance);
+        return true;
+    }
+
+    public static void Postfix(MapRoomCamera __instance)
+    {
+        if (!__instance.TryGetNitroxId(out NitroxId cameraId) || cameraId == null)
+        {
+            return;
+        }
+
+        bool hasMovementOwnership = Resolve<SimulationOwnership>().HasExclusiveLock(cameraId);
+
+        if (!hasMovementOwnership)
+        {
+            if (preInputStatesByCameraId.TryGetValue(cameraId, out CameraFrameState preInputState))
+            {
+                preInputState.Restore(__instance);
+                preInputStatesByCameraId.Remove(cameraId);
+            }
+
+            // While viewing a camera without movement ownership, keep trying to acquire control at
+            // a throttled rate. This lets a viewer automatically become controller after the old
+            // owner exits/switches away, and gives late-join loose cameras a clean path to recover
+            // from stale ownership state without needing to switch away and back.
+            MapRoomCamera_ControlCamera_Patch.RequestControl(__instance, null, "HandleInputViewerRetry", false);
+
+            return;
+        }
+
+        preInputStatesByCameraId.Remove(cameraId);
+
+        if (PacketSuppressor<MapRoomCameraLightChanged>.IsSuppressed)
+        {
+            return;
+        }
+
+        bool currentLightState = __instance.lightsParent && __instance.lightsParent.activeInHierarchy;
+        if (currentLightState == previousLightState)
+        {
+            return;
+        }
+
+        Resolve<IPacketSender>().Send(new MapRoomCameraLightChanged(cameraId, currentLightState));
+    }
+
+    private static bool HasBlockedControlInput()
+    {
+        if (GameInput.GetMoveDirection().sqrMagnitude > 0.0001f)
+        {
+            return true;
+        }
+
+        return UnityEngine.Mathf.Abs(Input.GetAxisRaw("Mouse X")) > 0.001f ||
+               UnityEngine.Mathf.Abs(Input.GetAxisRaw("Mouse Y")) > 0.001f;
+    }
+
+    private readonly struct CameraFrameState
+    {
+        private readonly Vector3 position;
+        private readonly Quaternion rotation;
+        private readonly Vector3 velocity;
+        private readonly Vector3 angularVelocity;
+        private readonly bool hadRigidBody;
+        private readonly bool rigidBodyWasKinematic;
+
+        public CameraFrameState(MapRoomCamera camera)
+        {
+            position = camera.transform.position;
+            rotation = camera.transform.rotation;
+
+            hadRigidBody = camera.rigidBody;
+            if (camera.rigidBody)
+            {
+                velocity = camera.rigidBody.velocity;
+                angularVelocity = camera.rigidBody.angularVelocity;
+                rigidBodyWasKinematic = camera.rigidBody.isKinematic;
+            }
+            else
+            {
+                velocity = Vector3.zero;
+                angularVelocity = Vector3.zero;
+                rigidBodyWasKinematic = false;
+            }
+        }
+
+        public void Restore(MapRoomCamera camera)
+        {
+            if (!camera)
+            {
+                return;
+            }
+
+            camera.transform.SetPositionAndRotation(position, rotation);
+
+            if (hadRigidBody && camera.rigidBody)
+            {
+                camera.rigidBody.position = position;
+                camera.rigidBody.rotation = rotation;
+                camera.rigidBody.velocity = velocity;
+                camera.rigidBody.angularVelocity = angularVelocity;
+                camera.rigidBody.isKinematic = rigidBodyWasKinematic;
+            }
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Start_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomCamera_Start_Patch.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Reflection;
+using NitroxClient.GameLogic.Bases;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomCamera_Start_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomCamera t) => t.Start());
+
+    public static void Postfix(MapRoomCamera __instance)
+    {
+        __instance.StartCoroutine(RequestNumberAfterCameraStart(__instance));
+    }
+
+    private static IEnumerator RequestNumberAfterCameraStart(MapRoomCamera camera)
+    {
+        yield return null;
+
+        if (!camera)
+        {
+            yield break;
+        }
+
+        if (camera.dockingPoint)
+        {
+            MapRoomCameraIdentity.NormalizeCameraNumbers();
+            yield break;
+        }
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+
+        yield return MapRoomCameraIdentity.RequestCameraNumberWhenReady(camera);
+
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomScreen_FindCamera_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomScreen_FindCamera_Patch.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using NitroxClient.GameLogic.Bases;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomScreen_FindCamera_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomScreen t) => t.FindCamera(default));
+
+    public static void Prefix()
+    {
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/MapRoomScreen_OnMapRoomCameraChanged_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/MapRoomScreen_OnMapRoomCameraChanged_Patch.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using NitroxClient.GameLogic.Bases;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+public sealed partial class MapRoomScreen_OnMapRoomCameraChanged_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((MapRoomScreen t) => t.OnMapRoomCameraChanged(default));
+
+    public static void Prefix()
+    {
+        MapRoomCameraIdentity.NormalizeCameraNumbers();
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_Drop_Patch.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -14,5 +15,11 @@ public sealed partial class Pickupable_Drop_Patch : NitroxPatch, IDynamicPatch
             return;
         }
         Resolve<Items>().Dropped(__instance.gameObject, __instance.GetTechType());
+
+        MapRoomCamera camera = __instance.GetComponent<MapRoomCamera>();
+        if (camera)
+        {
+            __instance.StartCoroutine(MapRoomCameraIdentity.RequestCameraNumberWhenReady(camera));
+        }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/Pickupable_Pickup_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Pickupable_Pickup_Patch.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using NitroxClient.GameLogic;
+using NitroxClient.GameLogic.Bases;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -9,7 +10,13 @@ public sealed partial class Pickupable_Pickup_Patch : NitroxPatch, IDynamicPatch
 
     public static void Prefix(Pickupable __instance)
     {
+        MapRoomCamera camera = __instance.GetComponent<MapRoomCamera>();
+        if (camera)
+        {
+            //MapRoomCameraIdentity.NotifyCameraPickedUp(camera);
+            MapRoomCameraIdentity.ReleaseCameraNumber(camera);
+        }
+
         Resolve<Items>().PickedUpByPlayer(__instance.gameObject, __instance.GetTechType());
     }
 }
-


### PR DESCRIPTION
﻿## Summary

Contributes to https://github.com/SubnauticaNitrox/Nitrox/issues/2410.

This PR implements a complete scanner room camera synchronization system for multiplayer.

Scanner room cameras were previously not reliably synchronized across clients, especially across save upgrades, docking/undocking, pickup/drop, late joins, relogs, multiple simultaneous viewers, and control handoff between players. Several of these failures were connected, so fixing only one piece in isolation caused the others to regress. This PR is intentionally larger because the scanner room camera behavior depends on several systems working together:

- Server-side camera registry and numbering
- Docked camera persistence
- Loose camera world entity persistence
- Legacy/upgraded save repair
- Camera movement replication
- Control ownership/locking
- Camera pickup/drop and dock/undock transitions
- Client-side scanner room screen camera selection
- Player body/tracker anchoring while controlling a remote camera
- User feedback when a camera is available or already in use

Taken separately, some of these changes look unusual or overly broad. Together, they form a single scanner room camera synchronization and persistence system.

## What this fixes

This PR fixes scanner room camera behavior in multiplayer, including:

- Scanner room cameras now receive stable server-assigned camera numbers.
- Camera numbering is replayed to joining clients.
- Camera numbers remain stable after relogging.
- Docked scanner room cameras are tracked by map room and docking slot.
- Loose/undocked scanner room cameras are tracked as persistent world entities.
- Existing/upgraded saves with legacy/broken camera state are normalized.
- Docked cameras from older saves can be promoted/adopted into the new synced system.
- Loose cameras retain correct world state after undocking, pickup/drop, and relog.
- Multiple players can view scanner room cameras without stealing movement control.
- Only the client with the simulation lock can drive a scanner camera.
- Other clients viewing the same camera are denied control while still seeing the correct camera feed.
- Camera control handoff works when the controlling player exits/releases a camera.
- Remote viewers no longer see the controlling player standing outside in the water while using a camera.
- Player body/tracker position is anchored while the player is controlling a scanner camera.
- Scanner camera movement remains synced when a stalker grabs and later drops a controlled camera.
- Camera control status is shown to players with `AVAILABLE` / `IN USE` overlay feedback.

## System overview

### Server camera registry

A server-side scanner camera registry assigns and tracks camera numbers by camera `NitroxId`.

The registry is responsible for keeping numbering authoritative and consistent rather than letting each client independently infer scanner camera numbers. This avoids duplicate or drifting numbering when players join in different orders, when cameras are docked/undocked, and when legacy save data is repaired.

The server replays the scanner camera registry to joining clients during initial sync so late joiners receive the current authoritative camera numbering.

### Docking state tracking

Scanner room camera docking state is persisted as part of the map room entity data.

For each scanner room, the system tracks docking slot state and the camera id assigned to each dock. This allows clients to reconstruct docked camera state consistently and prevents each client from independently creating or resolving docked cameras differently.

Dock/undock changes are sent through scanner camera docking packets so the server and other clients can keep the map room docking state synchronized.

### Loose camera persistence

Undocked scanner room cameras are treated as persistent world entities.

When a scanner room camera becomes loose, the system ensures it exists as a world entity with the correct scanner camera prefab/class id, tech type, world level, transform, and identity. This is necessary so loose cameras can survive relogs and so late-joining clients receive them as actual synced world objects instead of stale local-only objects.

### Legacy/upgraded save repair

Existing saves can contain scanner room cameras in old or inconsistent states because scanner room cameras were not previously synchronized correctly.

This PR includes compatibility handling for upgraded saves:

- Loose scanner camera world entities are normalized.
- Broken legacy scanner camera root entities can be purged when appropriate.
- Docked legacy scanner cameras can be adopted into the synchronized registry.
- Legacy docked cameras can be assigned correct ids and numbers.
- Persisted dock-slot information is restored to live map room docking objects.
- Existing scanner camera battery/ready state is repaired where required so restored cameras are controllable.

This is why the PR includes both client and server changes. Save repair and runtime synchronization have to agree with each other or players will see different camera lists, duplicate cameras, missing cameras, or non-controllable cameras.

### Camera numbering and client normalization

Clients apply server-assigned camera numbers to live camera objects and normalize the local `MapRoomCamera.cameras` list.

This avoids local duplicate/stale entries and keeps scanner room screen camera selection in server-number order. Screen camera lookup is normalized before scanner camera selection/change paths so the UI does not accidentally select a stale or duplicate camera object.

### Movement and control ownership

Scanner camera movement now uses the existing movement broadcaster/replicator path with scanner-camera-specific handling.

The controlling client broadcasts movement for the scanner camera it owns. Remote clients receive movement snapshots and interpolate the camera transform. The scanner camera movement replicator deliberately avoids vehicle-only side effects because scanner room cameras do not need steering wheel, IK, or animation behavior.

Control is guarded by simulation ownership:

- A client requests an exclusive lock when entering/controlling a scanner camera.
- If the lock is granted, that client broadcasts camera movement.
- If the lock is denied, the client may view the camera but cannot move it.
- Viewers keep retrying in the background so control can be acquired once the previous controller releases it.
- Viewers are prevented from locally driving the camera without ownership.

### Player body/tracker anchoring

When a player controls a scanner room camera, their body/tracker position must remain anchored at the scanner room terminal instead of appearing outside in the world at the camera’s position.

This PR adds player movement anchoring while controlling scanner cameras so other clients continue to see the controlling player in the correct place. This fixes the issue where a remote player could appear standing in the water or at the camera location while using a scanner room camera.

### Camera status UI

The scanner camera control flow now shows lightweight status feedback:

- `AVAILABLE` when a camera is free/available for control.
- `IN USE` when another player already controls that camera.

This makes simultaneous camera use understandable. A player can view a camera that someone else is controlling, but they receive clear feedback that they do not own movement control.

## Multiplayer behavior

The intended behavior after this PR:

- Multiple players can use the scanner room camera system at the same time.
- Two players can view the same camera.
- Only one player can control/move a given camera at a time.
- If Player 1 controls a camera and Player 2 switches to that camera, Player 2 sees `IN USE`.
- Player 2 cannot move or rotate the camera while Player 1 owns control.
- Player 2 still sees the correct owner-driven camera view.
- When Player 1 releases control, Player 2 can acquire control and sees `AVAILABLE`.
- Players can control different scanner cameras at the same time.
- Camera numbering remains stable and consistent for both players.
- Camera state remains stable across relog.

## Tested scenarios

This was tested extensively with two multiplayer clients and multiple save states.

### General scanner camera sync

Tested:

- Fresh scanner room camera use
- Existing scanner room camera use
- Multiple camera numbers
- Camera number stability
- Scanner room screen camera switching
- Simultaneous camera viewing
- Simultaneous control of different cameras
- Attempting to control a camera already controlled by another player
- Releasing control and allowing another player to acquire it
- Viewer denial behavior with `IN USE`
- Available control behavior with `AVAILABLE`

Result:

- Camera selection, numbering, availability display, and control ownership behaved correctly.

### Docked cameras

Tested:

- Docked scanner room cameras restored from save
- Docked camera numbering
- Docked camera control
- Docked camera lock denial when another player controls it
- Docking state persistence after relog
- Multiple dock slots

Result:

- Docking state and camera ids remained consistent across clients.

### Loose/undocked cameras

Tested:

- Loose scanner room cameras restored from save
- Loose camera numbering
- Loose camera control
- Loose camera movement replication
- Pickup/drop behavior
- Undock behavior
- Relog after loose camera state existed

Result:

- Loose cameras remained tracked, visible, numbered, and controllable.

### Save upgrade / legacy camera tests

Tested with multiple upgraded/legacy scanner room camera save states.

The tests covered saves where scanner room cameras had never worked correctly before this system and needed repair/adoption into the synchronized registry.

Result:

- Legacy/upgraded save states were repaired into usable synchronized camera state.
- Camera numbers, docking slots, and world cameras restored correctly after relog.
- No duplicate/broken camera behavior was observed in the final tested state.

### Relog / late join

Tested:

- Player 1 joins first, Player 2 joins second
- Player 2 joins first, Player 1 joins second
- Relog after scanner camera registry is populated
- Relog after camera docking state exists
- Relog after loose camera state exists
- Registry replay during join

Result:

- Joining order did not break final camera numbering/control behavior.
- Registry replay restored scanner camera numbering and state to the joining client.

### Stalker camera test

Tested:

- Player controls a scanner camera.
- Stalker grabs the controlled camera.
- Remote player observes the camera movement.
- Stalker drops the camera.
- Original camera control resumes/continues.

Result:

- Remote view stayed synchronized when the stalker moved the controlled camera.
- After the stalker dropped the camera, camera control/view sync recovered correctly.

### Player body/tracker test

Tested:

- Player controls a scanner room camera while another player watches the player/tracker state.
- Viewer checks that the controlling player does not appear at the camera’s world position.

Result:

- Player body/tracker stayed anchored correctly while the player controlled a scanner room camera.

## Notes on PR size

This PR is intentionally not split into several smaller scanner camera PRs because the pieces are interdependent.

For example:

- Server numbering without client normalization can still leave clients selecting the wrong local camera.
- Docked camera persistence without loose world-entity handling breaks undocked cameras.
- Camera movement replication without ownership control allows camera fights.
- Ownership control without viewer UI makes simultaneous camera behavior confusing.
- Legacy save repair without registry replay breaks late join/relog.
- Player movement broadcast changes are required so remote players do not see the controlling player standing outside in the water.

For that reason, this is best understood as one scanner room camera synchronization system rather than a collection of unrelated fixes.

## Result

Scanner room cameras are now synchronized as persistent, numbered, controllable multiplayer entities across docking, undocking, pickup/drop, relog, upgraded saves, simultaneous viewing, simultaneous control of different cameras, and hostile creature movement.
