### PR TITLE
Fix a few user-facing typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        # This no place to seek help with installation or connection problems. For that visit our [Discord](https://discord.com/invite/E8B4X9s).
+        # This is not the place to seek help with installation or connection problems. For that visit our [Discord](https://discord.com/invite/E8B4X9s).
         ## Thanks for filling out a bug report. Please be sure that a similar issue wasn't already created by searching [here](https://github.com/SubnauticaNitrox/Nitrox/issues?q=is%3Aissue) with general keywords. If it's a new issue please fill out as much detail as possible.
         
   - type: dropdown

--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -29,7 +29,7 @@
     "Nitrox_EnterName": "Enter your player name",
     "Nitrox_ErrorDesyncDetected": "[Safe Building] This base is currently desynced so you can't modify it unless you resync buildings (in Nitrox settings)",
     "Nitrox_ErrorRecentBuildUpdate": "Cannot modify a base that was recently updated by another player",
-    "Nitrox_Failure": "An error occurred",
+    "Nitrox_Failure": "An error occured",
     "Nitrox_FinishedResyncRequest": "Took {TIME}ms to resync {COUNT} entities",
     "Nitrox_FirewallInterfering": "Seems like your firewall settings are interfering",
     "Nitrox_HideIp": "Hide IP addresses",

--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -29,7 +29,7 @@
     "Nitrox_EnterName": "Enter your player name",
     "Nitrox_ErrorDesyncDetected": "[Safe Building] This base is currently desynced so you can't modify it unless you resync buildings (in Nitrox settings)",
     "Nitrox_ErrorRecentBuildUpdate": "Cannot modify a base that was recently updated by another player",
-    "Nitrox_Failure": "An error occured",
+    "Nitrox_Failure": "An error occurred",
     "Nitrox_FinishedResyncRequest": "Took {TIME}ms to resync {COUNT} entities",
     "Nitrox_FirewallInterfering": "Seems like your firewall settings are interfering",
     "Nitrox_HideIp": "Hide IP addresses",

--- a/NitroxClient/MonoBehaviours/Discord/DiscordClient.cs
+++ b/NitroxClient/MonoBehaviours/Discord/DiscordClient.cs
@@ -62,7 +62,7 @@ public class DiscordClient : MonoBehaviour
         {
             // Happens when Discord is closed while Nitrox has its Discord hook running (and for other reason)
             DisposeAndScheduleHookRestart();
-            Log.ErrorOnce($"An error occured while running callbacks for Discord, will retry every {RETRY_INTERVAL} seconds: {ex.Message}");
+            Log.ErrorOnce($"An error occurred while running callbacks for Discord, will retry every {RETRY_INTERVAL} seconds: {ex.Message}");
         }
     }
 

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_HandleInput_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_HandleInput_Patch.cs
@@ -54,7 +54,7 @@ public sealed partial class uGUI_SceneIntro_HandleInput_Patch : NitroxPatch, IDy
             return false;
         }
 
-        Log.Error($"Undefined behaviour occured inside {nameof(uGUI_SceneIntro_HandleInput_Patch)}");
+        Log.Error($"Undefined behaviour occurred inside {nameof(uGUI_SceneIntro_HandleInput_Patch)}");
         return false;
     }
 


### PR DESCRIPTION
## Linked Issues / Context

Small text cleanup found during maintenance.

## Description of Change

- Fixes "occured" to "occurred" in an English launcher string and two log messages.
- Fixes a missing word in the bug report issue template intro.

## Validation

- `git diff --check`
- `python3 -m json.tool Nitrox.Assets.Subnautica/LanguageFiles/en.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/bug_report.yaml")'`\n\n`dotnet test` was not run locally because `dotnet` is not installed in this environment.\n\n## PR Checklist\n\n- [x] PR rebased on top of `master` at the time of opening\n- [x] Has tests for the changes (if applicable)\n- [ ] Has a linked issue\n- [ ] Has been tested in-game (if applicable)\n- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)\n\n🤖 This code was created with the help of AI.