### PR TITLE
[codex] Send admin login permission updates directly

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Commands/LoginCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/LoginCommand.cs
@@ -24,8 +24,9 @@ internal sealed class LoginCommand(IOptions<SubnauticaServerOptions> optionsProv
             case PlayerToServerCommandContext { Player: { Permissions: < Perms.ADMIN } player }:
                 if (activePassword == adminPassword)
                 {
-                    player.Permissions = Perms.ADMIN;
-                    await context.ReplyAsync(new PermsChanged(Perms.ADMIN));
+                    Perms newPerms = Perms.ADMIN;
+                    player.Permissions = newPerms;
+                    await context.SendAsync(player.SessionId, new PermsChanged(newPerms));
                     await context.ReplyAsync($"You've been made {nameof(Perms.ADMIN)} on this server!");
                 }
                 else


### PR DESCRIPTION
## Purpose
Ensure the player who logs in as admin receives the permission-change packet directly after the server updates their permissions.

## What changed
- Stores the new permission in a local variable.
- Sends `PermsChanged` to the player session via `SendAsync` instead of replying with the packet payload.

## Validation
- `git diff --check`
- `dotnet test` could not be run here because `dotnet` is not installed.