### PR TITLE
fix remote players becoming permanently invisible due to NaN velocity

### DIFF
--- a/NitroxClient/GameLogic/MovementHelper.cs
+++ b/NitroxClient/GameLogic/MovementHelper.cs
@@ -36,7 +36,7 @@ namespace NitroxClient.GameLogic
 
             float distance = difference.magnitude;
 
-            if (distance > 20f)
+            if (float.IsNaN(distance) || distance > 20f)
             {
                 // This should be a one-off teleport.
                 gameObject.transform.position = remotePosition;
@@ -58,6 +58,12 @@ namespace NitroxClient.GameLogic
             // We get an infinite axis in the event that our rotation is already aligned.
             if (float.IsInfinity(axis.x))
             {
+                return angularVelocty;
+            }
+
+            if (float.IsNaN(angle) || float.IsNaN(axis.x))
+            {
+                gameObject.transform.rotation = remoteRotation;
                 return angularVelocty;
             }
 

--- a/NitroxClient/GameLogic/MovementHelper.cs
+++ b/NitroxClient/GameLogic/MovementHelper.cs
@@ -36,6 +36,7 @@ namespace NitroxClient.GameLogic
 
             float distance = difference.magnitude;
 
+            // NaN guard to recover if distance becomes invalid 
             if (float.IsNaN(distance) || distance > 20f)
             {
                 // This should be a one-off teleport.
@@ -61,6 +62,7 @@ namespace NitroxClient.GameLogic
                 return angularVelocty;
             }
 
+            // Guard for NaN when remoteRotation and gameobjects rotation are parallel (witnessed during macOS habitat transition)
             if (float.IsNaN(angle) || float.IsNaN(axis.x))
             {
                 gameObject.transform.rotation = remoteRotation;


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

- This issue was only on my mac, and not on the other persons windows pc (may be unrelated, but something to note)
- Played for a few hours, and got these warnings when the other person disappeard. 
- Mostly happen when we entered a habitat but also happened while swimming

```
[18:16:51.906] [ERR-UNITY] Infinity or NaN floating point numbers appear when calculating the transform matrix for a Collider. Scene hierarchy path "silje"
...
[19:17:37.047] [ERR-UNITY] Infinity or NaN floating point numbers appear when calculating the transform matrix for a Collider. Scene hierarchy path "silje/player_view/signal_silje"
...
[18:47:32.547] [ERR-UNITY] Infinity or NaN floating point numbers appear when calculating the transform matrix for a Collider. Scene hierarchy path "Landscape/Global Root/Base(Clone)/silje"
...
[19:23:31.791] [ERR-UNITY] Infinity or NaN floating point numbers appear when calculating the transform matrix for a Collider. Scene hierarchy path "EscapePod-MainPrefab/EscapePod/silje"
```

## Description of Change

- guard for nan values

## Validation

- added temporary logging, and entered/exited buildings a few times. 
- in 5 min i got this, BUT the person did not despawn
```
[21:24:08.268] [WRN] NaN rotation on "Player1": local rotation (0.0, -0.2, 0.0, -1.0), incoming remote rotation (0.0, 0.2, 0.0, 1.0), delta angle 360, delta axis (NaN, Infinity, NaN), incoming angular velocity (0.0, 0.0, 0.0)
[21:24:12.284] [WRN] NaN rotation on "Player1": local rotation (0.0, -0.4, 0.0, 0.9), incoming remote rotation (0.0, 0.4, 0.0, -0.9), delta angle 360, delta axis (NaN, Infinity, NaN), incoming angular velocity (0.0, 0.0, 0.0)
[21:26:01.568] [WRN] NaN rotation on "Player1": local rotation (0.0, -1.0, 0.0, 0.2), incoming remote rotation (0.0, 1.0, 0.0, -0.2), delta angle 360, delta axis (NaN, Infinity, NaN), incoming angular velocity (0.0, 0.0, 0.0)
```

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This code was created with the help of AI.
Pair programmed with ai
