### PR TITLE
Fix console input corruption under non-native terminal front-ends (e.g. PufferPanel)

### DIFF
--- a/Nitrox.Server.Subnautica/Services/ConsoleInputService.cs
+++ b/Nitrox.Server.Subnautica/Services/ConsoleInputService.cs
@@ -44,6 +44,10 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
     private async Task HandleInputAsync(CancellationToken cancellationToken)
     {
         StringBuilder inputLineBuilder = new();
+        // Tracks the caret position ourselves instead of reading it back from Console.CursorLeft: on Unix, that getter
+        // round-trips an ANSI cursor-position query through the same stdin stream that key presses are read from, which
+        // some non-native terminal front-ends (e.g. PufferPanel's console) don't relay correctly, corrupting input.
+        int caretIndex = 0;
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -88,51 +92,58 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
             {
                 switch (keyInfo.Key)
                 {
-                    case ConsoleKey.LeftArrow when Console.CursorLeft > 0:
-                        Console.CursorLeft--;
+                    case ConsoleKey.LeftArrow when caretIndex > 0:
+                        caretIndex--;
+                        Console.CursorLeft = caretIndex;
                         continue;
-                    case ConsoleKey.RightArrow when Console.CursorLeft < inputLineBuilder.Length:
-                        Console.CursorLeft++;
+                    case ConsoleKey.RightArrow when caretIndex < inputLineBuilder.Length:
+                        caretIndex++;
+                        Console.CursorLeft = caretIndex;
                         continue;
                     case ConsoleKey.Backspace:
-                        if (inputLineBuilder.Length > Console.CursorLeft - 1 && Console.CursorLeft > 0)
+                        if (inputLineBuilder.Length > caretIndex - 1 && caretIndex > 0)
                         {
-                            inputLineBuilder.Remove(Console.CursorLeft - 1, 1);
-                            Console.CursorLeft--;
+                            inputLineBuilder.Remove(caretIndex - 1, 1);
+                            caretIndex--;
+                            Console.CursorLeft = caretIndex;
                             Console.Write(' ');
-                            Console.CursorLeft--;
+                            Console.CursorLeft = caretIndex;
                             RedrawInput();
                         }
                         continue;
                     case ConsoleKey.Delete:
-                        if (inputLineBuilder.Length > 0 && Console.CursorLeft < inputLineBuilder.Length)
+                        if (inputLineBuilder.Length > 0 && caretIndex < inputLineBuilder.Length)
                         {
-                            inputLineBuilder.Remove(Console.CursorLeft, 1);
-                            RedrawInput(Console.CursorLeft, inputLineBuilder.Length - Console.CursorLeft);
+                            inputLineBuilder.Remove(caretIndex, 1);
+                            RedrawInput(caretIndex, inputLineBuilder.Length - caretIndex);
                         }
                         continue;
                     case ConsoleKey.Home:
-                        Console.CursorLeft = 0;
+                        caretIndex = 0;
+                        Console.CursorLeft = caretIndex;
                         continue;
                     case ConsoleKey.End:
-                        Console.CursorLeft = inputLineBuilder.Length;
+                        caretIndex = inputLineBuilder.Length;
+                        Console.CursorLeft = caretIndex;
                         continue;
                     case ConsoleKey.Escape:
                         ClearInputLine();
                         continue;
                     case ConsoleKey.Tab:
-                        if (Console.CursorLeft + 4 < GetConsoleWidth())
+                        if (caretIndex + 4 < GetConsoleWidth())
                         {
-                            inputLineBuilder.Insert(Console.CursorLeft, "    ");
-                            RedrawInput(Console.CursorLeft, -1);
-                            Console.CursorLeft += 4;
+                            inputLineBuilder.Insert(caretIndex, "    ");
+                            RedrawInput(caretIndex, -1);
+                            caretIndex += 4;
+                            Console.CursorLeft = caretIndex;
                         }
                         continue;
                     case ConsoleKey.UpArrow when inputHistory.Count > 0 && currentHistoryIndex > -inputHistory.Count:
                         inputLineBuilder.Clear();
                         inputLineBuilder.Append(inputHistory[--currentHistoryIndex]);
                         RedrawInput();
-                        Console.CursorLeft = Math.Min(inputLineBuilder.Length, GetConsoleWidth());
+                        caretIndex = Math.Min(inputLineBuilder.Length, GetConsoleWidth());
+                        Console.CursorLeft = caretIndex;
                         continue;
                     case ConsoleKey.DownArrow when inputHistory.Count > 0 && currentHistoryIndex < 0:
                         if (currentHistoryIndex == -1)
@@ -143,7 +154,8 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
                         inputLineBuilder.Clear();
                         inputLineBuilder.Append(inputHistory[++currentHistoryIndex]);
                         RedrawInput();
-                        Console.CursorLeft = Math.Min(inputLineBuilder.Length, GetConsoleWidth());
+                        caretIndex = Math.Min(inputLineBuilder.Length, GetConsoleWidth());
+                        Console.CursorLeft = caretIndex;
                         continue;
                 }
             }
@@ -162,6 +174,7 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
                 }
                 currentHistoryIndex = 0;
                 inputLineBuilder.Clear();
+                caretIndex = 0;
                 Console.WriteLine();
                 SubmitInput(submit);
                 continue;
@@ -171,17 +184,18 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
             if (keyInfo.KeyChar != 0)
             {
                 Console.Write(keyInfo.KeyChar);
-                if (Console.CursorLeft - 1 < inputLineBuilder.Length)
+                caretIndex++;
+                if (caretIndex - 1 < inputLineBuilder.Length)
                 {
                     try
                     {
-                        inputLineBuilder.Insert(Console.CursorLeft - 1, keyInfo.KeyChar);
+                        inputLineBuilder.Insert(caretIndex - 1, keyInfo.KeyChar);
                     }
                     catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
                     {
                         // ignored
                     }
-                    RedrawInput(Console.CursorLeft, -1);
+                    RedrawInput(caretIndex, -1);
                 }
                 else
                 {
@@ -196,12 +210,13 @@ internal sealed class ConsoleInputService(CommandService commandService, IPacket
         {
             currentHistoryIndex = 0;
             inputLineBuilder.Clear();
+            caretIndex = 0;
             Console.Write($"\r{new string(' ', GetConsoleWidth(-1))}\r");
         }
 
         void RedrawInput(int start = 0, int end = 0)
         {
-            int lastPosition = Console.CursorLeft;
+            int lastPosition = caretIndex;
             // Expand range to end if end value is -1
             if (start > -1 && end == -1)
             {


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2616

## Description of Change

When running the Nitrox server through PufferPanel (which relays console input/output through its own web-based terminal wrapper instead of a real interactive PTY), typing any console command produced garbled, repeating, partially-reversed output (e.g. typing `help` echoed back mangled fragments), and even `quit` stopped working, requiring the process to be killed. The same server worked fine when connected to over SSH.

**Root cause:** `ConsoleInputService` implements its own line editor (arrow keys, backspace, history, tab) and repeatedly reads the `Console.CursorLeft` **getter** to track where the caret currently is. On Unix, .NET implements that getter by writing an ANSI "Device Status Report" escape sequence (`\x1b[6n`) to stdout and then reading the terminal's position response back from the *same* stdin stream that `Console.ReadKey()` uses to read key presses.

- Over a real terminal (SSH), that query/response round-trip resolves instantly and correctly.
- Under PufferPanel's console wrapper (not a genuine PTY), that escape response either isn't relayed back correctly or gets interleaved with real key presses in the same input buffer. `Console.ReadKey()` then misreads those stray escape/response bytes as literal typed characters, which is exactly what produced the corrupted, growing, reversed-looking output reported in the issue — and eventually desynced the input state badly enough that `quit` no longer registered.

**Fix:** `ConsoleInputService` now tracks the caret position itself in a local variable instead of reading it back from the terminal. `Console.CursorLeft` is only ever *written* to (to move the visible cursor for redraws), never read — a write-only operation that doesn't require any response from the terminal. This removes the stdin round-trip entirely, so the behavior no longer depends on whether the underlying terminal front-end correctly relays ANSI cursor-position queries.

## Validation

I verified the refactor line-by-line against the original implementation to confirm identical logic/semantics (every prior read of `Console.CursorLeft` is replaced by an equivalent read of the new locally-tracked caret index, with the index updated at every point where the terminal cursor would previously have moved). I was not able to build/run the project in the environment this change was written in.

**This should still be tested on a real PufferPanel setup (or similar non-PTY console wrapper) before merging**, to confirm the fix resolves the reported behavior in practice — normal SSH/interactive console usage should also be re-checked (arrow keys, backspace, tab, history) to make sure nothing regressed there.

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [ ] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

🤖 This code was created with the help of AI.