### PR TITLE
[MacOS] Improve app bundle packaging steps

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,6 @@
 
     <PropertyGroup>
         <_GitShortHashFilePath>$(IntermediateOutputPath)git_short_hash.cache</_GitShortHashFilePath>
-        <_PathSeparator>$([System.IO.Path]::DirectorySeparatorChar)</_PathSeparator>
     </PropertyGroup>
 
     <Target Name="_CreateGitShortHashCacheFile" Inputs="$(_GitRefHashFilePath)" Outputs="$(_GitShortHashFilePath)" Condition="Exists('$(_GitRefHashFilePath)')">
@@ -52,21 +51,17 @@
         </DiscoverGame>
         <Error Condition="'$(GameDir)' == '' and '$(SUBNAUTICA_INSTALLATION_PATH)' == ''" Text="Failed to find the game '$(GameName)' on your machine" />
         <PropertyGroup>
-            <GameDir Condition="Exists('$(GameDir)')">$(GameDir)$(_PathSeparator)</GameDir>
-            <GameDir Condition="!Exists('$(GameDir)')">$(SUBNAUTICA_INSTALLATION_PATH)$(_PathSeparator)</GameDir>
+            <GameDir Condition="Exists('$(GameDir)')">$(GameDir)\</GameDir>
+            <GameDir Condition="!Exists('$(GameDir)')">$(SUBNAUTICA_INSTALLATION_PATH)\</GameDir>
             <GameDataFolder>Subnautica_Data</GameDataFolder>
         </PropertyGroup>
         <PropertyGroup Condition="$(_IsMacOS)">
-            <GameDataFolder>Resources$(_PathSeparator)Data</GameDataFolder>
-        </PropertyGroup>
-        <PropertyGroup Condition="Exists('$(GameDir)Subnautica_Data')">
-            <GameDataFolder>Subnautica_Data</GameDataFolder>
+            <GameDataFolder>Resources\Data</GameDataFolder>
         </PropertyGroup>
         <PropertyGroup>
-            <GameManagedDir>$(GameDir)$(GameDataFolder)$(_PathSeparator)Managed$(_PathSeparator)</GameManagedDir>
-            <GameVersionFile>$(GameDir)$(GameDataFolder)$(_PathSeparator)StreamingAssets$(_PathSeparator)SNUnmanagedData$(_PathSeparator)plastic_status.ignore</GameVersionFile>
+            <GameManagedDir>$(GameDir)$(GameDataFolder)\Managed\</GameManagedDir>
+            <GameVersionFile>$(GameDir)$(GameDataFolder)\StreamingAssets\SNUnmanagedData\plastic_status.ignore</GameVersionFile>
         </PropertyGroup>
-        <Error Condition="!Exists('$(GameVersionFile)')" Text="Failed to find the game version file at '$(GameVersionFile)'" />
         <ReadLinesFromFile File="$(GameVersionFile)">
             <Output TaskParameter="Lines" ItemName="GameVersion" />
         </ReadLinesFromFile>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -52,8 +52,8 @@
         </DiscoverGame>
         <Error Condition="'$(GameDir)' == '' and '$(SUBNAUTICA_INSTALLATION_PATH)' == ''" Text="Failed to find the game '$(GameName)' on your machine" />
         <PropertyGroup>
-            <GameDir Condition="'$(GameDir)' != '' and Exists('$(GameDir)')">$(GameDir)$(_PathSeparator)</GameDir>
-            <GameDir Condition="'$(GameDir)' == '' and '$(SUBNAUTICA_INSTALLATION_PATH)' != ''">$(SUBNAUTICA_INSTALLATION_PATH)$(_PathSeparator)</GameDir>
+            <GameDir Condition="Exists('$(GameDir)')">$(GameDir)$(_PathSeparator)</GameDir>
+            <GameDir Condition="!Exists('$(GameDir)')">$(SUBNAUTICA_INSTALLATION_PATH)$(_PathSeparator)</GameDir>
             <GameDataFolder>Subnautica_Data</GameDataFolder>
         </PropertyGroup>
         <PropertyGroup Condition="$(_IsMacOS)">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
 
     <PropertyGroup>
         <_GitShortHashFilePath>$(IntermediateOutputPath)git_short_hash.cache</_GitShortHashFilePath>
+        <_PathSeparator>$([System.IO.Path]::DirectorySeparatorChar)</_PathSeparator>
     </PropertyGroup>
 
     <Target Name="_CreateGitShortHashCacheFile" Inputs="$(_GitRefHashFilePath)" Outputs="$(_GitShortHashFilePath)" Condition="Exists('$(_GitRefHashFilePath)')">
@@ -51,17 +52,21 @@
         </DiscoverGame>
         <Error Condition="'$(GameDir)' == '' and '$(SUBNAUTICA_INSTALLATION_PATH)' == ''" Text="Failed to find the game '$(GameName)' on your machine" />
         <PropertyGroup>
-            <GameDir Condition="Exists('$(GameDir)')">$(GameDir)\</GameDir>
-            <GameDir Condition="!Exists('$(GameDir)')">$(SUBNAUTICA_INSTALLATION_PATH)\</GameDir>
+            <GameDir Condition="'$(GameDir)' != '' and Exists('$(GameDir)')">$(GameDir)$(_PathSeparator)</GameDir>
+            <GameDir Condition="'$(GameDir)' == '' and '$(SUBNAUTICA_INSTALLATION_PATH)' != ''">$(SUBNAUTICA_INSTALLATION_PATH)$(_PathSeparator)</GameDir>
             <GameDataFolder>Subnautica_Data</GameDataFolder>
         </PropertyGroup>
         <PropertyGroup Condition="$(_IsMacOS)">
-            <GameDataFolder>Resources\Data</GameDataFolder>
+            <GameDataFolder>Resources$(_PathSeparator)Data</GameDataFolder>
+        </PropertyGroup>
+        <PropertyGroup Condition="Exists('$(GameDir)Subnautica_Data')">
+            <GameDataFolder>Subnautica_Data</GameDataFolder>
         </PropertyGroup>
         <PropertyGroup>
-            <GameManagedDir>$(GameDir)$(GameDataFolder)\Managed\</GameManagedDir>
-            <GameVersionFile>$(GameDir)$(GameDataFolder)\StreamingAssets\SNUnmanagedData\plastic_status.ignore</GameVersionFile>
+            <GameManagedDir>$(GameDir)$(GameDataFolder)$(_PathSeparator)Managed$(_PathSeparator)</GameManagedDir>
+            <GameVersionFile>$(GameDir)$(GameDataFolder)$(_PathSeparator)StreamingAssets$(_PathSeparator)SNUnmanagedData$(_PathSeparator)plastic_status.ignore</GameVersionFile>
         </PropertyGroup>
+        <Error Condition="!Exists('$(GameVersionFile)')" Text="Failed to find the game version file at '$(GameVersionFile)'" />
         <ReadLinesFromFile File="$(GameVersionFile)">
             <Output TaskParameter="Lines" ItemName="GameVersion" />
         </ReadLinesFromFile>

--- a/Nitrox.Shared.targets
+++ b/Nitrox.Shared.targets
@@ -216,8 +216,10 @@
               SkipUnchangedFiles="True"
               ContinueOnError="ErrorAndStop" />
 
+        <Exec Condition="$(_IsMacOS)" Command="chmod +x &quot;$(_MacOSDir)$(AssemblyName)&quot;" />
+
         <!-- Remove quarantine that prevents app from being run after download -->
-        <Exec Condition="$(_IsMacOS)" Command="xattr -r -d com.apple.quarantine $(_AppBundleDir)" />
+        <Exec Condition="$(_IsMacOS)" Command="xattr -r -d com.apple.quarantine &quot;$(_AppBundleDir)&quot;" ContinueOnError="WarnAndContinue" />
 
         <ZipDirectory SourceDirectory="$(_ZipDir)"
                       DestinationFile="$(_ZipFilePath)"


### PR DESCRIPTION
## Purpose
Keep the macOS app-bundle packaging steps resilient without touching game discovery or MSBuild game-data path construction.

## What changed
- Marks the generated macOS app-bundle executable as executable.
- Quotes the app bundle path when removing quarantine metadata.
- Makes quarantine metadata removal warn instead of failing the whole package step when the attribute is absent or unsupported.

## Validation
- `git diff --check`
- GitHub Actions reported 256 tests, 253 passing, 3 skipped, 0 failures on the prior commit.
- `dotnet` is not installed in this local environment, so package validation could not be run locally.