### PR TITLE
[MacOS] Normalize native app bundle paths

### DIFF
--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -84,6 +84,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
 
     private static void SetTargetedSubnauticaPath(string path)
     {
+        path = GameInstallationHelper.NormalizeGamePath(path, GameInfo.Subnautica);
         if (!Directory.Exists(path))
         {
             return;
@@ -120,12 +121,13 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
             return;
         }
 
-        if (!GameInstallationHelper.HasGameExecutable(selectedDirectory, GameInfo.Subnautica))
+        if (!GameInstallationHelper.HasValidGameFolder(selectedDirectory, GameInfo.Subnautica))
         {
-            LauncherNotifier.Error("Invalid subnautica directory");
+            LauncherNotifier.Error("Invalid Subnautica directory. Select Subnautica.app, its Contents folder, or the Subnautica install folder.");
             return;
         }
 
+        selectedDirectory = GameInstallationHelper.NormalizeGamePath(selectedDirectory, GameInfo.Subnautica);
         if (!selectedDirectory.Equals(SelectedGame.PathToGame, StringComparison.OrdinalIgnoreCase))
         {
             await Task.Run(() => SetTargetedSubnauticaPath(selectedDirectory));

--- a/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
+++ b/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -7,15 +9,7 @@ public static class GameInstallationHelper
 {
     public static bool HasGameExecutable(string path, GameInfo gameInfo)
     {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return File.Exists(Path.Combine(path, "MacOS", gameInfo.ExeName));
-        }
-        return File.Exists(Path.Combine(path, gameInfo.ExeName));
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && File.Exists(layout.ExecutablePath);
     }
 
     public static bool HasValidGameFolder(string path, GameInfo gameInfo)
@@ -24,19 +18,108 @@ public static class GameInstallationHelper
         {
             return false;
         }
-        if (!Directory.Exists(path))
+        return TryGetGameInstallation(path, gameInfo, out _);
+    }
+
+    public static string NormalizeGamePath(string path, GameInfo gameInfo)
+    {
+        if (string.IsNullOrWhiteSpace(path))
         {
-            return false;
+            return "";
         }
-        if (!HasGameExecutable(path, gameInfo))
+
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) ? layout.RootPath : Path.GetFullPath(path);
+    }
+
+    public static bool TryGetGameExecutablePath(string path, GameInfo gameInfo, out string executablePath)
+    {
+        if (TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout))
         {
-            return false;
+            executablePath = layout.ExecutablePath;
+            return true;
         }
-        if (!Directory.Exists(Path.Combine(path, gameInfo.DataFolder, "Managed")))
+
+        executablePath = "";
+        return false;
+    }
+
+    public static bool IsNativeMacOSGameLayout(string path, GameInfo gameInfo)
+    {
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && layout.Kind == GameInstallationKind.NativeMacOS;
+    }
+
+    public static bool TryGetGameInstallation(string path, GameInfo gameInfo, out GameInstallationLayout layout)
+    {
+        layout = null;
+        if (string.IsNullOrWhiteSpace(path))
         {
             return false;
         }
 
-        return true;
+        string rootPath = Path.GetFullPath(path);
+        foreach (string candidatePath in GetCandidateRootPaths(rootPath, gameInfo))
+        {
+            if (TryCreateLayout(candidatePath, gameInfo, out layout))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
+
+    private static bool TryCreateLayout(string rootPath, GameInfo gameInfo, out GameInstallationLayout layout)
+    {
+        layout = null;
+        if (!Directory.Exists(rootPath))
+        {
+            return false;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            string nativeMacExecutable = Path.Combine(rootPath, "MacOS", gameInfo.ExeName);
+            string nativeMacManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
+            if (File.Exists(nativeMacExecutable) && Directory.Exists(nativeMacManagedPath))
+            {
+                layout = new(rootPath, nativeMacExecutable, nativeMacManagedPath, GameInstallationKind.NativeMacOS);
+                return true;
+            }
+        }
+
+        string hostExecutable = Path.Combine(rootPath, gameInfo.ExeName);
+        string hostManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
+        if (File.Exists(hostExecutable) && Directory.Exists(hostManagedPath))
+        {
+            layout = new(rootPath, hostExecutable, hostManagedPath, GameInstallationKind.Host);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetCandidateRootPaths(string path, GameInfo gameInfo)
+    {
+        yield return path;
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            yield break;
+        }
+
+        if (Path.GetExtension(path).Equals(".app", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return Path.Combine(path, "Contents");
+        }
+
+        yield return Path.Combine(path, $"{gameInfo.Name}.app", "Contents");
+    }
+}
+
+public sealed record GameInstallationLayout(string RootPath, string ExecutablePath, string ManagedPath, GameInstallationKind Kind);
+
+public enum GameInstallationKind
+{
+    Host,
+    NativeMacOS
 }

--- a/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
+++ b/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
@@ -31,24 +31,7 @@ public static class GameInstallationHelper
         return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) ? layout.RootPath : Path.GetFullPath(path);
     }
 
-    public static bool TryGetGameExecutablePath(string path, GameInfo gameInfo, out string executablePath)
-    {
-        if (TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout))
-        {
-            executablePath = layout.ExecutablePath;
-            return true;
-        }
-
-        executablePath = "";
-        return false;
-    }
-
-    public static bool IsNativeMacOSGameLayout(string path, GameInfo gameInfo)
-    {
-        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && layout.Kind == GameInstallationKind.NativeMacOS;
-    }
-
-    public static bool TryGetGameInstallation(string path, GameInfo gameInfo, out GameInstallationLayout layout)
+    private static bool TryGetGameInstallation(string path, GameInfo gameInfo, out GameInstallationLayout layout)
     {
         layout = null;
         if (string.IsNullOrWhiteSpace(path))
@@ -82,7 +65,7 @@ public static class GameInstallationHelper
             string nativeMacManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
             if (File.Exists(nativeMacExecutable) && Directory.Exists(nativeMacManagedPath))
             {
-                layout = new(rootPath, nativeMacExecutable, nativeMacManagedPath, GameInstallationKind.NativeMacOS);
+                layout = new(rootPath, nativeMacExecutable);
                 return true;
             }
         }
@@ -91,7 +74,7 @@ public static class GameInstallationHelper
         string hostManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
         if (File.Exists(hostExecutable) && Directory.Exists(hostManagedPath))
         {
-            layout = new(rootPath, hostExecutable, hostManagedPath, GameInstallationKind.Host);
+            layout = new(rootPath, hostExecutable);
             return true;
         }
 
@@ -114,12 +97,6 @@ public static class GameInstallationHelper
 
         yield return Path.Combine(path, $"{gameInfo.Name}.app", "Contents");
     }
-}
 
-public sealed record GameInstallationLayout(string RootPath, string ExecutablePath, string ManagedPath, GameInstallationKind Kind);
-
-public enum GameInstallationKind
-{
-    Host,
-    NativeMacOS
+    private sealed record GameInstallationLayout(string RootPath, string ExecutablePath);
 }

--- a/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
+++ b/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
@@ -1,0 +1,68 @@
+using Nitrox.Model;
+using Nitrox.Model.Platforms.Discovery;
+using Nitrox.Test.Model.Platforms;
+
+namespace Nitrox.Test.Model.Platforms.Discovery;
+
+[TestClass]
+public class GameInstallationHelperTest
+{
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void NormalizeGamePath_ShouldAcceptMacOSSteamGameFolder()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string steamGameRoot = Path.Combine(tempDir, "steamapps", "common", "Subnautica");
+            string appContents = Path.Combine(steamGameRoot, "Subnautica.app", "Contents");
+            CreateNativeMacSubnautica(appContents);
+
+            string normalized = GameInstallationHelper.NormalizeGamePath(steamGameRoot, GameInfo.Subnautica);
+
+            normalized.Should().Be(appContents);
+            GameInstallationHelper.HasValidGameFolder(normalized, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.IsNativeMacOSGameLayout(normalized, GameInfo.Subnautica).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void NormalizeGamePath_ShouldAcceptMacOSAppBundle()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string steamGameRoot = Path.Combine(tempDir, "steamapps", "common", "Subnautica");
+            string appBundle = Path.Combine(steamGameRoot, "Subnautica.app");
+            string appContents = Path.Combine(appBundle, "Contents");
+            CreateNativeMacSubnautica(appContents);
+
+            string normalized = GameInstallationHelper.NormalizeGamePath(appBundle, GameInfo.Subnautica);
+
+            normalized.Should().Be(appContents);
+            GameInstallationHelper.TryGetGameExecutablePath(normalized, GameInfo.Subnautica, out string executablePath).Should().BeTrue();
+            executablePath.Should().Be(Path.Combine(appContents, "MacOS", "Subnautica"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"NitroxGameInstallationHelperTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void CreateNativeMacSubnautica(string contentsPath)
+    {
+        Directory.CreateDirectory(Path.Combine(contentsPath, "MacOS"));
+        Directory.CreateDirectory(Path.Combine(contentsPath, "Resources", "Data", "Managed"));
+        File.WriteAllText(Path.Combine(contentsPath, "MacOS", "Subnautica"), "");
+    }
+}

--- a/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
+++ b/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
@@ -21,7 +21,7 @@ public class GameInstallationHelperTest
 
             normalized.Should().Be(appContents);
             GameInstallationHelper.HasValidGameFolder(normalized, GameInfo.Subnautica).Should().BeTrue();
-            GameInstallationHelper.IsNativeMacOSGameLayout(normalized, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.HasGameExecutable(steamGameRoot, GameInfo.Subnautica).Should().BeTrue();
         }
         finally
         {
@@ -43,8 +43,8 @@ public class GameInstallationHelperTest
             string normalized = GameInstallationHelper.NormalizeGamePath(appBundle, GameInfo.Subnautica);
 
             normalized.Should().Be(appContents);
-            GameInstallationHelper.TryGetGameExecutablePath(normalized, GameInfo.Subnautica, out string executablePath).Should().BeTrue();
-            executablePath.Should().Be(Path.Combine(appContents, "MacOS", "Subnautica"));
+            GameInstallationHelper.HasValidGameFolder(appBundle, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.HasGameExecutable(appBundle, GameInfo.Subnautica).Should().BeTrue();
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Normalize native macOS Steam game paths so selecting the `Subnautica` folder or `Subnautica.app` resolves to `Subnautica.app/Contents`.
- Keep the existing host executable layout checks for non-macOS paths.
- Keep the new layout detection internals private, so callers still use `HasValidGameFolder`, `HasGameExecutable`, and `NormalizeGamePath`.

## Context
This PR is intentionally limited to the native macOS app-bundle layout. I dropped Wine fallback/emulation work from this stack after maintainer feedback, because the macOS game build is native.

## Validation
- `git diff --check`
- Not run locally: .NET tests, because `dotnet` is not installed in this local environment.
