### PR TITLE
partial fix with crashfish not working (adds crashfish to simulated entities)

### DIFF
--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
@@ -31,37 +31,77 @@ internal sealed class EntitySimulation : ISessionCleaner
         this.logger = logger;
     }
 
-    public List<SimulatedEntity> GetSimulationChangesForCell(Player player, AbsoluteEntityCell cell)
+    public IEnumerable<SimulatedEntity> GetSimulationChangesForCell(Player player, AbsoluteEntityCell cell)
     {
-        List<WorldEntity> entities = worldEntityManager.GetEntities(cell);
-        List<WorldEntity> addedEntities = FilterSimulatableEntities(player, entities);
-
-        foreach (WorldEntity child in addedEntities.SelectMany(GetSimulatableChildren).ToList())
-            if (simulationOwnershipData.TryToAcquire(child.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
-                addedEntities.Add(child);
-
-        List<SimulatedEntity> ownershipChanges = new();
-
-        foreach (WorldEntity entity in addedEntities)
+        foreach (WorldEntity entity in GetPlayerSimulatedEntities(player, cell))
         {
             bool doesEntityMove = ShouldSimulateEntityMovement(entity);
-            ownershipChanges.Add(new SimulatedEntity(entity.Id, player.SessionId, doesEntityMove, DEFAULT_ENTITY_SIMULATION_LOCKTYPE));
+            yield return new SimulatedEntity(entity.Id, player.SessionId, doesEntityMove, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
         }
-
-        return ownershipChanges;
     }
 
     public void FillWithRemovedCells(Player player, AbsoluteEntityCell removedCell, List<SimulatedEntity> ownershipChanges)
     {
-        List<WorldEntity> rootEntities = worldEntityManager.GetEntities(removedCell);
-        IEnumerable<WorldEntity> entities = rootEntities.Concat(rootEntities.SelectMany(GetSimulatableChildren));
-        IEnumerable<WorldEntity> revokedEntities = entities.Where(entity => !player.CanSee(entity) && simulationOwnershipData.RevokeIfOwner(entity.Id, player));
-        AssignEntitiesToOtherPlayers(player.SessionId, revokedEntities, ownershipChanges);
+        AssignEntitiesToOtherPlayers(player.SessionId, GetEntitiesToRevoke(player, removedCell), ownershipChanges);
+        return;
+
+        IEnumerable<WorldEntity> GetEntitiesOfCell(AbsoluteEntityCell cell)
+        {
+            foreach (WorldEntity entity in worldEntityManager.GetEntities(cell))
+            {
+                yield return entity;
+                foreach (WorldEntity child in GetSimulatableChildren(entity))
+                {
+                    yield return child;
+                }
+            }
+        }
+
+        IEnumerable<WorldEntity> GetEntitiesToRevoke(Player simulatingPlayer, AbsoluteEntityCell cell)
+        {
+            foreach (WorldEntity entity in GetEntitiesOfCell(cell))
+            {
+                if (player.CanSee(entity))
+                    continue;
+                if (!simulationOwnershipData.RevokeIfOwner(entity.Id, simulatingPlayer))
+                    continue;
+
+                yield return entity;
+            }
+        }
     }
 
     private IEnumerable<WorldEntity> GetSimulatableChildren(WorldEntity entity)
     {
         return entity.ChildEntities.OfType<WorldEntity>().Where(ShouldSimulateEntity);
+    }
+
+    private IEnumerable<WorldEntity> GetPlayerSimulatedEntities(Player simulatingPlayer, AbsoluteEntityCell cell)
+    {
+        foreach (WorldEntity entity in worldEntityManager.GetEntities(cell))
+        {
+            if (!simulatingPlayer.CanSee(entity))
+            {
+                continue;
+            }
+            if (!ShouldSimulateEntity(entity))
+            {
+                continue;
+            }
+            if (!simulationOwnershipData.TryToAcquire(entity.Id, simulatingPlayer, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
+            {
+                continue;
+            }
+
+            yield return entity;
+            foreach (WorldEntity child in GetSimulatableChildren(entity))
+            {
+                if (simulationOwnershipData.TryToAcquire(child.Id, simulatingPlayer, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
+                {
+                    yield return child;
+                }
+            }
+        }
     }
 
     public void BroadcastSimulationChanges(List<SimulatedEntity> ownershipChanges)
@@ -175,14 +215,5 @@ internal sealed class EntitySimulation : ISessionCleaner
                 ownershipChanges.Add(simulatedEntity);
             }
         }
-    }
-
-    private List<WorldEntity> FilterSimulatableEntities(Player player, List<WorldEntity> entities)
-    {
-        return entities.Where(entity =>
-        {
-            bool isEligibleForSimulation = player.CanSee(entity) && ShouldSimulateEntity(entity);
-            return isEligibleForSimulation && simulationOwnershipData.TryToAcquire(entity.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE);
-        }).ToList();
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
@@ -36,6 +36,10 @@ internal sealed class EntitySimulation : ISessionCleaner
         List<WorldEntity> entities = worldEntityManager.GetEntities(cell);
         List<WorldEntity> addedEntities = FilterSimulatableEntities(player, entities);
 
+        foreach (WorldEntity child in addedEntities.SelectMany(GetSimulatableChildren).ToList())
+            if (simulationOwnershipData.TryToAcquire(child.Id, player, DEFAULT_ENTITY_SIMULATION_LOCKTYPE))
+                addedEntities.Add(child);
+
         List<SimulatedEntity> ownershipChanges = new();
 
         foreach (WorldEntity entity in addedEntities)
@@ -49,9 +53,15 @@ internal sealed class EntitySimulation : ISessionCleaner
 
     public void FillWithRemovedCells(Player player, AbsoluteEntityCell removedCell, List<SimulatedEntity> ownershipChanges)
     {
-        List<WorldEntity> entities = worldEntityManager.GetEntities(removedCell);
+        List<WorldEntity> rootEntities = worldEntityManager.GetEntities(removedCell);
+        IEnumerable<WorldEntity> entities = rootEntities.Concat(rootEntities.SelectMany(GetSimulatableChildren));
         IEnumerable<WorldEntity> revokedEntities = entities.Where(entity => !player.CanSee(entity) && simulationOwnershipData.RevokeIfOwner(entity.Id, player));
         AssignEntitiesToOtherPlayers(player.SessionId, revokedEntities, ownershipChanges);
+    }
+
+    private IEnumerable<WorldEntity> GetSimulatableChildren(WorldEntity entity)
+    {
+        return entity.ChildEntities.OfType<WorldEntity>().Where(ShouldSimulateEntity);
     }
 
     public void BroadcastSimulationChanges(List<SimulatedEntity> ownershipChanges)

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntitySimulation.cs
@@ -62,9 +62,13 @@ internal sealed class EntitySimulation : ISessionCleaner
             foreach (WorldEntity entity in GetEntitiesOfCell(cell))
             {
                 if (player.CanSee(entity))
+                {
                     continue;
+                }
                 if (!simulationOwnershipData.RevokeIfOwner(entity.Id, simulatingPlayer))
+                {
                     continue;
+                }
 
                 yield return entity;
             }


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

~~fixes~~ does not correct https://github.com/SubnauticaNitrox/Nitrox/issues/2673 
Fixes https://github.com/SubnauticaNitrox/Nitrox/issues/2773

## Description of Change

- Filter and simulate children of entities.
- In this case, the root entity is the crashHome, and the crash is not added to the list. So by going to the children we add them too.

## Validation

- Opened an existing world, went to the closest crashfish and now it triggered and exploded. Only tested with a single user. See video in https://github.com/SubnauticaNitrox/Nitrox/issues/2773 for how it behaved before for single user

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This code was created with the help of AI.

Used ai for code review + debug help


