### PR TITLE
Fix base leaks not syncing after repair

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/LeakRepairedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/LeakRepairedProcessor.cs
@@ -1,17 +1,50 @@
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.Packets.Core;
+using Nitrox.Server.Subnautica.Services;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 
-sealed class LeakRepairedProcessor(WorldEntityManager worldEntityManager) : IAuthPacketProcessor<LeakRepaired>
+internal sealed class LeakRepairedProcessor(WorldEntityManager worldEntityManager, SaveService saveService, ILogger<LeakRepairedProcessor> logger) : IAuthPacketProcessor<LeakRepaired>
 {
+    private static readonly Lock saveDebounceLock = new();
+    private static DateTime lastSaveRequest = DateTime.MinValue;
+    private static readonly TimeSpan saveDebounceInterval = TimeSpan.FromSeconds(5);
+
     private readonly WorldEntityManager worldEntityManager = worldEntityManager;
+    private readonly SaveService saveService = saveService;
+    private readonly ILogger<LeakRepairedProcessor> logger = logger;
 
     public async Task Process(AuthProcessorContext context, LeakRepaired packet)
     {
         if (worldEntityManager.TryDestroyEntity(packet.LeakId, out _))
         {
             await context.SendToOthersAsync(packet);
+            
+            // Trigger a debounced save to persist the leak removal
+            // This ensures that if the server crashes or a player joins before the next autosave,
+            // the repaired leak won't reappear
+            await TriggerDebouncedSaveAsync();
+        }
+    }
+
+    private async Task TriggerDebouncedSaveAsync()
+    {
+        bool shouldTriggerSave = false;
+        
+        lock (saveDebounceLock)
+        {
+            DateTime now = DateTime.UtcNow;
+            if (now - lastSaveRequest >= saveDebounceInterval)
+            {
+                lastSaveRequest = now;
+                shouldTriggerSave = true;
+            }
+        }
+
+        if (shouldTriggerSave)
+        {
+            logger.ZLogDebug($"Queueing save after base leak repair to ensure persistence");
+            await saveService.QueueActionAsync(SaveService.ServiceAction.SAVE);
         }
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Bases/BaseLeakEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/BaseLeakEntitySpawner.cs
@@ -32,6 +32,14 @@ public class BaseLeakEntitySpawner : SyncEntitySpawner<BaseLeakEntity>
             return true;
         }
 
+        // Skip spawning leaks that are already at full health (fully repaired)
+        // This handles edge cases where a leak was repaired but the save hasn't persisted yet
+        if (entity.Health >= 100f)
+        {
+            Log.Debug($"[{nameof(BaseLeakEntitySpawner)}] Skipping spawn of fully repaired leak {entity.Id} (Health: {entity.Health})");
+            return true;
+        }
+
         BaseLeakManager baseLeakManager = baseHullStrength.gameObject.EnsureComponent<BaseLeakManager>();
         baseLeakManager.EnsureLeak(entity.RelativeCell.ToUnity(), entity.Id, entity.Health);
         return true;


### PR DESCRIPTION
Closes #2769

## Description
Fixes base leaks not syncing properly between players and persisting after server restarts.

## Problem
When Player 1 repaired base leaks, Player 2 would still see the same leaks when joining. Additionally, after server restart, the repaired leaks would reappear for all players. This was caused by leak entities being destroyed from memory but not persisted to disk until the next autosave cycle.

## Solution
**Server-side:**
- Added debounced save trigger in `LeakRepairedProcessor` that queues a save within 5 seconds of leak repair
- Ensures leak deletions are persisted immediately, preventing reappearance after crashes or player joins
- Debouncing prevents excessive saves when multiple leaks are repaired rapidly

**Client-side:**
- Added defensive health check in `BaseLeakEntitySpawner` to skip spawning fully repaired leaks (Health >= 100)
- Provides additional safety layer for edge cases where save hasn't persisted yet

## Testing
Test 1: Player 1 repairs leaks → Player 2 joins → No leaks appear
Test 2: Player 1 repairs leaks → Server restart → No leaks reappear