### PR TITLE
[codex] Isolate macOS Wine launch support

### DIFF
--- a/Nitrox.Launcher/Models/Converters/PlatformToIconConverter.cs
+++ b/Nitrox.Launcher/Models/Converters/PlatformToIconConverter.cs
@@ -20,6 +20,7 @@ public class PlatformToIconConverter : Converter<PlatformToIconConverter>
         Platform.HEROIC => "/Assets/Images/store-icons/heroic.png",
         Platform.MICROSOFT => "/Assets/Images/store-icons/xbox.png",
         Platform.DISCORD => "/Assets/Images/store-icons/discord.png",
+        Platform.WINE => "/Assets/Images/store-icons/missing.png",
         _ => "/Assets/Images/store-icons/missing.png",
     };
 }

--- a/Nitrox.Launcher/Models/Utils/GameInspect.cs
+++ b/Nitrox.Launcher/Models/Utils/GameInspect.cs
@@ -7,6 +7,7 @@ using Nitrox.Launcher.Models.Services;
 using Nitrox.Launcher.ViewModels;
 using Nitrox.Model.Core;
 using Nitrox.Model.Logger;
+using Nitrox.Model.Platforms.Discovery;
 using Nitrox.Model.Platforms.OS.Shared;
 
 namespace Nitrox.Launcher.Models.Utils;
@@ -22,7 +23,8 @@ internal static class GameInspect
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(gameInstallPath);
 
-            string gameVersionFile = Path.Combine(gameInstallPath, GameInfo.Subnautica.DataFolder, "StreamingAssets", "SNUnmanagedData", "plastic_status.ignore");
+            string dataPath = GetGameDataPath(gameInstallPath);
+            string gameVersionFile = Path.Combine(dataPath, "StreamingAssets", "SNUnmanagedData", "plastic_status.ignore");
             if (int.TryParse(await File.ReadAllTextAsync(gameVersionFile), out int gameVersion) && gameVersion < NitroxEnvironment.GameMinimumVersion)
             {
                 if (dialogService != null)
@@ -47,6 +49,16 @@ internal static class GameInspect
         }
 
         return false;
+    }
+
+    private static string GetGameDataPath(string gameInstallPath)
+    {
+        if (GameInstallationHelper.TryGetGameInstallation(gameInstallPath, GameInfo.Subnautica, out GameInstallationLayout layout))
+        {
+            return Path.GetDirectoryName(layout.ManagedPath) ?? Path.Combine(layout.RootPath, GameInfo.Subnautica.DataFolder);
+        }
+
+        return Path.Combine(gameInstallPath, GameInfo.Subnautica.DataFolder);
     }
 
     /// <summary>

--- a/Nitrox.Launcher/Models/Utils/NitroxEntryPatch.cs
+++ b/Nitrox.Launcher/Models/Utils/NitroxEntryPatch.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;
 using Nitrox.Model.Logger;
+using Nitrox.Model.Platforms.Discovery;
 using Nitrox.Model.Platforms.OS.Shared;
 
 namespace Nitrox.Launcher.Models.Utils;
@@ -31,7 +32,7 @@ public static class NitroxEntryPatch
     {
         ArgumentException.ThrowIfNullOrEmpty(subnauticaBasePath, nameof(subnauticaBasePath));
 
-        string subnauticaManagedPath = Path.Combine(subnauticaBasePath, GameInfo.Subnautica.DataFolder, "Managed");
+        string subnauticaManagedPath = GetManagedPath(subnauticaBasePath);
         string assemblyCSharp = Path.Combine(subnauticaManagedPath, GAME_ASSEMBLY_NAME);
         string nitroxPatcherPath = Path.Combine(subnauticaManagedPath, NITROX_ASSEMBLY_NAME);
         string modifiedAssemblyCSharp = Path.Combine(subnauticaManagedPath, GAME_ASSEMBLY_MODIFIED_NAME);
@@ -134,7 +135,7 @@ public static class NitroxEntryPatch
 
         Log.Debug("Removing Nitrox entry point from Subnautica");
 
-        string subnauticaManagedPath = Path.Combine(subnauticaBasePath, GameInfo.Subnautica.DataFolder, "Managed");
+        string subnauticaManagedPath = GetManagedPath(subnauticaBasePath);
         string assemblyCSharp = Path.Combine(subnauticaManagedPath, GAME_ASSEMBLY_NAME);
         string modifiedAssemblyCSharp = Path.Combine(subnauticaManagedPath, GAME_ASSEMBLY_MODIFIED_NAME);
 
@@ -200,7 +201,7 @@ public static class NitroxEntryPatch
 
     public static bool IsPatchApplied(string subnauticaBasePath)
     {
-        string subnauticaManagedPath = Path.Combine(subnauticaBasePath, GameInfo.Subnautica.DataFolder, "Managed");
+        string subnauticaManagedPath = GetManagedPath(subnauticaBasePath);
         string gameInputPath = Path.Combine(subnauticaManagedPath, GAME_ASSEMBLY_NAME);
 
         using (ModuleDefMD module = ModuleDefMD.Load(gameInputPath))
@@ -210,5 +211,15 @@ public static class NitroxEntryPatch
 
             return awakeMethod.Body.Instructions[0]?.ToString() == NITROX_EXECUTE_INSTRUCTION;
         }
+    }
+
+    private static string GetManagedPath(string subnauticaBasePath)
+    {
+        if (GameInstallationHelper.TryGetGameInstallation(subnauticaBasePath, GameInfo.Subnautica, out GameInstallationLayout layout))
+        {
+            return layout.ManagedPath;
+        }
+
+        return Path.Combine(subnauticaBasePath, GameInfo.Subnautica.DataFolder, "Managed");
     }
 }

--- a/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/LaunchGameViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -18,6 +17,7 @@ using Nitrox.Model.Constants;
 using Nitrox.Model.Core;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Logger;
+using Nitrox.Model.Platforms.Discovery;
 using Nitrox.Model.Platforms.Discovery.Models;
 using Nitrox.Model.Platforms.OS.Shared;
 using Nitrox.Model.Platforms.Store;
@@ -82,7 +82,10 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
                 return;
             }
 
-            NitroxEntryPatch.Remove(NitroxUser.GamePath);
+            if (!GameInstallationHelper.IsNativeMacOSGameLayout(NitroxUser.GamePath, GameInfo.Subnautica))
+            {
+                NitroxEntryPatch.Remove(NitroxUser.GamePath);
+            }
             await StartSubnauticaAsync();
         }
         catch (Exception ex)
@@ -101,14 +104,28 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
         Log.Info("Launching Subnautica in multiplayer mode");
         try
         {
+            if (string.IsNullOrWhiteSpace(NitroxUser.GamePath) || !Directory.Exists(NitroxUser.GamePath))
+            {
+                ChangeView(optionsViewModel);
+                LauncherNotifier.Warning("Location of Subnautica is unknown. Set the path to it in settings");
+                return;
+            }
+            if (GameInstallationHelper.IsNativeMacOSGameLayout(NitroxUser.GamePath, GameInfo.Subnautica))
+            {
+                const string message = "Native macOS Subnautica client injection is not supported yet. The launcher can detect your Steam install, but Nitrox multiplayer currently needs a Windows Subnautica install through Wine or a future native client/runtime port.";
+                Log.Warn(message);
+                LauncherNotifier.Error(message);
+                await dialogService.ShowAsync<DialogBoxViewModel>(model =>
+                {
+                    model.Title = "Native macOS multiplayer is not supported";
+                    model.Description = message;
+                    model.ButtonOptions = ButtonOptions.Ok;
+                });
+                return;
+            }
+
             bool setupResult = await Task.Run(async () =>
             {
-                if (string.IsNullOrWhiteSpace(NitroxUser.GamePath) || !Directory.Exists(NitroxUser.GamePath))
-                {
-                    ChangeView(optionsViewModel);
-                    LauncherNotifier.Warning("Location of Subnautica is unknown. Set the path to it in settings");
-                    return false;
-                }
                 if (PirateDetection.HasTriggered)
                 {
                     LauncherNotifier.Error("Aarrr! Nitrox has walked the plank :(");
@@ -137,7 +154,7 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
 
                     File.Copy(
                         patcherDllPath,
-                        Path.Combine(NitroxUser.GamePath, GameInfo.Subnautica.DataFolder, "Managed", PATCHER_DLL_NAME),
+                        Path.Combine(GetGameLayout().ManagedPath, PATCHER_DLL_NAME),
                         true
                     );
                 }
@@ -223,9 +240,7 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
     {
         LauncherNotifier.Info("Starting game");
 
-        string gameExePathSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "MacOS" : string.Empty;
-        string gameExePath = Path.Combine(NitroxUser.GamePath, gameExePathSuffix, gameInfo.ExeName);
-        if (!File.Exists(gameExePath))
+        if (!GameInstallationHelper.TryGetGameExecutablePath(NitroxUser.GamePath, gameInfo, out string gameExePath))
         {
             throw new FileNotFoundException($"Unable to find {gameInfo.ExeName}");
         }
@@ -245,6 +260,7 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
             HeroicGames => await HeroicGames.StartGameAsync(gameInfo.EgsNamespace, launchArguments),
             MSStore => await MSStore.StartGameAsync(gameExePath, launchArguments),
             Discord => await Discord.StartGameAsync(gameExePath, launchArguments),
+            Wine => await Wine.StartGameAsync(gameExePath, launchArguments),
             _ => await Standalone.StartGameAsync(gameExePath, launchArguments),
         };
 
@@ -281,5 +297,15 @@ internal partial class LaunchGameViewModel(DialogService dialogService, ServerSe
         }
 
         return false; // Default: use Steam unless explicitly disabled for special cases
+    }
+
+    private static GameInstallationLayout GetGameLayout()
+    {
+        if (GameInstallationHelper.TryGetGameInstallation(NitroxUser.GamePath, GameInfo.Subnautica, out GameInstallationLayout layout))
+        {
+            return layout;
+        }
+
+        throw new DirectoryNotFoundException("Subnautica installation path is invalid");
     }
 }

--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -17,6 +18,7 @@ using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery;
 using Nitrox.Model.Platforms.Discovery.Models;
 using Nitrox.Model.Platforms.OS.Shared;
+using Nitrox.Model.Platforms.Store;
 
 namespace Nitrox.Launcher.ViewModels;
 
@@ -83,6 +85,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
 
     private void SetTargetedSubnauticaPath(string path)
     {
+        path = GameInstallationHelper.NormalizeGamePath(path, GameInfo.Subnautica);
         if (!Directory.Exists(path))
         {
             return;
@@ -101,7 +104,8 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
 
         // Save game path as preferred for future sessions.
         NitroxUser.PreferredGamePath = path;
-        NitroxUser.SetGamePathAndPlatform(path, null);
+        bool isWineLayout = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && GameInstallationHelper.IsWindowsGameLayout(path, GameInfo.Subnautica);
+        NitroxUser.SetGamePathAndPlatform(path, isWineLayout ? GamePlatforms.GetPlatformByFlag(GameLibraries.WINE) : null, !isWineLayout);
     }
 
     [RelayCommand]
@@ -113,17 +117,29 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
             return;
         }
 
-        if (!GameInstallationHelper.HasGameExecutable(selectedDirectory, GameInfo.Subnautica))
+        if (!GameInstallationHelper.HasValidGameFolder(selectedDirectory, GameInfo.Subnautica))
         {
-            LauncherNotifier.Error("Invalid subnautica directory");
+            LauncherNotifier.Error("Invalid Subnautica directory. Select Subnautica.app, its Contents folder, or a Windows install root for Wine.");
             return;
         }
 
+        selectedDirectory = GameInstallationHelper.NormalizeGamePath(selectedDirectory, GameInfo.Subnautica);
         if (!selectedDirectory.Equals(SelectedGame.PathToGame, StringComparison.OrdinalIgnoreCase))
         {
             await Task.Run(() => SetTargetedSubnauticaPath(selectedDirectory));
             SelectedGame = new() { PathToGame = NitroxUser.GamePath, Platform = NitroxUser.GamePlatform?.Platform ?? Platform.NONE };
-            LauncherNotifier.Success("Applied changes");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && GameInstallationHelper.IsNativeMacOSGameLayout(selectedDirectory, GameInfo.Subnautica))
+            {
+                LauncherNotifier.Warning("Native macOS Subnautica was selected. Singleplayer can be launched, but multiplayer requires a Windows install through Wine.");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && GameInstallationHelper.IsWindowsGameLayout(selectedDirectory, GameInfo.Subnautica))
+            {
+                LauncherNotifier.Success("Applied Wine Subnautica path");
+            }
+            else
+            {
+                LauncherNotifier.Success("Applied changes");
+            }
         }
     }
 

--- a/Nitrox.Model/Helper/NitroxUser.cs
+++ b/Nitrox.Model/Helper/NitroxUser.cs
@@ -168,9 +168,9 @@ public static class NitroxUser
         }
     }
 
-    public static void SetGamePathAndPlatform(string path, IGamePlatform? platform)
+    public static void SetGamePathAndPlatform(string path, IGamePlatform? platform, bool inferPlatform = true)
     {
         gamePath = Path.GetFullPath(path);
-        GamePlatform = platform ?? GamePlatforms.GetPlatformByGameDir(path);
+        GamePlatform = platform ?? (inferPlatform ? GamePlatforms.GetPlatformByGameDir(path) : null);
     }
 }

--- a/Nitrox.Model/Helper/PirateDetection.cs
+++ b/Nitrox.Model/Helper/PirateDetection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Nitrox.Model.Platforms.Discovery;
 using Nitrox.Model.Platforms.OS.Shared;
 
 namespace Nitrox.Model.Helper
@@ -42,7 +43,8 @@ namespace Nitrox.Model.Helper
 
         private static bool IsPirateByDirectory(string subnauticaRoot)
         {
-            string subdirDll = Path.Combine(subnauticaRoot, GameInfo.Subnautica.DataFolder, "Plugins", "x86_64", "steam_api64.dll");
+            string dataPath = GetGameDataPath(subnauticaRoot);
+            string subdirDll = Path.Combine(dataPath, "Plugins", "x86_64", "steam_api64.dll");
             if (File.Exists(subdirDll) && !FileSystem.Instance.IsTrustedFile(subdirDll))
             {
                 return true;
@@ -55,6 +57,16 @@ namespace Nitrox.Model.Helper
             }
 
             return false;
+        }
+
+        private static string GetGameDataPath(string subnauticaRoot)
+        {
+            if (GameInstallationHelper.TryGetGameInstallation(subnauticaRoot, GameInfo.Subnautica, out GameInstallationLayout layout))
+            {
+                return Path.GetDirectoryName(layout.ManagedPath) ?? Path.Combine(layout.RootPath, GameInfo.Subnautica.DataFolder);
+            }
+
+            return Path.Combine(subnauticaRoot, GameInfo.Subnautica.DataFolder);
         }
 
         private static void OnPirateDetected()

--- a/Nitrox.Model/Platforms/Discovery/GameInstallationFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/GameInstallationFinder.cs
@@ -19,6 +19,7 @@ public static class GameInstallationFinder
     private static readonly Dictionary<GameLibraries, IGameFinder> finders = new()
     {
         { GameLibraries.STEAM, new SteamFinder() },
+        { GameLibraries.WINE, new WineFinder() },
         { GameLibraries.EPIC, new EpicGamesFinder() },
         { GameLibraries.HEROIC, new HeroicGamesFinder() },
         { GameLibraries.MICROSOFT, new MicrosoftFinder() },
@@ -45,9 +46,20 @@ public static class GameInstallationFinder
                     HeroicGames => GameLibraries.HEROIC,
                     MSStore => GameLibraries.MICROSOFT,
                     Discord => GameLibraries.DISCORD,
+                    Wine => GameLibraries.WINE,
                     _ => throw new ArgumentOutOfRangeException()
                 }
             };
+        }
+        if (!string.IsNullOrWhiteSpace(NitroxUser.GamePath) && GameInstallationHelper.HasValidGameFolder(NitroxUser.GamePath, gameInfo))
+        {
+            GameLibraries origin = GameInstallationHelper.IsWindowsGameLayout(NitroxUser.GamePath, gameInfo) ? GameLibraries.WINE : GameLibraries.CONFIG;
+            if (origin == GameLibraries.WINE)
+            {
+                NitroxUser.SetGamePathAndPlatform(NitroxUser.GamePath, GamePlatforms.GetPlatformByFlag(GameLibraries.WINE), false);
+            }
+
+            return GameFinderResult.Ok(NitroxUser.GamePath) with { Origin = origin };
         }
 
         List<GameFinderResult> finderResults = FindGame(gameInfo, gameLibraries).TakeUntilInclusive(r => r is { IsOk: false }).ToList();
@@ -55,7 +67,11 @@ public static class GameInstallationFinder
         if (potentiallyValidResult is { IsOk: true })
         {
             Log.Debug($"Game installation was found by {potentiallyValidResult.FinderName} at '{potentiallyValidResult.Path}'");
-            NitroxUser.SetGamePathAndPlatform(potentiallyValidResult.Path, GamePlatforms.GetPlatformByFlag(potentiallyValidResult.Origin) ?? GamePlatforms.GetPlatformByGameDir(potentiallyValidResult.Path));
+            NitroxUser.SetGamePathAndPlatform(
+                potentiallyValidResult.Path,
+                GamePlatforms.GetPlatformByFlag(potentiallyValidResult.Origin),
+                potentiallyValidResult.Origin != GameLibraries.WINE
+            );
             return potentiallyValidResult;
         }
 

--- a/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
+++ b/Nitrox.Model/Platforms/Discovery/GameInstallationHelper.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -7,15 +9,7 @@ public static class GameInstallationHelper
 {
     public static bool HasGameExecutable(string path, GameInfo gameInfo)
     {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return File.Exists(Path.Combine(path, "MacOS", gameInfo.ExeName));
-        }
-        return File.Exists(Path.Combine(path, gameInfo.ExeName));
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && File.Exists(layout.ExecutablePath);
     }
 
     public static bool HasValidGameFolder(string path, GameInfo gameInfo)
@@ -24,19 +18,125 @@ public static class GameInstallationHelper
         {
             return false;
         }
-        if (!Directory.Exists(path))
+        return TryGetGameInstallation(path, gameInfo, out _);
+    }
+
+    public static string NormalizeGamePath(string path, GameInfo gameInfo)
+    {
+        if (string.IsNullOrWhiteSpace(path))
         {
-            return false;
+            return "";
         }
-        if (!HasGameExecutable(path, gameInfo))
+
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) ? layout.RootPath : Path.GetFullPath(path);
+    }
+
+    public static bool TryGetGameExecutablePath(string path, GameInfo gameInfo, out string executablePath)
+    {
+        if (TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout))
         {
-            return false;
+            executablePath = layout.ExecutablePath;
+            return true;
         }
-        if (!Directory.Exists(Path.Combine(path, gameInfo.DataFolder, "Managed")))
+
+        executablePath = "";
+        return false;
+    }
+
+    public static bool IsNativeMacOSGameLayout(string path, GameInfo gameInfo)
+    {
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && layout.Kind == GameInstallationKind.NativeMacOS;
+    }
+
+    public static bool IsWindowsGameLayout(string path, GameInfo gameInfo)
+    {
+        return TryGetGameInstallation(path, gameInfo, out GameInstallationLayout layout) && layout.Kind == GameInstallationKind.Windows;
+    }
+
+    public static bool TryGetGameInstallation(string path, GameInfo gameInfo, out GameInstallationLayout layout)
+    {
+        layout = null;
+        if (string.IsNullOrWhiteSpace(path))
         {
             return false;
         }
 
-        return true;
+        string rootPath = Path.GetFullPath(path);
+        foreach (string candidatePath in GetCandidateRootPaths(rootPath, gameInfo))
+        {
+            if (TryCreateLayout(candidatePath, gameInfo, out layout))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
+
+    private static bool TryCreateLayout(string rootPath, GameInfo gameInfo, out GameInstallationLayout layout)
+    {
+        layout = null;
+        if (!Directory.Exists(rootPath))
+        {
+            return false;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            string nativeMacExecutable = Path.Combine(rootPath, "MacOS", gameInfo.ExeName);
+            string nativeMacManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
+            if (File.Exists(nativeMacExecutable) && Directory.Exists(nativeMacManagedPath))
+            {
+                layout = new(rootPath, nativeMacExecutable, nativeMacManagedPath, GameInstallationKind.NativeMacOS);
+                return true;
+            }
+        }
+
+        string hostExecutable = Path.Combine(rootPath, gameInfo.ExeName);
+        string hostManagedPath = Path.Combine(rootPath, gameInfo.DataFolder, "Managed");
+        if (File.Exists(hostExecutable) && Directory.Exists(hostManagedPath))
+        {
+            layout = new(rootPath, hostExecutable, hostManagedPath, GameInstallationKind.Host);
+            return true;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            string windowsExecutable = Path.Combine(rootPath, $"{gameInfo.Name}.exe");
+            string windowsManagedPath = Path.Combine(rootPath, $"{gameInfo.Name}_Data", "Managed");
+            if (File.Exists(windowsExecutable) && Directory.Exists(windowsManagedPath))
+            {
+                layout = new(rootPath, windowsExecutable, windowsManagedPath, GameInstallationKind.Windows);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetCandidateRootPaths(string path, GameInfo gameInfo)
+    {
+        yield return path;
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            yield break;
+        }
+
+        if (Path.GetExtension(path).Equals(".app", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return Path.Combine(path, "Contents");
+        }
+
+        yield return Path.Combine(path, $"{gameInfo.Name}.app", "Contents");
+    }
+}
+
+public sealed record GameInstallationLayout(string RootPath, string ExecutablePath, string ManagedPath, GameInstallationKind Kind);
+
+public enum GameInstallationKind
+{
+    Host,
+    NativeMacOS,
+    Windows
 }

--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/SteamFinder.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Nitrox.Model.Platforms.Discovery.InstallationFinders.Core;
@@ -38,10 +40,7 @@ public sealed class SteamFinder : IGameFinder
             }
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            path = Path.Combine(path, $"{gameInfo.Name}.app", "Contents");
-        }
+        path = GameInstallationHelper.NormalizeGamePath(path, gameInfo);
         if (!GameInstallationHelper.HasValidGameFolder(path, gameInfo))
         {
             return Error($"Path '{path}' known by Steam for '{gameInfo.FullName}' does not point to a valid game file structure");
@@ -50,7 +49,7 @@ public sealed class SteamFinder : IGameFinder
         return Ok(path);
     }
 
-    private static string GetSteamPath()
+    internal static string GetSteamPath()
     {
         // OSX: Steam dynamic data isn't near the steam exe. Because it can't (or isn't supposed to) write anything inside application bundle.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -79,20 +78,43 @@ public sealed class SteamFinder : IGameFinder
     /// <summary>
     /// Finds game install directory by iterating through all the steam game libraries configured, matching the given appid.
     /// </summary>
-    private static string? SearchAllInstallations(string libraryFolders, int appid, string gameName)
+    internal static string? SearchAllInstallations(string libraryFolders, int appid, string gameName)
     {
         if (!File.Exists(libraryFolders))
         {
             return null;
         }
 
-        StreamReader file = new(libraryFolders);
-        char[] trimChars = [' ', '\t'];
+        string steamPath = Directory.GetParent(Path.GetDirectoryName(libraryFolders) ?? "")?.FullName ?? "";
+        foreach (string libraryPath in GetLibraryPaths(libraryFolders).Append(steamPath).Where(static path => !string.IsNullOrWhiteSpace(path)).Distinct())
+        {
+            if (File.Exists(Path.Combine(libraryPath, "steamapps", $"appmanifest_{appid}.acf")))
+            {
+                return Path.Combine(libraryPath, "steamapps", "common", gameName);
+            }
+        }
 
+        return null;
+    }
+
+    internal static IEnumerable<string> GetLibraryPaths(string libraryFolders)
+    {
+        if (!File.Exists(libraryFolders))
+        {
+            yield break;
+        }
+
+        using StreamReader file = new(libraryFolders);
+        char[] trimChars = [' ', '\t'];
         while (file.ReadLine() is { } line)
         {
             line = line.Trim(trimChars);
-            Match regMatch = Regex.Match(line, "\"(.*)\"\t*\"(.*)\"");
+            Match regMatch = Regex.Match(line, "\"([^\"]+)\"\\s+\"(.*)\"");
+            if (!regMatch.Success)
+            {
+                continue;
+            }
+
             string key = regMatch.Groups[1].Value;
 
             // New format (about 2021-07-16) uses "path" key instead of steam-library-index as key. If either, it could be steam game path.
@@ -101,14 +123,7 @@ public sealed class SteamFinder : IGameFinder
                 continue;
             }
 
-            string value = regMatch.Groups[2].Value;
-
-            if (File.Exists(Path.Combine(value, "steamapps", $"appmanifest_{appid}.acf")))
-            {
-                return Path.Combine(value, "steamapps", "common", gameName);
-            }
+            yield return regMatch.Groups[2].Value.Replace(@"\\", @"\");
         }
-
-        return null;
     }
 }

--- a/Nitrox.Model/Platforms/Discovery/InstallationFinders/WineFinder.cs
+++ b/Nitrox.Model/Platforms/Discovery/InstallationFinders/WineFinder.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Nitrox.Model.Platforms.Discovery.InstallationFinders.Core;
+using static Nitrox.Model.Platforms.Discovery.InstallationFinders.Core.GameFinderResult;
+
+namespace Nitrox.Model.Platforms.Discovery.InstallationFinders;
+
+/// <summary>
+///     Finds Windows Subnautica installs inside common macOS Wine-style prefixes.
+/// </summary>
+public sealed class WineFinder : IGameFinder
+{
+    public GameFinderResult FindGame(GameInfo gameInfo)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Error("Wine prefix detection is only supported on macOS");
+        }
+
+        return FindGameInPrefixes(gameInfo, GetCandidatePrefixes());
+    }
+
+    internal static GameFinderResult FindGameInPrefixes(GameInfo gameInfo, IEnumerable<string> prefixes)
+    {
+        foreach (string prefixPath in prefixes)
+        {
+            foreach (string steamPath in GetSteamPaths(prefixPath))
+            {
+                string appsPath = Path.Combine(steamPath, "steamapps");
+                string? path = null;
+                if (File.Exists(Path.Combine(appsPath, $"appmanifest_{gameInfo.SteamAppId}.acf")))
+                {
+                    path = Path.Combine(appsPath, "common", gameInfo.Name);
+                }
+                else
+                {
+                    path = SteamFinder.SearchAllInstallations(Path.Combine(appsPath, "libraryfolders.vdf"), gameInfo.SteamAppId, gameInfo.Name);
+                }
+
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
+                path = GameInstallationHelper.NormalizeGamePath(path, gameInfo);
+                if (GameInstallationHelper.IsWindowsGameLayout(path, gameInfo))
+                {
+                    return Ok(path);
+                }
+            }
+        }
+
+        return NotFound();
+    }
+
+    internal static IEnumerable<string> GetCandidatePrefixes(string? homePath = null)
+    {
+        homePath ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(homePath))
+        {
+            homePath = Environment.GetEnvironmentVariable("HOME");
+        }
+        if (string.IsNullOrWhiteSpace(homePath) || !Directory.Exists(homePath))
+        {
+            yield break;
+        }
+
+        foreach (string path in EnumerateExistingDirectories(Path.Combine(homePath, ".wine")))
+        {
+            yield return path;
+        }
+
+        foreach (string path in EnumerateExistingDirectories(Path.Combine(homePath, ".local", "share", "wineprefixes"), "*"))
+        {
+            yield return path;
+        }
+
+        foreach (string path in EnumerateExistingDirectories(Path.Combine(homePath, "Games"), "*"))
+        {
+            if (Directory.Exists(Path.Combine(path, "drive_c")))
+            {
+                yield return path;
+            }
+        }
+
+        foreach (string path in EnumerateExistingDirectories(Path.Combine(homePath, "Library", "Application Support", "CrossOver", "Bottles"), "*"))
+        {
+            yield return path;
+        }
+    }
+
+    private static IEnumerable<string> GetSteamPaths(string prefixPath)
+    {
+        string driveC = Path.Combine(prefixPath, "drive_c");
+        if (!Directory.Exists(driveC))
+        {
+            yield break;
+        }
+
+        string[] candidatePaths =
+        [
+            Path.Combine(driveC, "Program Files (x86)", "Steam"),
+            Path.Combine(driveC, "Program Files", "Steam")
+        ];
+
+        foreach (string path in candidatePaths.Where(Directory.Exists))
+        {
+            yield return path;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateExistingDirectories(string path, string? searchPattern = null)
+    {
+        if (searchPattern == null)
+        {
+            if (Directory.Exists(path))
+            {
+                yield return path;
+            }
+            yield break;
+        }
+
+        if (!Directory.Exists(path))
+        {
+            yield break;
+        }
+
+        foreach (string directory in Directory.EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly))
+        {
+            yield return directory;
+        }
+    }
+}

--- a/Nitrox.Model/Platforms/Discovery/Models/GameLibraries.cs
+++ b/Nitrox.Model/Platforms/Discovery/Models/GameLibraries.cs
@@ -21,24 +21,29 @@ public enum GameLibraries
     STEAM = 1 << 2,
 
     /// <summary>
+    /// Windows game installation in a Wine-style prefix.
+    /// </summary>
+    WINE = 1 << 3,
+
+    /// <summary>
     /// Epic games
     /// </summary>
-    EPIC = 1 << 3,
+    EPIC = 1 << 4,
 
     /// <summary>
     /// Heroic Games Launcher
     /// </summary>
-    HEROIC = 1 << 4,
+    HEROIC = 1 << 5,
 
     /// <summary>
     /// Microsoft store
     /// </summary>
-    MICROSOFT = 1 << 5,
+    MICROSOFT = 1 << 6,
 
     /// <summary>
     /// Discord game store
     /// </summary>
-    DISCORD = 1 << 6,
+    DISCORD = 1 << 7,
 
     /// <summary>
     /// Related to an official game platform
@@ -48,7 +53,7 @@ public enum GameLibraries
     /// <summary>
     /// Related to an external provider source
     /// </summary>
-    CUSTOM = CONFIG | ENVIRONMENT,
+    CUSTOM = CONFIG | ENVIRONMENT | WINE,
 
     /// <summary>
     /// All Nitrox supported provider

--- a/Nitrox.Model/Platforms/Discovery/Models/Platform.cs
+++ b/Nitrox.Model/Platforms/Discovery/Models/Platform.cs
@@ -20,5 +20,8 @@ public enum Platform
     MICROSOFT,
 
     [Description("Discord")]
-    DISCORD
+    DISCORD,
+
+    [Description("Wine")]
+    WINE
 }

--- a/Nitrox.Model/Platforms/Store/EpicGames.cs
+++ b/Nitrox.Model/Platforms/Store/EpicGames.cs
@@ -17,6 +17,10 @@ public sealed class EpicGames : IGamePlatform
     public bool OwnsGame(string gameDirectory)
     {
         string path = Path.Combine(gameDirectory, ".egstore");
+        if (!Directory.Exists(path))
+        {
+            return false;
+        }
         
         try
         {

--- a/Nitrox.Model/Platforms/Store/GamePlatforms.cs
+++ b/Nitrox.Model/Platforms/Store/GamePlatforms.cs
@@ -9,6 +9,7 @@ public static class GamePlatforms
 {
     private static readonly Dictionary<GameLibraries, IGamePlatform> allPlatforms = new()
     {
+        { GameLibraries.WINE, new Wine() },
         { GameLibraries.STEAM, new Steam() },
         { GameLibraries.EPIC, new EpicGames() },
         { GameLibraries.HEROIC, new HeroicGames() },

--- a/Nitrox.Model/Platforms/Store/Standalone.cs
+++ b/Nitrox.Model/Platforms/Store/Standalone.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.OS.Shared;
@@ -9,6 +11,11 @@ public static class Standalone
 {
     public static Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && Path.GetExtension(pathToGameExe).Equals(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return Wine.StartGameAsync(pathToGameExe, launchArguments);
+        }
+
         return Task.FromResult(
             ProcessEx.Start(
                 pathToGameExe,

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -128,7 +128,13 @@ public sealed class Steam : IGamePlatform
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            steamExecutable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx");
+            string[] commonPaths =
+            [
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "Steam.AppBundle", "Steam", "Contents", "MacOS", "steam_osx"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx"),
+                Path.Combine(Path.DirectorySeparatorChar.ToString(), "Applications", "Steam.app", "Contents", "MacOS", "steam_osx")
+            ];
+            steamExecutable = commonPaths.FirstOrDefault(File.Exists) ?? "";
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/Nitrox.Model/Platforms/Store/Wine.cs
+++ b/Nitrox.Model/Platforms/Store/Wine.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Nitrox.Model.Helper;
+using Nitrox.Model.Platforms.Discovery;
+using Nitrox.Model.Platforms.Discovery.Models;
+using Nitrox.Model.Platforms.OS.Shared;
+using Nitrox.Model.Platforms.Store.Exceptions;
+using Nitrox.Model.Platforms.Store.Interfaces;
+
+namespace Nitrox.Model.Platforms.Store;
+
+public sealed class Wine : IGamePlatform
+{
+    private const string WineExecutableOverrideEnvKey = "NITROX_WINE_EXE";
+    private const string SteamStartupDelayMsEnvKey = "NITROX_WINE_STEAM_STARTUP_DELAY_MS";
+    private const string DisableIpv6EnvKey = "NITROX_DISABLE_IPV6";
+    private const string ClientConnectTimeoutMsEnvKey = "NITROX_CLIENT_CONNECT_TIMEOUT_MS";
+    private const string LiteNetLibManualModeEnvKey = "NITROX_LITENETLIB_MANUAL_MODE";
+    private const string LiteNetLibCrcFallbackEnvKey = "NITROX_LITENETLIB_CRC_FALLBACK";
+    private const string LiteNetLibDisableNativeSocketsEnvKey = "NITROX_DISABLE_LITENETLIB_NATIVE_SOCKETS";
+    private const int DefaultSteamStartupDelayMs = 10_000;
+    private static readonly string SteamLaunchArguments = string.Join(" ",
+    [
+        "-noverifyfiles",
+        "-nobootstrapupdate",
+        "-skipinitialbootstrap",
+        "-norepairfiles",
+        "-overridepackageurl",
+        "-vgui",
+        "-noreactlogin",
+        "-allosarches",
+        "-cef-force-32bit",
+        "-no-cef-sandbox",
+        "-cef-disable-sandbox",
+        "-cef-disable-gpu",
+        "-cef-disable-gpu-sandbox"
+    ]);
+
+    public string Name => nameof(Wine);
+    public Platform Platform => Platform.WINE;
+
+    public bool OwnsGame(string gameDirectory)
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+               GameInstallationHelper.IsWindowsGameLayout(gameDirectory, GameInfo.Subnautica);
+    }
+
+    public static async Task<ProcessEx> StartGameAsync(string pathToGameExe, string launchArguments)
+    {
+        string? wineExecutable = FindWineExecutable();
+        if (wineExecutable == null)
+        {
+            throw new GamePlatformException(GameLibraries.WINE, "Wine was not found. Install Wine and Windows Steam/Subnautica in a Wine prefix, or set NITROX_WINE_EXE to the wine executable path.");
+        }
+
+        ProcessStartInfo? steamStartInfo = CreateSteamStartInfoIfNeeded(pathToGameExe, wineExecutable);
+        if (steamStartInfo != null)
+        {
+            using Process? steamProcess = Process.Start(steamStartInfo);
+            await Task.Delay(GetSteamStartupDelayMs());
+        }
+
+        ProcessStartInfo startInfo = CreateStartInfo(pathToGameExe, launchArguments, wineExecutable, NitroxUser.LauncherPath);
+        ProcessEx? process = ProcessEx.From(startInfo);
+        if (process == null)
+        {
+            throw new GamePlatformException(GameLibraries.WINE, "Subnautica exited immediately after starting through Wine.");
+        }
+
+        return process;
+    }
+
+    internal static ProcessStartInfo? CreateSteamStartInfoIfNeeded(string pathToGameExe, string wineExecutable)
+    {
+        string? steamExecutable = FindSteamExecutableForGame(pathToGameExe);
+        if (steamExecutable == null)
+        {
+            return null;
+        }
+
+        return CreateStartInfo(steamExecutable, SteamLaunchArguments, wineExecutable, NitroxUser.LauncherPath);
+    }
+
+    internal static ProcessStartInfo CreateStartInfo(string pathToGameExe, string launchArguments, string wineExecutable, string launcherPath)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = wineExecutable,
+            WorkingDirectory = Path.GetDirectoryName(pathToGameExe) ?? Directory.GetCurrentDirectory(),
+            UseShellExecute = false,
+            CreateNoWindow = false
+        };
+
+#if NET
+        startInfo.ArgumentList.Add(pathToGameExe);
+        foreach (string argument in ParseArguments(launchArguments))
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+#else
+        startInfo.Arguments = string.Join(" ", new[] { QuoteArgument(pathToGameExe) }.Concat(ParseArguments(launchArguments).Select(QuoteArgument)));
+#endif
+
+        startInfo.EnvironmentVariables[NitroxUser.LAUNCHER_PATH_ENV_KEY] = launcherPath;
+        startInfo.EnvironmentVariables[DisableIpv6EnvKey] = Environment.GetEnvironmentVariable(DisableIpv6EnvKey) ?? "1";
+        startInfo.EnvironmentVariables[ClientConnectTimeoutMsEnvKey] = Environment.GetEnvironmentVariable(ClientConnectTimeoutMsEnvKey) ?? "10000";
+        startInfo.EnvironmentVariables[LiteNetLibManualModeEnvKey] = Environment.GetEnvironmentVariable(LiteNetLibManualModeEnvKey) ?? "0";
+        startInfo.EnvironmentVariables[LiteNetLibCrcFallbackEnvKey] = Environment.GetEnvironmentVariable(LiteNetLibCrcFallbackEnvKey) ?? "1";
+        startInfo.EnvironmentVariables[LiteNetLibDisableNativeSocketsEnvKey] = Environment.GetEnvironmentVariable(LiteNetLibDisableNativeSocketsEnvKey) ?? "1";
+
+        string? inferredPrefix = InferWinePrefix(pathToGameExe);
+        if (!string.IsNullOrWhiteSpace(inferredPrefix) && string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WINEPREFIX")))
+        {
+            startInfo.EnvironmentVariables["WINEPREFIX"] = inferredPrefix;
+        }
+
+        return startInfo;
+    }
+
+    internal static string? FindSteamExecutableForGame(string pathToGameExe)
+    {
+        string[] pathParts = pathToGameExe.Split([Path.DirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+        int steamAppsIndex = Array.FindIndex(pathParts, static part => part.Equals("steamapps", StringComparison.OrdinalIgnoreCase));
+        if (steamAppsIndex <= 0)
+        {
+            return null;
+        }
+
+        string steamPath = Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Take(steamAppsIndex));
+        string steamExecutable = Path.Combine(steamPath, "steam.exe");
+        return File.Exists(steamExecutable) ? steamExecutable : null;
+    }
+
+    internal static string? InferWinePrefix(string windowsExePath)
+    {
+        string[] pathParts = windowsExePath.Split([Path.DirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+        int driveCIndex = Array.FindIndex(pathParts, static part => part.Equals("drive_c", StringComparison.OrdinalIgnoreCase));
+        if (driveCIndex <= 0)
+        {
+            return null;
+        }
+
+        string prefix = Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Take(driveCIndex));
+        return Directory.Exists(prefix) ? prefix : null;
+    }
+
+    internal static string? FindWineExecutable()
+    {
+        string? configuredPath = Environment.GetEnvironmentVariable(WineExecutableOverrideEnvKey);
+        if (!string.IsNullOrWhiteSpace(configuredPath) && File.Exists(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        return FindExecutableOnPath("wine64") ??
+               FindExecutableOnPath("wine") ??
+               FindExecutableInCommonMacOSLocations();
+    }
+
+    private static string? FindExecutableInCommonMacOSLocations()
+    {
+        string homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string[] candidatePaths =
+        [
+            "/opt/homebrew/bin/wine",
+            "/opt/homebrew/bin/wine64",
+            "/usr/local/bin/wine",
+            "/usr/local/bin/wine64",
+            Path.Combine(homePath, "Applications", "Wine Stable.app", "Contents", "Resources", "wine", "bin", "wine"),
+            Path.Combine(homePath, "Applications", "Wine Stable.app", "Contents", "Resources", "wine", "bin", "wine64"),
+            "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wine",
+            "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wine64"
+        ];
+
+        return candidatePaths.FirstOrDefault(File.Exists);
+    }
+
+    private static string? FindExecutableOnPath(string executableName)
+    {
+        string? pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(pathValue))
+        {
+            return null;
+        }
+
+        foreach (string path in pathValue.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            string executablePath = Path.Combine(path, executableName);
+            if (File.Exists(executablePath))
+            {
+                return executablePath;
+            }
+        }
+
+        return null;
+    }
+
+    internal static string[] ParseArguments(string arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return [];
+        }
+
+        List<string> parsedArguments = [];
+        StringBuilder currentArgument = new();
+        bool insideQuotes = false;
+
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            char character = arguments[i];
+            if (character == '\\' && i + 1 < arguments.Length && arguments[i + 1] == '"')
+            {
+                currentArgument.Append('"');
+                i++;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                insideQuotes = !insideQuotes;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(character) && !insideQuotes)
+            {
+                AddArgumentIfPresent();
+                continue;
+            }
+
+            currentArgument.Append(character);
+        }
+
+        AddArgumentIfPresent();
+        return [.. parsedArguments];
+
+        void AddArgumentIfPresent()
+        {
+            if (currentArgument.Length == 0)
+            {
+                return;
+            }
+
+            parsedArguments.Add(currentArgument.ToString());
+            currentArgument.Clear();
+        }
+    }
+
+    private static int GetSteamStartupDelayMs()
+    {
+        string? configuredDelay = Environment.GetEnvironmentVariable(SteamStartupDelayMsEnvKey);
+        if (int.TryParse(configuredDelay, out int delay) && delay >= 0)
+        {
+            return delay;
+        }
+
+        return DefaultSteamStartupDelayMs;
+    }
+
+    private static string QuoteArgument(string argument)
+    {
+        if (string.IsNullOrEmpty(argument))
+        {
+            return "\"\"";
+        }
+
+        if (!argument.Any(char.IsWhiteSpace) && !argument.Contains('"'))
+        {
+            return argument;
+        }
+
+        return $"\"{argument.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+    }
+}

--- a/Nitrox.Model/Platforms/Store/Wine.cs
+++ b/Nitrox.Model/Platforms/Store/Wine.cs
@@ -129,12 +129,15 @@ public sealed class Wine : IGamePlatform
         int steamAppsIndex = Array.FindIndex(pathParts, static part => part.Equals("steamapps", StringComparison.OrdinalIgnoreCase));
         if (steamAppsIndex <= 0)
         {
-            return null;
+            return FindSteamExecutableInPrefix(Environment.GetEnvironmentVariable("WINEPREFIX")) ??
+                   FindSteamExecutableInAncestorPrefix(pathToGameExe);
         }
 
         string steamPath = Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Take(steamAppsIndex));
         string steamExecutable = Path.Combine(steamPath, "steam.exe");
-        return File.Exists(steamExecutable) ? steamExecutable : null;
+        return File.Exists(steamExecutable) ? steamExecutable :
+            FindSteamExecutableInPrefix(Environment.GetEnvironmentVariable("WINEPREFIX")) ??
+            FindSteamExecutableInAncestorPrefix(pathToGameExe);
     }
 
     internal static string? InferWinePrefix(string windowsExePath)
@@ -143,11 +146,46 @@ public sealed class Wine : IGamePlatform
         int driveCIndex = Array.FindIndex(pathParts, static part => part.Equals("drive_c", StringComparison.OrdinalIgnoreCase));
         if (driveCIndex <= 0)
         {
-            return null;
+            return FindAncestorPrefix(windowsExePath);
         }
 
         string prefix = Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Take(driveCIndex));
         return Directory.Exists(prefix) ? prefix : null;
+    }
+
+    private static string? FindSteamExecutableInAncestorPrefix(string pathToGameExe)
+    {
+        return FindSteamExecutableInPrefix(FindAncestorPrefix(pathToGameExe));
+    }
+
+    private static string? FindAncestorPrefix(string pathToGameExe)
+    {
+        DirectoryInfo? directory = new(Path.GetDirectoryName(pathToGameExe) ?? pathToGameExe);
+        while (directory != null)
+        {
+            if (FindSteamExecutableInPrefix(directory.FullName) != null)
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static string? FindSteamExecutableInPrefix(string? prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return null;
+        }
+
+        string[] steamCandidates =
+        [
+            Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam", "steam.exe"),
+            Path.Combine(prefix, "drive_c", "Program Files", "Steam", "steam.exe")
+        ];
+        return steamCandidates.FirstOrDefault(File.Exists);
     }
 
     internal static string? FindWineExecutable()

--- a/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
+++ b/Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs
@@ -1,0 +1,159 @@
+using Nitrox.Model;
+using Nitrox.Model.Platforms.Discovery;
+using Nitrox.Model.Platforms.Discovery.InstallationFinders;
+using Nitrox.Test.Model.Platforms;
+
+namespace Nitrox.Test.Model.Platforms.Discovery;
+
+[TestClass]
+public class GameInstallationHelperTest
+{
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void NormalizeGamePath_ShouldAcceptMacOSAppBundle()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string steamGameRoot = Path.Combine(tempDir, "steamapps", "common", "Subnautica");
+            string appContents = Path.Combine(steamGameRoot, "Subnautica.app", "Contents");
+            CreateNativeMacSubnautica(appContents);
+
+            string normalizedFromRoot = GameInstallationHelper.NormalizeGamePath(steamGameRoot, GameInfo.Subnautica);
+            string normalizedFromBundle = GameInstallationHelper.NormalizeGamePath(Path.Combine(steamGameRoot, "Subnautica.app"), GameInfo.Subnautica);
+
+            normalizedFromRoot.Should().Be(appContents);
+            normalizedFromBundle.Should().Be(appContents);
+            GameInstallationHelper.HasValidGameFolder(normalizedFromBundle, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.IsNativeMacOSGameLayout(normalizedFromBundle, GameInfo.Subnautica).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void NormalizeGamePath_ShouldAcceptWindowsWineLayoutOnMacOS()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string gameRoot = Path.Combine(tempDir, "drive_c", "Program Files (x86)", "Steam", "steamapps", "common", "Subnautica");
+            CreateWindowsSubnautica(gameRoot);
+
+            string normalized = GameInstallationHelper.NormalizeGamePath(gameRoot, GameInfo.Subnautica);
+
+            normalized.Should().Be(gameRoot);
+            GameInstallationHelper.HasValidGameFolder(normalized, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.IsWindowsGameLayout(normalized, GameInfo.Subnautica).Should().BeTrue();
+            GameInstallationHelper.TryGetGameExecutablePath(normalized, GameInfo.Subnautica, out string executablePath).Should().BeTrue();
+            executablePath.Should().EndWith(Path.Combine("Subnautica", "Subnautica.exe"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void SteamFinder_ShouldParseModernLibraryFoldersVdf()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string libraryRoot = Path.Combine(tempDir, "SteamLibrary");
+            Directory.CreateDirectory(Path.Combine(libraryRoot, "steamapps"));
+            File.WriteAllText(Path.Combine(libraryRoot, "steamapps", $"appmanifest_{GameInfo.Subnautica.SteamAppId}.acf"), "");
+
+            string steamApps = Path.Combine(tempDir, "Steam", "steamapps");
+            Directory.CreateDirectory(steamApps);
+            string libraryFolders = Path.Combine(steamApps, "libraryfolders.vdf");
+            File.WriteAllText(libraryFolders, $$"""
+                                                "libraryfolders"
+                                                {
+                                                    "0"
+                                                    {
+                                                        "path" "{{libraryRoot}}"
+                                                        "apps"
+                                                        {
+                                                            "{{GameInfo.Subnautica.SteamAppId}}" "1"
+                                                        }
+                                                    }
+                                                }
+                                                """);
+
+            string? path = SteamFinder.SearchAllInstallations(libraryFolders, GameInfo.Subnautica.SteamAppId, GameInfo.Subnautica.Name);
+
+            path.Should().Be(Path.Combine(libraryRoot, "steamapps", "common", GameInfo.Subnautica.Name));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void WineFinder_ShouldIncludeCommonMacOSPrefixes()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string crossoverBottle = Path.Combine(tempDir, "Library", "Application Support", "CrossOver", "Bottles", "Steam");
+            string winePrefix = Path.Combine(tempDir, ".wine");
+            Directory.CreateDirectory(Path.Combine(crossoverBottle, "drive_c"));
+            Directory.CreateDirectory(Path.Combine(winePrefix, "drive_c"));
+
+            List<string> prefixes = WineFinder.GetCandidatePrefixes(tempDir).ToList();
+            prefixes.Should().Contain(crossoverBottle);
+            prefixes.Should().Contain(winePrefix);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void WineFinder_ShouldFindSteamSubnauticaInsideWinePrefix()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string prefix = Path.Combine(tempDir, ".wine");
+            string steamApps = Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam", "steamapps");
+            string gameRoot = Path.Combine(steamApps, "common", "Subnautica");
+            Directory.CreateDirectory(steamApps);
+            File.WriteAllText(Path.Combine(steamApps, $"appmanifest_{GameInfo.Subnautica.SteamAppId}.acf"), "");
+            CreateWindowsSubnautica(gameRoot);
+
+            Nitrox.Model.Platforms.Discovery.InstallationFinders.Core.GameFinderResult result = WineFinder.FindGameInPrefixes(GameInfo.Subnautica, [prefix]);
+
+            result.IsOk.Should().BeTrue();
+            result.Path.Should().Be(gameRoot);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"NitroxTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void CreateNativeMacSubnautica(string contentsPath)
+    {
+        Directory.CreateDirectory(Path.Combine(contentsPath, "MacOS"));
+        Directory.CreateDirectory(Path.Combine(contentsPath, "Resources", "Data", "Managed"));
+        File.WriteAllText(Path.Combine(contentsPath, "MacOS", "Subnautica"), "");
+    }
+
+    private static void CreateWindowsSubnautica(string gameRoot)
+    {
+        Directory.CreateDirectory(Path.Combine(gameRoot, "Subnautica_Data", "Managed"));
+        File.WriteAllText(Path.Combine(gameRoot, "Subnautica.exe"), "");
+    }
+}

--- a/Nitrox.Test/Model/Platforms/Store/WineTest.cs
+++ b/Nitrox.Test/Model/Platforms/Store/WineTest.cs
@@ -1,0 +1,149 @@
+using Nitrox.Model;
+using Nitrox.Model.Helper;
+using Nitrox.Model.Platforms.Store;
+using Nitrox.Test.Model.Platforms;
+
+namespace Nitrox.Test.Model.Platforms.Store;
+
+[TestClass]
+public class WineTest
+{
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void InferWinePrefix_ShouldReturnPrefixContainingDriveC()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string prefix = Path.Combine(tempDir, "Games", "SubnauticaPrefix");
+            string exePath = Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam", "steamapps", "common", "Subnautica", "Subnautica.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(exePath)!);
+            File.WriteAllText(exePath, "");
+
+            Wine.InferWinePrefix(exePath).Should().Be(prefix);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void FindSteamExecutableForGame_ShouldReturnSteamExeFromSteamLibrary()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string steamRoot = Path.Combine(tempDir, "drive_c", "Program Files (x86)", "Steam");
+            string gameRoot = Path.Combine(steamRoot, "steamapps", "common", "Subnautica");
+            string steamExePath = Path.Combine(steamRoot, "steam.exe");
+            string gameExePath = Path.Combine(gameRoot, "Subnautica.exe");
+            Directory.CreateDirectory(gameRoot);
+            File.WriteAllText(steamExePath, "");
+            File.WriteAllText(gameExePath, "");
+
+            Wine.FindSteamExecutableForGame(gameExePath).Should().Be(steamExePath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateSteamStartInfoIfNeeded_ShouldBuildSteamLaunchCommand()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string steamRoot = Path.Combine(tempDir, "drive_c", "Program Files (x86)", "Steam");
+            string gameRoot = Path.Combine(steamRoot, "steamapps", "common", "Subnautica");
+            string steamExePath = Path.Combine(steamRoot, "steam.exe");
+            string gameExePath = Path.Combine(gameRoot, "Subnautica.exe");
+            string winePath = Path.Combine(tempDir, "bin", "wine64");
+            Directory.CreateDirectory(gameRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(winePath)!);
+            File.WriteAllText(steamExePath, "");
+            File.WriteAllText(gameExePath, "");
+            File.WriteAllText(winePath, "");
+
+            System.Diagnostics.ProcessStartInfo? startInfo = Wine.CreateSteamStartInfoIfNeeded(gameExePath, winePath);
+
+            startInfo.Should().NotBeNull();
+            startInfo!.FileName.Should().Be(winePath);
+            startInfo.WorkingDirectory.Should().Be(steamRoot);
+            startInfo.ArgumentList.First().Should().Be(steamExePath);
+            startInfo.ArgumentList.Should().Contain("-nobootstrapupdate");
+            startInfo.ArgumentList.Should().Contain("-cef-disable-gpu");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void CreateStartInfo_ShouldBuildWineLaunchCommand()
+    {
+        string tempDir = CreateTempDir();
+        string? originalDisableIpv6 = Environment.GetEnvironmentVariable("NITROX_DISABLE_IPV6");
+        string? originalConnectTimeout = Environment.GetEnvironmentVariable("NITROX_CLIENT_CONNECT_TIMEOUT_MS");
+        string? originalManualMode = Environment.GetEnvironmentVariable("NITROX_LITENETLIB_MANUAL_MODE");
+        string? originalCrcFallback = Environment.GetEnvironmentVariable("NITROX_LITENETLIB_CRC_FALLBACK");
+        string? originalDisableNativeSockets = Environment.GetEnvironmentVariable("NITROX_DISABLE_LITENETLIB_NATIVE_SOCKETS");
+        try
+        {
+            Environment.SetEnvironmentVariable("NITROX_DISABLE_IPV6", null);
+            Environment.SetEnvironmentVariable("NITROX_CLIENT_CONNECT_TIMEOUT_MS", null);
+            Environment.SetEnvironmentVariable("NITROX_LITENETLIB_MANUAL_MODE", null);
+            Environment.SetEnvironmentVariable("NITROX_LITENETLIB_CRC_FALLBACK", null);
+            Environment.SetEnvironmentVariable("NITROX_DISABLE_LITENETLIB_NATIVE_SOCKETS", null);
+
+            string prefix = Path.Combine(tempDir, ".wine");
+            string gameRoot = Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam", "steamapps", "common", "Subnautica");
+            string exePath = Path.Combine(gameRoot, "Subnautica.exe");
+            string winePath = Path.Combine(tempDir, "bin", "wine64");
+            string launcherPath = Path.Combine(tempDir, "Nitrox Launcher.app", "Contents", "MacOS", "Nitrox.Launcher");
+            Directory.CreateDirectory(gameRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(winePath)!);
+            File.WriteAllText(exePath, "");
+            File.WriteAllText(winePath, "");
+
+            System.Diagnostics.ProcessStartInfo startInfo = Wine.CreateStartInfo(exePath, "-vrmode none --nitrox \"launcher with spaces\"", winePath, launcherPath);
+
+            startInfo.FileName.Should().Be(winePath);
+            startInfo.WorkingDirectory.Should().Be(gameRoot);
+            startInfo.ArgumentList.Should().Equal(exePath, "-vrmode", "none", "--nitrox", "launcher with spaces");
+            startInfo.EnvironmentVariables[NitroxUser.LAUNCHER_PATH_ENV_KEY].Should().Be(launcherPath);
+            startInfo.EnvironmentVariables["WINEPREFIX"].Should().Be(prefix);
+            startInfo.EnvironmentVariables["NITROX_DISABLE_IPV6"].Should().Be("1");
+            startInfo.EnvironmentVariables["NITROX_CLIENT_CONNECT_TIMEOUT_MS"].Should().Be("10000");
+            startInfo.EnvironmentVariables["NITROX_LITENETLIB_MANUAL_MODE"].Should().Be("0");
+            startInfo.EnvironmentVariables["NITROX_LITENETLIB_CRC_FALLBACK"].Should().Be("1");
+            startInfo.EnvironmentVariables["NITROX_DISABLE_LITENETLIB_NATIVE_SOCKETS"].Should().Be("1");
+            startInfo.UseShellExecute.Should().BeFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NITROX_DISABLE_IPV6", originalDisableIpv6);
+            Environment.SetEnvironmentVariable("NITROX_CLIENT_CONNECT_TIMEOUT_MS", originalConnectTimeout);
+            Environment.SetEnvironmentVariable("NITROX_LITENETLIB_MANUAL_MODE", originalManualMode);
+            Environment.SetEnvironmentVariable("NITROX_LITENETLIB_CRC_FALLBACK", originalCrcFallback);
+            Environment.SetEnvironmentVariable("NITROX_DISABLE_LITENETLIB_NATIVE_SOCKETS", originalDisableNativeSockets);
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void SplitArguments_ShouldPreserveQuotedValues()
+    {
+        Wine.ParseArguments("-vrmode none --nitrox \"path with spaces\" --flag").Should()
+            .Equal("-vrmode", "none", "--nitrox", "path with spaces", "--flag");
+    }
+
+    private static string CreateTempDir()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"NitroxWineTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+}

--- a/Nitrox.Test/Model/Platforms/Store/WineTest.cs
+++ b/Nitrox.Test/Model/Platforms/Store/WineTest.cs
@@ -28,6 +28,28 @@ public class WineTest
     }
 
     [TestMethod]
+    public void InferWinePrefix_ShouldReturnAncestorPrefixContainingSteam()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string prefix = Path.Combine(tempDir, "Games", "NitroxGPTK");
+            string steamExePath = Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam", "steam.exe");
+            string gameExePath = Path.Combine(prefix, "steamapps-backup", "common", "Subnautica", "Subnautica.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(steamExePath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(gameExePath)!);
+            File.WriteAllText(steamExePath, "");
+            File.WriteAllText(gameExePath, "");
+
+            Wine.InferWinePrefix(gameExePath).Should().Be(prefix);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
     public void FindSteamExecutableForGame_ShouldReturnSteamExeFromSteamLibrary()
     {
         string tempDir = CreateTempDir();
@@ -37,6 +59,30 @@ public class WineTest
             string gameRoot = Path.Combine(steamRoot, "steamapps", "common", "Subnautica");
             string steamExePath = Path.Combine(steamRoot, "steam.exe");
             string gameExePath = Path.Combine(gameRoot, "Subnautica.exe");
+            Directory.CreateDirectory(gameRoot);
+            File.WriteAllText(steamExePath, "");
+            File.WriteAllText(gameExePath, "");
+
+            Wine.FindSteamExecutableForGame(gameExePath).Should().Be(steamExePath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [TestMethod]
+    public void FindSteamExecutableForGame_ShouldReturnSteamExeFromAncestorPrefix()
+    {
+        string tempDir = CreateTempDir();
+        try
+        {
+            string prefix = Path.Combine(tempDir, "NitroxGPTK");
+            string steamRoot = Path.Combine(prefix, "drive_c", "Program Files (x86)", "Steam");
+            string gameRoot = Path.Combine(prefix, "steamapps-backup", "common", "Subnautica");
+            string steamExePath = Path.Combine(steamRoot, "steam.exe");
+            string gameExePath = Path.Combine(gameRoot, "Subnautica.exe");
+            Directory.CreateDirectory(steamRoot);
             Directory.CreateDirectory(gameRoot);
             File.WriteAllText(steamExePath, "");
             File.WriteAllText(gameExePath, "");

--- a/docs/macos-launcher.md
+++ b/docs/macos-launcher.md
@@ -1,0 +1,115 @@
+# macOS launcher support
+
+This document tracks the current macOS state of the Nitrox launcher. It is not a claim of full native macOS Nitrox client support.
+
+## Prerequisites
+
+- macOS 12 or newer.
+- .NET 10 SDK.
+- Git.
+- Steam for native macOS Subnautica detection.
+- Optional for multiplayer on macOS: Wine or a Wine-compatible wrapper when using a Windows Subnautica install. The launcher looks for `wine64` or `wine` on `PATH`, common Homebrew Wine paths, and Wine Stable app locations; `NITROX_WINE_EXE=/path/to/wine` can be used to override that.
+
+## Build and run
+
+From the repository root:
+
+```bash
+dotnet restore Nitrox.Launcher/Nitrox.Launcher.csproj
+dotnet build Nitrox.Launcher/Nitrox.Launcher.csproj -c Debug
+dotnet run --project Nitrox.Launcher/Nitrox.Launcher.csproj
+```
+
+The same commands are available through `scripts/macos-launcher.sh`:
+
+```bash
+scripts/macos-launcher.sh restore
+scripts/macos-launcher.sh build
+scripts/macos-launcher.sh run
+```
+
+To create a basic macOS app bundle zip:
+
+```bash
+dotnet build Nitrox.Launcher/Nitrox.Launcher.csproj -c Release -r osx-arm64 -p:CreateAppBundle=true
+scripts/macos-launcher.sh bundle
+```
+
+Use `-r osx-x64` for Intel Macs. The bundle output is under `Nitrox.Launcher/bin/Release/net10.0/<rid>/Nitrox.app.zip`.
+
+If the only available Subnautica install is the Windows build inside a Wine prefix, point the build at that install so the Unity reference assemblies can be resolved:
+
+```bash
+export SUBNAUTICA_INSTALLATION_PATH="$HOME/Games/NitroxWine/drive_c/Program Files (x86)/Steam/steamapps/common/Subnautica"
+dotnet build Nitrox.Launcher/Nitrox.Launcher.csproj -c Release -r osx-arm64 -p:CreateAppBundle=true
+```
+
+## Current behavior
+
+- Launcher config/data uses the existing macOS `NitroxDirectory` mapping:
+  - config, saves, logs, backups: `~/Library/Application Support/Nitrox`
+  - cache: `~/Library/Caches/Nitrox`
+- Native Steam detection checks the standard Steam data directory at `~/Library/Application Support/Steam`.
+- Steam `libraryfolders.vdf` is parsed for additional library folders.
+- Native macOS Steam installs can be resolved from the Steam common folder, `Subnautica.app`, or `Subnautica.app/Contents`.
+- Manual path selection accepts:
+  - `Subnautica.app`
+  - `Subnautica.app/Contents`
+  - the Steam common `Subnautica` folder that contains `Subnautica.app`
+  - a Windows install root containing `Subnautica.exe` and `Subnautica_Data/Managed`
+- Windows Subnautica installs inside common macOS Wine-style prefixes are searched when possible and are saved as the Wine platform:
+  - `~/.wine`
+  - `~/.local/share/wineprefixes/*`
+  - `~/Games/*` entries with `drive_c`
+  - `~/Library/Application Support/CrossOver/Bottles/*`
+- Wine launches use `wine64` or `wine` from `PATH` or common macOS install locations, infer `WINEPREFIX` from paths containing `drive_c`, and pass `NITROX_LAUNCHER_PATH` into the Wine process.
+- If a native macOS `Subnautica.app` is selected, the launcher keeps multiplayer blocked with a clear message. Use a Windows Steam/Subnautica install inside Wine for multiplayer testing.
+- Current Windows Steam builds may need to be started with `-no-cef-sandbox` under Wine before installing Subnautica, for example:
+  ```bash
+  WINEPREFIX="$HOME/Games/NitroxWine" wine "$HOME/Games/NitroxWine/drive_c/Program Files (x86)/Steam/steam.exe" -no-cef-sandbox steam://install/264710
+  ```
+
+## What does not work yet
+
+### Launcher blockers
+
+- The launcher still needs real-device UI verification on macOS with an installed .NET 10 SDK.
+- The Wine path support does not manage Wine installation, bottle creation, or wrapper-specific launchers.
+- Native Steam launch has not been verified end to end on macOS hardware in this change.
+
+### Native macOS client/runtime blockers
+
+- Native macOS multiplayer client injection is explicitly blocked in the launcher with a clear error.
+- NitroxPatcher is still a `net472` patcher artifact and the runtime/injection path has not been ported or verified for native macOS Subnautica.
+- No native macOS game-client compatibility claim should be made until the client injection/runtime is designed, built, and tested against the macOS game.
+
+### Wine-wrapper blockers
+
+- Wine launch requires a working `wine64` or `wine` executable on `PATH`, or `NITROX_WINE_EXE` pointing at a Wine executable.
+- Apple Silicon Wine graphics support may need extra configuration. Plain Wine can fail D3D11 feature-level creation, while DXVK through MoltenVK can fail if the Vulkan stack does not expose required features such as `geometryShader`.
+- Steam overlay and Steam client integration inside Wine are not handled by the launcher yet.
+- CrossOver-style paths are detected as prefixes, but CrossOver itself is not invoked or required by this project.
+- The Windows Steam/Subnautica install inside Wine must already be legitimate and functional before Nitrox can patch and launch it.
+
+## Tests
+
+Focused path, detection, and Wine launch-command tests live in:
+
+- `Nitrox.Test/Model/Platforms/Discovery/GameInstallationHelperTest.cs`
+- `Nitrox.Test/Model/Platforms/Store/WineTest.cs`
+
+Run the relevant tests with:
+
+```bash
+export SUBNAUTICA_INSTALLATION_PATH="$HOME/Games/NitroxWine/drive_c/Program Files (x86)/Steam/steamapps/common/Subnautica"
+dotnet test Nitrox.Test/Nitrox.Test.csproj --filter "GameInstallationHelperTest|WineTest"
+```
+
+## Suggested next tasks
+
+1. Verify the launcher UI on a macOS machine with .NET 10 SDK installed and enough disk space for restore/build.
+2. Test native Steam detection with an actual `Subnautica.app` install.
+3. Install Wine on macOS and test launch against a clean Wine prefix containing Steam and Windows Subnautica.
+4. Verify patching and local server join from the Wine-launched Windows game.
+5. Decide whether the launcher should automate Wine prefix creation or keep setup manual.
+6. Split native macOS client/runtime investigation into a separate project or issue; keep it outside launcher support work.

--- a/scripts/macos-launcher.sh
+++ b/scripts/macos-launcher.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT_DIR/Nitrox.Launcher/Nitrox.Launcher.csproj"
+TEST_PROJECT="$ROOT_DIR/Nitrox.Test/Nitrox.Test.csproj"
+RID="${NITROX_MACOS_RID:-osx-arm64}"
+
+command="${1:-build}"
+
+case "$command" in
+  restore)
+    dotnet restore "$PROJECT"
+    ;;
+  build)
+    dotnet build "$PROJECT" -c Debug
+    ;;
+  run)
+    dotnet run --project "$PROJECT"
+    ;;
+  test)
+    dotnet test "$TEST_PROJECT" --filter "GameInstallationHelperTest|WineTest"
+    ;;
+  bundle)
+    dotnet build "$PROJECT" -c Release -r "$RID" -p:CreateAppBundle=true
+    ;;
+  *)
+    echo "Usage: $0 [restore|build|run|test|bundle]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Purpose
Isolate the Wine fallback from the closed macOS launcher PR (#2782) into one dedicated draft PR so it can be accepted, declined, or redesigned independently from native macOS support.

Maintainer note from #2782 said native macOS support is preferred; this PR is intentionally separate from the smaller native macOS cleanup PRs.

## What changed
- Adds a Wine platform and icon fallback.
- Detects Windows Subnautica layouts inside macOS Wine/CrossOver-style prefixes.
- Normalizes native macOS and Windows game layouts through `GameInstallationHelper`.
- Starts Windows Subnautica through Wine with inferred `WINEPREFIX`, Steam startup support, launcher-path propagation, and Wine-specific environment defaults.
- Updates launcher path selection and launch dispatch for Wine installs.
- Adds focused tests for layout detection, prefix discovery, and Wine launch command construction.

## Validation
- `git diff --cached --check` before commit
- `dotnet test Nitrox.Test/Nitrox.Test.csproj --filter "GameInstallationHelperTest|WineTest"` could not be run here because `dotnet` is not installed.

## Scope
This does not claim native macOS multiplayer support. Wine gameplay still depends on the local Wine/D3D/Vulkan translation stack.