### PR TITLE
Fix finder names on non-Windows paths

### DIFF
--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/Core/GameFinderResult.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/Core/GameFinderResult.cs
@@ -1,5 +1,6 @@
 extern alias JB;
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
@@ -27,7 +28,7 @@ public sealed record GameFinderResult
     {
         return new GameFinderResult
         {
-            FinderName = callerCodeFile[(callerCodeFile.LastIndexOf("\\", StringComparison.Ordinal) + 1)..^3],
+            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile),
             ErrorMessage = message
         };
     }
@@ -39,7 +40,7 @@ public sealed record GameFinderResult
     {
         return new GameFinderResult
         {
-            FinderName = callerCodeFile[(callerCodeFile.LastIndexOf("\\", StringComparison.Ordinal) + 1)..^3]
+            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile)
         };
     }
 
@@ -48,7 +49,7 @@ public sealed record GameFinderResult
         Validate.NotNull(path);
         return new GameFinderResult
         {
-            FinderName = callerCodeFile[(callerCodeFile.LastIndexOf("\\", StringComparison.Ordinal) + 1)..^3],
+            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile),
             Path = path
         };
     }

--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/Core/GameFinderResult.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/Core/GameFinderResult.cs
@@ -1,17 +1,15 @@
 extern alias JB;
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
+using static System.IO.Path;
 
 namespace Nitrox.Model.Platforms.Discovery.InstallationFinders.Core;
 
 public sealed record GameFinderResult
 {
-    public string ErrorMessage { get; init; }
+    public string ErrorMessage { get; init; } = "";
     public GameLibraries Origin { get; init; }
-    public string Path { get; init; }
+    public string Path { get; init; } = "";
 
     /// <summary>
     ///     Gets the name of type that made the result.
@@ -28,7 +26,7 @@ public sealed record GameFinderResult
     {
         return new GameFinderResult
         {
-            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile),
+            FinderName = GetFileNameWithoutExtension(callerCodeFile),
             ErrorMessage = message
         };
     }
@@ -38,10 +36,7 @@ public sealed record GameFinderResult
     /// </summary>
     public static GameFinderResult NotFound([CallerFilePath] string callerCodeFile = "")
     {
-        return new GameFinderResult
-        {
-            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile)
-        };
+        return new GameFinderResult { FinderName = GetFileNameWithoutExtension(callerCodeFile) };
     }
 
     public static GameFinderResult Ok(string path, [CallerFilePath] string callerCodeFile = "")
@@ -49,7 +44,7 @@ public sealed record GameFinderResult
         Validate.NotNull(path);
         return new GameFinderResult
         {
-            FinderName = Path.GetFileNameWithoutExtension(callerCodeFile),
+            FinderName = GetFileNameWithoutExtension(callerCodeFile),
             Path = path
         };
     }


### PR DESCRIPTION
## Purpose
Fix `GameFinderResult.FinderName` when `[CallerFilePath]` uses `/` separators on macOS/Linux.

## What changed
- Replaced manual Windows-only path slicing with `Path.GetFileNameWithoutExtension`.

## Validation
- `git diff --check`
- `dotnet build Nitrox.Model/Nitrox.Model.csproj --no-restore` could not be run here because `dotnet` is not installed in this environment.