### PR TITLE
Fix base leak sync after server restart and repair

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/LeakRepairedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/LeakRepairedProcessor.cs
@@ -3,15 +3,20 @@ using Nitrox.Server.Subnautica.Models.Packets.Core;
 
 namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
 
-sealed class LeakRepairedProcessor(WorldEntityManager worldEntityManager) : IAuthPacketProcessor<LeakRepaired>
+sealed class LeakRepairedProcessor(WorldEntityManager worldEntityManager, ILogger<LeakRepairedProcessor> logger) : IAuthPacketProcessor<LeakRepaired>
 {
     private readonly WorldEntityManager worldEntityManager = worldEntityManager;
+    private readonly ILogger<LeakRepairedProcessor> logger = logger;
 
     public async Task Process(AuthProcessorContext context, LeakRepaired packet)
     {
         if (worldEntityManager.TryDestroyEntity(packet.LeakId, out _))
         {
             await context.SendToOthersAsync(packet);
+        }
+        else
+        {
+            logger.ZLogWarning($"Leak entity {packet.LeakId} not found in registry (base: {packet.BaseId}, cell: {packet.RelativeCell}). The repair will not be forwarded to other players.");
         }
     }
 }

--- a/NitroxClient/MonoBehaviours/BaseLeakManager.cs
+++ b/NitroxClient/MonoBehaviours/BaseLeakManager.cs
@@ -35,14 +35,20 @@ public class BaseLeakManager : MonoBehaviour
     /// </summary>
     public void EnsureLeak(Int3 relativeCell, NitroxId cellId, float health)
     {
+        // Always register the id first so that RemoveLeakByAbsoluteCell can produce a
+        // LeakRepaired packet even when the cell object is temporarily unavailable (e.g.
+        // during initial sync before base geometry is fully built). Without this, every
+        // tick of BroadcastChange would generate a brand-new NitroxId, leaving orphan
+        // BaseLeakEntity entries on the server that are never cleaned up.
+        idByRelativeCell[relativeCell] = cellId;
+
         Int3 absoluteCell = Absolute(relativeCell);
         Transform cellObject = @base.GetCellObject(absoluteCell);
         if (!cellObject)
         {
+            Log.Warn($"[{nameof(BaseLeakManager)}] Cell object not found for absolute cell {absoluteCell} (relative: {relativeCell}). Leak {cellId} is tracked but its health cannot be applied yet.");
             return;
         }
-
-        idByRelativeCell[relativeCell] = cellId;
 
         if (cellObject.TryGetComponent(out LiveMixin cellLiveMixin))
         {
@@ -86,11 +92,13 @@ public class BaseLeakManager : MonoBehaviour
 
     public void HealLeakToMax(Int3 relativeCell)
     {
+        // The server already confirmed the repair, so unconditionally drop the tracking
+        // entry regardless of whether the cell object is currently reachable.
+        idByRelativeCell.Remove(relativeCell);
         Transform cellObject = @base.GetCellObject(Absolute(relativeCell));
         if (cellObject && cellObject.TryGetComponent(out LiveMixin liveMixin))
         {
             this.Resolve<LiveMixinManager>().SyncRemoteHealth(liveMixin, liveMixin.maxHealth);
-            idByRelativeCell.Remove(relativeCell);
         }
     }
 


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2769

## Description of Change

### Root-Cause Analysis: Leak-ID Lifecycle

The underlying issue was in `BaseLeakManager.EnsureLeak`. Previously, the leak ID was stored only after the `GetCellObject` check. During initial sync, `GetCellObject` can return null if the base geometry is not fully initialized yet, for example when `BaseLeakEntitySpawner.SpawnSync` runs before the base cells are built.

That caused a cascading failure:

- `GetCellObject` returned null
- `idByRelativeCell` stayed empty
- the next tick generated a new `NitroxId`
- the server registered a new orphan leak entity
- this repeated every tick
- `RemoveLeakByAbsoluteCell()` could not resolve the leak ID
- no `LeakRepaired` packet was sent
- `TryDestroyEntity()` was never reached
- the leak remained stuck and could reappear after reconnect

### What changed

`BaseLeakManager.EnsureLeak` now stores `idByRelativeCell[relativeCell] = cellId` before the `GetCellObject` lookup. This keeps the leak ID lifecycle consistent even when the cell object is temporarily unavailable, preventing repeated orphan entities from being created on the server.

A warning is now logged when the cell object is missing, so this failure path is visible instead of silent.

`BaseLeakManager.HealLeakToMax` now removes the tracking entry before the `GetCellObject` lookup. Since the server has already confirmed the repair, the tracking state is cleaned up unconditionally.

`LeakRepairedProcessor` now injects `ILogger<LeakRepairedProcessor>` and logs a warning when `TryDestroyEntity()` fails, which makes the previously silent failure path visible.

### Remaining follow-up

If `GetCellObject` fails during initial sync, the visual leak state may only be applied on the next `EnsureLeak` call. This only happens when the base cells are not ready at spawn time and no further `BroadcastChange` tick follows.

`BaseLeakEntitySpawner` still does not prevent already repaired leaks from being spawned again. That is a separate, lower-priority follow-up issue.

The flood/water level state is still not fully synchronized for reconnecting players, so one player may see a different flood progression after rejoining.