### PR TITLE
Fix vehicle movement desync caused by ms/s unit mismatch in TimeService

### DIFF
--- a/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
@@ -119,7 +119,7 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
 
     public TimeChange MakeTimePacket()
     {
-        return new(GameTime.TotalSeconds, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), ActiveTime.TotalMilliseconds, ntpSyncer.OnlineMode, ntpSyncer.CorrectionOffset.Ticks);
+        return new(GameTime.TotalSeconds, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), ActiveTime.TotalSeconds, ntpSyncer.OnlineMode, ntpSyncer.CorrectionOffset.Ticks);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Server's `TimeService.MakeTimePacket` was passing `ActiveTime.TotalMilliseconds` into a packet field that the client's `TimeManager.RealTimeElapsed` getter treats as seconds, producing values ~1000x larger than intended.
- Non-first-joiner clients saw incoming `VehicleMovements` snapshots as thousands of seconds in the past; `MovementReplicator` dropped them as expired, leaving vehicles frozen on remote screens. Float precision loss at the inflated magnitude (~2×10⁷) also prevented the interpolation buffer from recovering even after `maxAllowedLatency` caught up.
- Likely fixes long-standing reports of "vehicle movement not synchronized" (e.g. #2119): host drives a seamoth and other players see it as stationary.

## Test plan
- [x] Reproduced the bug before the fix with two players (one host, one joiner): host drives seamoth, joiner sees it frozen wherever it was when ownership transitioned.
- [x] After the fix: joiner sees seamoth move in real time as host drives it.
- [x] Verified server still sends consistent time data (no other consumers of `TimeChange.RealTimeElapsed` rely on the millisecond magnitude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)