### PR TITLE
[Server] Back off repeated NTP sync failures

### DIFF
--- a/Nitrox.Model/Networking/NtpSyncer.cs
+++ b/Nitrox.Model/Networking/NtpSyncer.cs
@@ -38,6 +38,10 @@ public sealed class NtpSyncer
         {
             logger = optionalLogger;
         }
+
+        IsComplete = false;
+        OnlineMode = false;
+        CorrectionOffset = TimeSpan.Zero;
         DisposeCallback = finishCallback;
 
         ntp = new(TreatPacket);

--- a/Nitrox.Server.Subnautica/Models/GameLogic/NtpRetryCircuitBreaker.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/NtpRetryCircuitBreaker.cs
@@ -1,0 +1,48 @@
+namespace Nitrox.Server.Subnautica.Models.GameLogic;
+
+internal sealed class NtpRetryCircuitBreaker
+{
+    private readonly TimeSpan closedRetryDelay;
+    private readonly TimeSpan openRetryDelay;
+    private readonly int failureThreshold;
+
+    private int consecutiveFailures;
+
+    public NtpRetryCircuitBreaker(TimeSpan closedRetryDelay, TimeSpan openRetryDelay, int failureThreshold)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(closedRetryDelay, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(openRetryDelay, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(failureThreshold, 1);
+
+        this.closedRetryDelay = closedRetryDelay;
+        this.openRetryDelay = openRetryDelay;
+        this.failureThreshold = failureThreshold;
+    }
+
+    public bool IsOpen { get; private set; }
+
+    public RetryDecision RegisterFailure()
+    {
+        if (IsOpen)
+        {
+            return new(openRetryDelay, breakerOpened: false);
+        }
+
+        consecutiveFailures++;
+        if (consecutiveFailures < failureThreshold)
+        {
+            return new(closedRetryDelay, breakerOpened: false);
+        }
+
+        IsOpen = true;
+        return new(openRetryDelay, breakerOpened: true);
+    }
+
+    public void RegisterSuccess()
+    {
+        consecutiveFailures = 0;
+        IsOpen = false;
+    }
+}
+
+internal readonly record struct RetryDecision(TimeSpan Delay, bool BreakerOpened);

--- a/Nitrox.Server.Subnautica/Models/GameLogic/NtpRetryCircuitBreaker.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/NtpRetryCircuitBreaker.cs
@@ -25,17 +25,17 @@ internal sealed class NtpRetryCircuitBreaker
     {
         if (IsOpen)
         {
-            return new(openRetryDelay, breakerOpened: false);
+            return new(openRetryDelay, BreakerOpened: false);
         }
 
         consecutiveFailures++;
         if (consecutiveFailures < failureThreshold)
         {
-            return new(closedRetryDelay, breakerOpened: false);
+            return new(closedRetryDelay, BreakerOpened: false);
         }
 
         IsOpen = true;
-        return new(openRetryDelay, breakerOpened: true);
+        return new(openRetryDelay, BreakerOpened: true);
     }
 
     public void RegisterSuccess()

--- a/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
@@ -30,17 +30,25 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
     ///     Time in seconds between each ntp connection attempt.
     /// </summary>
     private const int NTP_RETRY_INTERVAL_SECONDS = 60;
+    private const int NTP_RETRY_BREAKER_INTERVAL_MINUTES = 10;
+    private const int NTP_RETRY_BREAKER_FAILURE_THRESHOLD = 3;
 
     private readonly ILogger<TimeService> logger = logger;
     private readonly ILoggerFactory loggerFactory = loggerFactory;
+    private readonly NtpRetryCircuitBreaker ntpRetryCircuitBreaker = new(
+        TimeSpan.FromSeconds(NTP_RETRY_INTERVAL_SECONDS),
+        TimeSpan.FromMinutes(NTP_RETRY_BREAKER_INTERVAL_MINUTES),
+        NTP_RETRY_BREAKER_FAILURE_THRESHOLD);
 
     private readonly NtpSyncer ntpSyncer = ntpSyncer;
     private readonly IPacketSender packetSender = packetSender;
 
     private readonly PeriodicTimer resyncTimer = new(TimeSpan.FromSeconds(RESYNC_INTERVAL_SECONDS));
     private readonly Stopwatch stopWatch = new();
+    private readonly Lock ntpRetryTimerLock = new();
 
     private double activeRealTimeSeconds;
+    private Timer? ntpRetryTimer;
 
     public TimeSkippedEventHandler? TimeSkipped;
 
@@ -140,14 +148,7 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         // We only need the correction offset to be calculated once
-        ntpSyncer.Setup((onlineMode, _) =>
-        {
-            if (!onlineMode)
-            {
-                // until we get online even once, we'll retry the ntp sync sequence every NTP_RETRY_INTERVAL
-                StartNtpTimer();
-            }
-        }, loggerFactory.CreateLogger<NtpSyncer>());
+        ntpSyncer.Setup(OnNtpSyncCompleted, loggerFactory.CreateLogger<NtpSyncer>());
         ntpSyncer.RequestNtpService();
 
         while (!stoppingToken.IsCancellationRequested)
@@ -177,25 +178,53 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
         return Task.CompletedTask;
     }
 
-    private void StartNtpTimer()
+    private void OnNtpSyncCompleted(bool onlineMode, TimeSpan _)
     {
-        Timer retryTimer = new(TimeSpan.FromSeconds(NTP_RETRY_INTERVAL_SECONDS).TotalMilliseconds)
+        if (onlineMode)
         {
-            AutoReset = true,
+            ntpRetryCircuitBreaker.RegisterSuccess();
+            CloseNtpRetryTimer();
+            return;
+        }
+
+        RetryDecision retryDecision = ntpRetryCircuitBreaker.RegisterFailure();
+        if (retryDecision.BreakerOpened)
+        {
+            logger.ZLogWarning($"NTP sync failed {NTP_RETRY_BREAKER_FAILURE_THRESHOLD} times in a row; delaying the next retry for {retryDecision.Delay.TotalMinutes:0} minutes.");
+        }
+
+        StartNtpTimer(retryDecision.Delay);
+    }
+
+    private void StartNtpTimer(TimeSpan retryDelay)
+    {
+        CloseNtpRetryTimer();
+
+        Timer retryTimer = new(retryDelay.TotalMilliseconds)
+        {
+            AutoReset = false,
         };
         retryTimer.Elapsed += delegate
         {
-            // Reset the syncer before starting another round of it
             ntpSyncer.Complete();
-            ntpSyncer.Setup((onlineMode, _) =>
-            {
-                if (onlineMode)
-                {
-                    retryTimer.Close();
-                }
-            }, loggerFactory.CreateLogger<NtpSyncer>());
+            ntpSyncer.Setup(OnNtpSyncCompleted, loggerFactory.CreateLogger<NtpSyncer>());
             ntpSyncer.RequestNtpService();
         };
+
+        lock (ntpRetryTimerLock)
+        {
+            ntpRetryTimer = retryTimer;
+        }
+
         retryTimer.Start();
+    }
+
+    private void CloseNtpRetryTimer()
+    {
+        lock (ntpRetryTimerLock)
+        {
+            ntpRetryTimer?.Close();
+            ntpRetryTimer = null;
+        }
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/TimeService.cs
@@ -52,6 +52,12 @@ internal sealed class TimeService(IPacketSender packetSender, NtpSyncer ntpSynce
 
     public TimeSkippedEventHandler? TimeSkipped;
 
+    public override void Dispose()
+    {
+        CloseNtpRetryTimer();
+        base.Dispose();
+    }
+
     /// <summary>
     ///     Gets the total game time the server was actively simulating the game. See
     ///     <see cref="HibernateService.IsSleeping" /> for more information.

--- a/Nitrox.Test/Server/GameLogic/NtpRetryCircuitBreakerTests.cs
+++ b/Nitrox.Test/Server/GameLogic/NtpRetryCircuitBreakerTests.cs
@@ -1,0 +1,67 @@
+using Nitrox.Server.Subnautica.Models.GameLogic;
+
+namespace Nitrox.Test.Server.GameLogic;
+
+[TestClass]
+public class NtpRetryCircuitBreakerTests
+{
+    private static readonly TimeSpan SHORT_DELAY = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan LONG_DELAY = TimeSpan.FromMinutes(10);
+
+    [TestMethod]
+    public void RegisterFailure_UsesShortDelayUntilThreshold()
+    {
+        NtpRetryCircuitBreaker breaker = new(SHORT_DELAY, LONG_DELAY, failureThreshold: 3);
+
+        RetryDecision firstDecision = breaker.RegisterFailure();
+        RetryDecision secondDecision = breaker.RegisterFailure();
+
+        firstDecision.Delay.Should().Be(SHORT_DELAY);
+        secondDecision.Delay.Should().Be(SHORT_DELAY);
+        firstDecision.BreakerOpened.Should().BeFalse();
+        secondDecision.BreakerOpened.Should().BeFalse();
+        breaker.IsOpen.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void RegisterFailure_OpensBreakerAtThreshold()
+    {
+        NtpRetryCircuitBreaker breaker = new(SHORT_DELAY, LONG_DELAY, failureThreshold: 3);
+
+        breaker.RegisterFailure();
+        breaker.RegisterFailure();
+        RetryDecision decision = breaker.RegisterFailure();
+
+        decision.Delay.Should().Be(LONG_DELAY);
+        decision.BreakerOpened.Should().BeTrue();
+        breaker.IsOpen.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void RegisterFailure_KeepsUsingLongDelayWhileOpen()
+    {
+        NtpRetryCircuitBreaker breaker = new(SHORT_DELAY, LONG_DELAY, failureThreshold: 1);
+
+        breaker.RegisterFailure();
+        RetryDecision decision = breaker.RegisterFailure();
+
+        decision.Delay.Should().Be(LONG_DELAY);
+        decision.BreakerOpened.Should().BeFalse();
+        breaker.IsOpen.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void RegisterSuccess_ClosesBreakerAndResetsFailureCount()
+    {
+        NtpRetryCircuitBreaker breaker = new(SHORT_DELAY, LONG_DELAY, failureThreshold: 2);
+
+        breaker.RegisterFailure();
+        breaker.RegisterFailure();
+        breaker.RegisterSuccess();
+        RetryDecision decision = breaker.RegisterFailure();
+
+        breaker.IsOpen.Should().BeFalse();
+        decision.Delay.Should().Be(SHORT_DELAY);
+        decision.BreakerOpened.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Add a small retry circuit breaker for server-side NTP sync retries.
- Switch NTP retries to one-shot scheduling so offline servers stop retrying every minute forever.
- Reset `NtpSyncer` state between retry rounds and close the retry timer when `TimeService` is disposed.
- Cover the breaker policy with focused tests.

Fixes #2698

## Validation
- `git diff --check`
- GitHub PR checks are running after the latest rebase/push.
- Not run locally: .NET tests, because `dotnet` is not installed in this local environment.
