### PR TITLE
[Steam] Make libraryfolders.vdf parsing whitespace-tolerant

### DIFF
--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Nitrox.Model.Platforms.Discovery.InstallationFinders.Core;
@@ -50,7 +52,7 @@ public sealed class SteamFinder : IGameFinder
         return Ok(path);
     }
 
-    private static string GetSteamPath()
+    internal static string GetSteamPath()
     {
         // OSX: Steam dynamic data isn't near the steam exe. Because it can't (or isn't supposed to) write anything inside application bundle.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -79,20 +81,43 @@ public sealed class SteamFinder : IGameFinder
     /// <summary>
     /// Finds game install directory by iterating through all the steam game libraries configured, matching the given appid.
     /// </summary>
-    private static string? SearchAllInstallations(string libraryFolders, int appid, string gameName)
+    internal static string? SearchAllInstallations(string libraryFolders, int appid, string gameName)
     {
         if (!File.Exists(libraryFolders))
         {
             return null;
         }
 
-        StreamReader file = new(libraryFolders);
-        char[] trimChars = [' ', '\t'];
+        string steamPath = Directory.GetParent(Path.GetDirectoryName(libraryFolders) ?? "")?.FullName ?? "";
+        foreach (string libraryPath in GetLibraryPaths(libraryFolders).Append(steamPath).Where(static path => !string.IsNullOrWhiteSpace(path)).Distinct())
+        {
+            if (File.Exists(Path.Combine(libraryPath, "steamapps", $"appmanifest_{appid}.acf")))
+            {
+                return Path.Combine(libraryPath, "steamapps", "common", gameName);
+            }
+        }
 
+        return null;
+    }
+
+    internal static IEnumerable<string> GetLibraryPaths(string libraryFolders)
+    {
+        if (!File.Exists(libraryFolders))
+        {
+            yield break;
+        }
+
+        using StreamReader file = new(libraryFolders);
+        char[] trimChars = [' ', '\t'];
         while (file.ReadLine() is { } line)
         {
             line = line.Trim(trimChars);
-            Match regMatch = Regex.Match(line, "\"(.*)\"\t*\"(.*)\"");
+            Match regMatch = Regex.Match(line, "\"([^\"]+)\"\\s+\"(.*)\"");
+            if (!regMatch.Success)
+            {
+                continue;
+            }
+
             string key = regMatch.Groups[1].Value;
 
             // New format (about 2021-07-16) uses "path" key instead of steam-library-index as key. If either, it could be steam game path.
@@ -101,14 +126,7 @@ public sealed class SteamFinder : IGameFinder
                 continue;
             }
 
-            string value = regMatch.Groups[2].Value;
-
-            if (File.Exists(Path.Combine(value, "steamapps", $"appmanifest_{appid}.acf")))
-            {
-                return Path.Combine(value, "steamapps", "common", gameName);
-            }
+            yield return regMatch.Groups[2].Value.Replace(@"\\", @"\");
         }
-
-        return null;
     }
 }

--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
@@ -52,7 +52,7 @@ public sealed class SteamFinder : IGameFinder
         return Ok(path);
     }
 
-    internal static string GetSteamPath()
+    private static string GetSteamPath()
     {
         // OSX: Steam dynamic data isn't near the steam exe. Because it can't (or isn't supposed to) write anything inside application bundle.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -88,8 +88,7 @@ public sealed class SteamFinder : IGameFinder
             return null;
         }
 
-        string steamPath = Directory.GetParent(Path.GetDirectoryName(libraryFolders) ?? "")?.FullName ?? "";
-        foreach (string libraryPath in GetLibraryPaths(libraryFolders).Append(steamPath).Where(static path => !string.IsNullOrWhiteSpace(path)).Distinct())
+        foreach (string libraryPath in GetLibraryPaths(libraryFolders).Where(static path => !string.IsNullOrWhiteSpace(path)).Distinct())
         {
             if (File.Exists(Path.Combine(libraryPath, "steamapps", $"appmanifest_{appid}.acf")))
             {
@@ -109,9 +108,21 @@ public sealed class SteamFinder : IGameFinder
 
         using StreamReader file = new(libraryFolders);
         char[] trimChars = [' ', '\t'];
+        int depth = 0;
         while (file.ReadLine() is { } line)
         {
             line = line.Trim(trimChars);
+            if (line == "{")
+            {
+                depth++;
+                continue;
+            }
+            if (line == "}")
+            {
+                depth = Math.Max(0, depth - 1);
+                continue;
+            }
+
             Match regMatch = Regex.Match(line, "\"([^\"]+)\"\\s+\"(.*)\"");
             if (!regMatch.Success)
             {
@@ -120,8 +131,8 @@ public sealed class SteamFinder : IGameFinder
 
             string key = regMatch.Groups[1].Value;
 
-            // New format (about 2021-07-16) uses "path" key instead of steam-library-index as key. If either, it could be steam game path.
-            if (!key.Equals("path", StringComparison.OrdinalIgnoreCase) && !int.TryParse(key, out _))
+            // Current libraryfolders.vdf entries use a nested "path" key; older entries used top-level numeric keys.
+            if (!key.Equals("path", StringComparison.OrdinalIgnoreCase) && (depth > 1 || !int.TryParse(key, out _)))
             {
                 continue;
             }

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -128,7 +128,13 @@ public sealed class Steam : IGamePlatform
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            steamExecutable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx");
+            string[] commonPaths =
+            [
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx"),
+                Path.Combine(Path.DirectorySeparatorChar.ToString(), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx")
+            ];
+            steamExecutable = commonPaths.FirstOrDefault(File.Exists) ?? "";
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -128,13 +128,7 @@ public sealed class Steam : IGamePlatform
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            string[] commonPaths =
-            [
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx"),
-                Path.Combine(Path.DirectorySeparatorChar.ToString(), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx")
-            ];
-            steamExecutable = commonPaths.FirstOrDefault(File.Exists) ?? "";
+            steamExecutable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx");
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/Nitrox.Test/Model/Platforms/Discovery/SteamFinderTest.cs
+++ b/Nitrox.Test/Model/Platforms/Discovery/SteamFinderTest.cs
@@ -1,0 +1,52 @@
+using Nitrox.Model;
+using Nitrox.Model.Platforms.Discovery.InstallationFinders;
+
+namespace Nitrox.Test.Model.Platforms.Discovery;
+
+[TestClass]
+public class SteamFinderTest
+{
+    [TestMethod]
+    public void SearchAllInstallations_ShouldParseModernLibraryFoldersVdf()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string libraryRoot = Path.Combine(tempDir, "SteamLibrary");
+            Directory.CreateDirectory(Path.Combine(libraryRoot, "steamapps"));
+            File.WriteAllText(Path.Combine(libraryRoot, "steamapps", $"appmanifest_{GameInfo.Subnautica.SteamAppId}.acf"), "");
+
+            string steamApps = Path.Combine(tempDir, "Steam", "steamapps");
+            Directory.CreateDirectory(steamApps);
+            string libraryFolders = Path.Combine(steamApps, "libraryfolders.vdf");
+            File.WriteAllText(libraryFolders, $$"""
+                                                "libraryfolders"
+                                                {
+                                                    "0"
+                                                    {
+                                                        "path" "{{libraryRoot}}"
+                                                        "apps"
+                                                        {
+                                                            "{{GameInfo.Subnautica.SteamAppId}}" "1"
+                                                        }
+                                                    }
+                                                }
+                                                """);
+
+            string? path = SteamFinder.SearchAllInstallations(libraryFolders, GameInfo.Subnautica.SteamAppId, GameInfo.Subnautica.Name);
+
+            path.Should().Be(Path.Combine(libraryRoot, "steamapps", "common", GameInfo.Subnautica.Name));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"NitroxSteamFinderTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+}

--- a/Nitrox.Test/Model/Platforms/Discovery/SteamFinderTest.cs
+++ b/Nitrox.Test/Model/Platforms/Discovery/SteamFinderTest.cs
@@ -7,7 +7,7 @@ namespace Nitrox.Test.Model.Platforms.Discovery;
 public class SteamFinderTest
 {
     [TestMethod]
-    public void SearchAllInstallations_ShouldParseModernLibraryFoldersVdf()
+    public void SearchAllInstallations_ShouldParseSpaceSeparatedLibraryFoldersVdf()
     {
         string tempDir = CreateTempDir();
         try
@@ -39,6 +39,65 @@ public class SteamFinderTest
         }
         finally
         {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void GetLibraryPaths_ShouldIgnoreAppEntriesInLibraryFoldersVdf()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string libraryRoot = Path.Combine(tempDir, "SteamLibrary");
+            string legacyLibraryRoot = Path.Combine(tempDir, "LegacySteamLibrary");
+            string libraryFolders = Path.Combine(tempDir, "libraryfolders.vdf");
+            File.WriteAllText(libraryFolders, $$"""
+                                                "libraryfolders"
+                                                {
+                                                    "0"
+                                                    {
+                                                        "path" "{{libraryRoot}}"
+                                                        "apps"
+                                                        {
+                                                            "{{GameInfo.Subnautica.SteamAppId}}" "1"
+                                                        }
+                                                    }
+                                                    "1" "{{legacyLibraryRoot}}"
+                                                }
+                                                """);
+
+            string[] paths = SteamFinder.GetLibraryPaths(libraryFolders).ToArray();
+
+            paths.Should().Equal(libraryRoot, legacyLibraryRoot);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void SearchAllInstallations_ShouldHandleRelativeLibraryFoldersPath()
+    {
+        string tempDir = CreateTempDir();
+        string currentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = tempDir;
+            File.WriteAllText("libraryfolders.vdf", """
+                                                    "libraryfolders"
+                                                    {
+                                                    }
+                                                    """);
+
+            Action search = () => SteamFinder.SearchAllInstallations("libraryfolders.vdf", GameInfo.Subnautica.SteamAppId, GameInfo.Subnautica.Name);
+
+            search.Should().NotThrow();
+        }
+        finally
+        {
+            Environment.CurrentDirectory = currentDirectory;
             Directory.Delete(tempDir, true);
         }
     }


### PR DESCRIPTION
## Purpose
Make Steam library discovery handle valid `libraryfolders.vdf` key/value lines when they are separated by whitespace other than tabs.

Follow-up from maintainer review: this is not a new Steam schema. The existing parser already handles the nested `path` format when Steam writes the file with tabs. This PR is narrowed to the smaller parser robustness issue.

## What changed
- Keeps discovery focused on `SteamFinder`; removed the separate macOS Steam executable lookup from this PR.
- Parses quoted key/value pairs with general whitespace instead of tab-only matching.
- Keeps legacy top-level numeric library entries, but ignores nested numeric app IDs under `apps`.
- Adds focused tests for space-separated entries, nested `apps` entries, and relative `libraryfolders.vdf` input.

## Validation
- `git diff --check`
- Not run locally: this environment still has no .NET SDK installed.