### PR TITLE
Fix for login command not updating PlayerTab UI

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Commands/LoginCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/LoginCommand.cs
@@ -25,6 +25,7 @@ internal sealed class LoginCommand(IOptions<SubnauticaServerOptions> optionsProv
                 if (activePassword == adminPassword)
                 {
                     player.Permissions = Perms.ADMIN;
+                    await context.ReplyAsync(new PermsChanged(Perms.ADMIN));
                     await context.ReplyAsync($"You've been made {nameof(Perms.ADMIN)} on this server!");
                 }
                 else


### PR DESCRIPTION
## Description of Change

<!-- Describe what this PR changes and why -->
Make sure to update LocalPlayer perms client-side while using login command.

Similar to what is done inside PromoteCommand

## Validation

<!-- Describe steps to validate your changes -->
* Connect two players
* One player use login command, and should see his player tab updated with abilities to teleport/kick with the UI

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)