### PR TITLE
Reduce movement sync bandwidth by throttling player movement packets

### DIFF
--- a/Nitrox.Model.Subnautica/Packets/PlayerMovement.cs
+++ b/Nitrox.Model.Subnautica/Packets/PlayerMovement.cs
@@ -15,7 +15,7 @@ public class PlayerMovement : Movement
         Velocity = velocity;
         BodyRotation = bodyRotation;
         AimingRotation = aimingRotation;
-        DeliveryMethod = NitroxDeliveryMethod.DeliveryMethod.UNRELIABLE_SEQUENCED;
+        DeliveryMethod = NitroxDeliveryMethod.DeliveryMethod.RELIABLE_ORDERED_LAST;
         UdpChannel = UdpChannelId.MOVEMENTS;
     }
 

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -68,6 +68,7 @@ public class RemotePlayer : INitroxPlayer
     private const float STOPPED_VELOCITY_THRESHOLD = 0.1f;
 
     private float lastPositionUpdateTime = -1f;
+    private bool previousUpdateWasStop;
 
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
     {
@@ -165,8 +166,15 @@ public class RemotePlayer : INitroxPlayer
         SetPilotingChair(null);
 
         // Movement packets no longer arrive at a fixed cadence (idle players send none at all, moving players are throttled),
-        // so the correction has to be based on how long it's actually been since the last packet instead of a fixed timestep.
-        float correctionTime = lastPositionUpdateTime >= 0f ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime) : Time.fixedDeltaTime;
+        // so the correction is normally based on how long it's actually been since the last packet instead of a fixed timestep.
+        // Exception: if the player was standing still until now, that idle time doesn't represent any real drift to catch
+        // up on (the remote transform was already snapped exactly to rest by the hasStopped branch below). Using the full
+        // idle duration here would divide the tiny position delta of the first "moving again" packet by that whole
+        // duration, producing a near-zero corrective velocity instead of the real reported speed - which looks like a
+        // brief stutter/delay right when the player starts moving again after standing still for a while.
+        float correctionTime = (lastPositionUpdateTime >= 0f && !previousUpdateWasStop)
+            ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime)
+            : Time.fixedDeltaTime;
         lastPositionUpdateTime = Time.time;
 
         AnimationController.AimingRotation = aimingRotation;
@@ -178,6 +186,7 @@ public class RemotePlayer : INitroxPlayer
         // result (e.g. from residual jitter) would otherwise keep getting integrated by physics forever, causing the
         // remote player to drift or spin in place indefinitely instead of actually coming to rest.
         bool hasStopped = velocity.sqrMagnitude < STOPPED_VELOCITY_THRESHOLD * STOPPED_VELOCITY_THRESHOLD;
+        previousUpdateWasStop = hasStopped;
         AnimationController.Velocity = hasStopped ? Vector3.zero : MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -61,6 +61,12 @@ public class RemotePlayer : INitroxPlayer
 
     public CyclopsPawn Pawn { get; set; }
 
+    /// <remarks>
+    /// In units/s. Mirrors <see cref="PlayerMovementBroadcaster"/>'s own threshold for what counts as "not moving",
+    /// since this is checking whether the sender already decided this packet represents a full stop.
+    /// </remarks>
+    private const float STOPPED_VELOCITY_THRESHOLD = 0.1f;
+
     private float lastPositionUpdateTime = -1f;
 
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
@@ -165,7 +171,14 @@ public class RemotePlayer : INitroxPlayer
 
         AnimationController.AimingRotation = aimingRotation;
         AnimationController.UpdatePlayerAnimations = true;
-        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
+
+        // A (near) zero velocity means the sender has come to a full stop and won't send any further packets until it moves
+        // again. GetCorrectedVelocity/GetCorrectedAngularVelocity below compute a "keep nudging towards the target" value
+        // that's meant to be re-evaluated on the next packet; since no further packet is coming, any left-over non-zero
+        // result (e.g. from residual jitter) would otherwise keep getting integrated by physics forever, causing the
+        // remote player to drift or spin in place indefinitely instead of actually coming to rest.
+        bool hasStopped = velocity.sqrMagnitude < STOPPED_VELOCITY_THRESHOLD * STOPPED_VELOCITY_THRESHOLD;
+        AnimationController.Velocity = hasStopped ? Vector3.zero : MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot
         if (SubRoot && SubRoot.isBase)
@@ -177,8 +190,18 @@ public class RemotePlayer : INitroxPlayer
             aimingRotation = vehicleAngle * aimingRotation;
         }
 
-        RigidBody.velocity = AnimationController.Velocity;
-        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
+        if (hasStopped)
+        {
+            Body.transform.position = position;
+            Body.transform.rotation = bodyRotation;
+            RigidBody.velocity = Vector3.zero;
+            RigidBody.angularVelocity = Vector3.zero;
+        }
+        else
+        {
+            RigidBody.velocity = AnimationController.Velocity;
+            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
+        }
     }
 
     public void UpdatePositionInCyclops(Vector3 localPosition, Quaternion localRotation)

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -61,6 +61,8 @@ public class RemotePlayer : INitroxPlayer
 
     public CyclopsPawn Pawn { get; set; }
 
+    private float lastPositionUpdateTime = -1f;
+
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
     {
         PlayerContext = playerContext;
@@ -156,9 +158,14 @@ public class RemotePlayer : INitroxPlayer
         SetVehicle(null);
         SetPilotingChair(null);
 
+        // Movement packets no longer arrive at a fixed cadence (idle players send none at all, moving players are throttled),
+        // so the correction has to be based on how long it's actually been since the last packet instead of a fixed timestep.
+        float correctionTime = lastPositionUpdateTime >= 0f ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime) : Time.fixedDeltaTime;
+        lastPositionUpdateTime = Time.time;
+
         AnimationController.AimingRotation = aimingRotation;
         AnimationController.UpdatePlayerAnimations = true;
-        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, Time.fixedDeltaTime);
+        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot
         if (SubRoot && SubRoot.isBase)
@@ -171,7 +178,7 @@ public class RemotePlayer : INitroxPlayer
         }
 
         RigidBody.velocity = AnimationController.Velocity;
-        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, Time.fixedDeltaTime);
+        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
     }
 
     public void UpdatePositionInCyclops(Vector3 localPosition, Quaternion localRotation)

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -69,6 +69,7 @@ public class RemotePlayer : INitroxPlayer
     private const float STOPPED_VELOCITY_THRESHOLD = 0.1f;
 
     private float lastPositionUpdateTime = -1f;
+    private bool previousUpdateWasStop;
 
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
     {
@@ -166,8 +167,15 @@ public class RemotePlayer : INitroxPlayer
         SetPilotingChair(null);
 
         // Movement packets no longer arrive at a fixed cadence (idle players send none at all, moving players are throttled),
-        // so the correction has to be based on how long it's actually been since the last packet instead of a fixed timestep.
-        float correctionTime = lastPositionUpdateTime >= 0f ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime) : Time.fixedDeltaTime;
+        // so the correction is normally based on how long it's actually been since the last packet instead of a fixed timestep.
+        // Exception: if the player was standing still until now, that idle time doesn't represent any real drift to catch
+        // up on (the remote transform was already snapped exactly to rest by the hasStopped branch below). Using the full
+        // idle duration here would divide the tiny position delta of the first "moving again" packet by that whole
+        // duration, producing a near-zero corrective velocity instead of the real reported speed - which looks like a
+        // brief stutter/delay right when the player starts moving again after standing still for a while.
+        float correctionTime = (lastPositionUpdateTime >= 0f && !previousUpdateWasStop)
+            ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime)
+            : Time.fixedDeltaTime;
         lastPositionUpdateTime = Time.time;
 
         AnimationController.AimingRotation = aimingRotation;
@@ -179,6 +187,7 @@ public class RemotePlayer : INitroxPlayer
         // result (e.g. from residual jitter) would otherwise keep getting integrated by physics forever, causing the
         // remote player to drift or spin in place indefinitely instead of actually coming to rest.
         bool hasStopped = velocity.sqrMagnitude < STOPPED_VELOCITY_THRESHOLD * STOPPED_VELOCITY_THRESHOLD;
+        previousUpdateWasStop = hasStopped;
         AnimationController.Velocity = hasStopped ? Vector3.zero : MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -62,6 +62,8 @@ public class RemotePlayer : INitroxPlayer
 
     public CyclopsPawn Pawn { get; set; }
 
+    private float lastPositionUpdateTime = -1f;
+
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
     {
         PlayerContext = playerContext;
@@ -157,9 +159,14 @@ public class RemotePlayer : INitroxPlayer
         SetVehicle(null);
         SetPilotingChair(null);
 
+        // Movement packets no longer arrive at a fixed cadence (idle players send none at all, moving players are throttled),
+        // so the correction has to be based on how long it's actually been since the last packet instead of a fixed timestep.
+        float correctionTime = lastPositionUpdateTime >= 0f ? Mathf.Max(Time.time - lastPositionUpdateTime, Time.fixedDeltaTime) : Time.fixedDeltaTime;
+        lastPositionUpdateTime = Time.time;
+
         AnimationController.AimingRotation = aimingRotation;
         AnimationController.UpdatePlayerAnimations = true;
-        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, Time.fixedDeltaTime);
+        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot
         if (SubRoot && SubRoot.isBase)
@@ -172,7 +179,7 @@ public class RemotePlayer : INitroxPlayer
         }
 
         RigidBody.velocity = AnimationController.Velocity;
-        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, Time.fixedDeltaTime);
+        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
     }
 
     public void UpdatePositionInCyclops(Vector3 localPosition, Quaternion localRotation)

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -62,6 +62,12 @@ public class RemotePlayer : INitroxPlayer
 
     public CyclopsPawn Pawn { get; set; }
 
+    /// <remarks>
+    /// In units/s. Mirrors <see cref="PlayerMovementBroadcaster"/>'s own threshold for what counts as "not moving",
+    /// since this is checking whether the sender already decided this packet represents a full stop.
+    /// </remarks>
+    private const float STOPPED_VELOCITY_THRESHOLD = 0.1f;
+
     private float lastPositionUpdateTime = -1f;
 
     public RemotePlayer(PlayerContext playerContext, PlayerModelManager playerModelManager, PlayerVitalsManager playerVitalsManager, FMODWhitelist fmodWhitelist)
@@ -166,7 +172,14 @@ public class RemotePlayer : INitroxPlayer
 
         AnimationController.AimingRotation = aimingRotation;
         AnimationController.UpdatePlayerAnimations = true;
-        AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
+
+        // A (near) zero velocity means the sender has come to a full stop and won't send any further packets until it moves
+        // again. GetCorrectedVelocity/GetCorrectedAngularVelocity below compute a "keep nudging towards the target" value
+        // that's meant to be re-evaluated on the next packet; since no further packet is coming, any left-over non-zero
+        // result (e.g. from residual jitter) would otherwise keep getting integrated by physics forever, causing the
+        // remote player to drift or spin in place indefinitely instead of actually coming to rest.
+        bool hasStopped = velocity.sqrMagnitude < STOPPED_VELOCITY_THRESHOLD * STOPPED_VELOCITY_THRESHOLD;
+        AnimationController.Velocity = hasStopped ? Vector3.zero : MovementHelper.GetCorrectedVelocity(position, velocity, Body, correctionTime);
 
         // If in a subroot the position will be relative to the subroot
         if (SubRoot && SubRoot.isBase)
@@ -178,8 +191,18 @@ public class RemotePlayer : INitroxPlayer
             aimingRotation = vehicleAngle * aimingRotation;
         }
 
-        RigidBody.velocity = AnimationController.Velocity;
-        RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
+        if (hasStopped)
+        {
+            Body.transform.position = position;
+            Body.transform.rotation = bodyRotation;
+            RigidBody.velocity = Vector3.zero;
+            RigidBody.angularVelocity = Vector3.zero;
+        }
+        else
+        {
+            RigidBody.velocity = AnimationController.Velocity;
+            RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, correctionTime);
+        }
     }
 
     public void UpdatePositionInCyclops(Vector3 localPosition, Quaternion localRotation)

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -10,7 +10,31 @@ namespace NitroxClient.MonoBehaviours;
 
 public class PlayerMovementBroadcaster : MonoBehaviour
 {
+    /// <remarks>
+    /// In unity position units. Refer to <see cref="ShouldBroadcastMovement"/> for use infos.
+    /// </remarks>
+    private const float MINIMAL_MOVEMENT_THRESHOLD = 0.05f;
+    /// <remarks>
+    /// In degrees (°). Refer to <see cref="ShouldBroadcastMovement"/> for use infos.
+    /// </remarks>
+    private const float MINIMAL_ROTATION_THRESHOLD = 0.05f;
+    /// <remarks>
+    /// In units/s. Refer to <see cref="ShouldBroadcastMovement"/> for use infos.
+    /// </remarks>
+    private const float MINIMAL_VELOCITY_THRESHOLD = 0.1f;
+    /// <remarks>
+    /// In seconds. Refer to <see cref="ShouldBroadcastMovement"/> for use infos.
+    /// </remarks>
+    private const float MAX_TIME_WITHOUT_BROADCAST = 5f;
+    /// <inheritdoc cref="MAX_TIME_WITHOUT_BROADCAST"/>
+    private const float SAFETY_BROADCAST_WINDOW = 0.2f;
+
     private LocalPlayer localPlayer;
+
+    private float latestBroadcastTime;
+    private Vector3 latestPositionSent;
+    private Quaternion latestBodyRotationSent;
+    private bool hasSentStoppedPacket;
 
     public void Awake()
     {
@@ -66,7 +90,65 @@ public class PlayerMovementBroadcaster : MonoBehaviour
             currentPosition = subRootTransform.TransformPoint(currentPosition);
         }
 
+        if (!ShouldBroadcastMovement(currentPosition, bodyRotation, playerVelocity))
+        {
+            return;
+        }
+        latestPositionSent = currentPosition;
+        latestBodyRotationSent = bodyRotation;
+
         localPlayer.BroadcastLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation);
+    }
+
+    /// <summary>
+    /// Rate limiter which prevents non-moving players from spamming movement packets following some rules:
+    /// - packets are never sent more often than <see cref="MovementBroadcaster.BROADCAST_PERIOD"/> allows
+    /// - position changes less than <see cref="MINIMAL_MOVEMENT_THRESHOLD"/> and rotation changes less than <see cref="MINIMAL_ROTATION_THRESHOLD"/> are ignored
+    /// - once the player comes to a full stop (velocity below <see cref="MINIMAL_VELOCITY_THRESHOLD"/>), exactly one final packet is sent so remote
+    /// machines settle on the stopped state, after which broadcasting stops completely until the player moves again
+    /// - if the player has velocity but hasn't moved past the position/rotation threshold yet (e.g. oscillating in place), a periodic resync every
+    /// <see cref="MAX_TIME_WITHOUT_BROADCAST"/> (with a <see cref="SAFETY_BROADCAST_WINDOW"/> grace period) corrects any drift accumulating remotely
+    /// </summary>
+    private bool ShouldBroadcastMovement(Vector3 currentPosition, Quaternion bodyRotation, Vector3 velocity)
+    {
+        float currentTime = (float)this.Resolve<TimeManager>().RealTimeElapsed;
+        if (currentTime < latestBroadcastTime + MovementBroadcaster.BROADCAST_PERIOD)
+        {
+            return false;
+        }
+
+        bool hasMoved = Vector3.Distance(latestPositionSent, currentPosition) > MINIMAL_MOVEMENT_THRESHOLD ||
+                        Quaternion.Angle(latestBodyRotationSent, bodyRotation) > MINIMAL_ROTATION_THRESHOLD;
+        if (hasMoved)
+        {
+            latestBroadcastTime = currentTime;
+            hasSentStoppedPacket = false;
+            return true;
+        }
+
+        bool isStandingStill = velocity.sqrMagnitude < MINIMAL_VELOCITY_THRESHOLD * MINIMAL_VELOCITY_THRESHOLD;
+        if (isStandingStill)
+        {
+            if (hasSentStoppedPacket)
+            {
+                return false;
+            }
+            latestBroadcastTime = currentTime;
+            hasSentStoppedPacket = true;
+            return true;
+        }
+
+        if (currentTime > latestBroadcastTime + MAX_TIME_WITHOUT_BROADCAST)
+        {
+            if (currentTime > latestBroadcastTime + MAX_TIME_WITHOUT_BROADCAST + SAFETY_BROADCAST_WINDOW)
+            {
+                // only reset the broadcast timer after the safety window has elapsed, mirroring WatchedEntry.ShouldBroadcastMovement
+                latestBroadcastTime = currentTime;
+            }
+            return true;
+        }
+
+        return false;
     }
 
     private bool BroadcastPlayerInCyclopsMovement()

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -104,10 +104,11 @@ public class PlayerMovementBroadcaster : MonoBehaviour
     /// Rate limiter which prevents non-moving players from spamming movement packets following some rules:
     /// - packets are never sent more often than <see cref="MovementBroadcaster.BROADCAST_PERIOD"/> allows
     /// - position changes less than <see cref="MINIMAL_MOVEMENT_THRESHOLD"/> and rotation changes less than <see cref="MINIMAL_ROTATION_THRESHOLD"/> are ignored
-    /// - once the player comes to a full stop (velocity below <see cref="MINIMAL_VELOCITY_THRESHOLD"/>), exactly one final packet is sent so remote
-    /// machines settle on the stopped state, after which broadcasting stops completely until the player moves again
-    /// - if the player has velocity but hasn't moved past the position/rotation threshold yet (e.g. oscillating in place), a periodic resync every
-    /// <see cref="MAX_TIME_WITHOUT_BROADCAST"/> (with a <see cref="SAFETY_BROADCAST_WINDOW"/> grace period) corrects any drift accumulating remotely
+    /// - once the player comes to a full stop (velocity below <see cref="MINIMAL_VELOCITY_THRESHOLD"/>), one packet is sent immediately so remote
+    /// machines settle on the stopped state
+    /// - after that, whether the player is fully stopped or just oscillating in place without net displacement, a low-rate resync every
+    /// <see cref="MAX_TIME_WITHOUT_BROADCAST"/> (with a <see cref="SAFETY_BROADCAST_WINDOW"/> grace period) keeps correcting any drift that
+    /// accumulates on remote machines (e.g. their local physics nudging the idle body). This mirrors <see cref="Vehicles.WatchedEntry"/>.
     /// </summary>
     private bool ShouldBroadcastMovement(Vector3 currentPosition, Quaternion bodyRotation, Vector3 velocity)
     {
@@ -127,17 +128,17 @@ public class PlayerMovementBroadcaster : MonoBehaviour
         }
 
         bool isStandingStill = velocity.sqrMagnitude < MINIMAL_VELOCITY_THRESHOLD * MINIMAL_VELOCITY_THRESHOLD;
-        if (isStandingStill)
+        if (isStandingStill && !hasSentStoppedPacket)
         {
-            if (hasSentStoppedPacket)
-            {
-                return false;
-            }
+            // Send one packet the moment the player stops so remote machines settle on the stopped state right away
             latestBroadcastTime = currentTime;
             hasSentStoppedPacket = true;
             return true;
         }
 
+        // Low-rate resync while the player isn't making net progress (fully stopped or oscillating in place): re-send every
+        // MAX_TIME_WITHOUT_BROADCAST (+ SAFETY_BROADCAST_WINDOW grace) so drift accumulated on remote machines still gets
+        // corrected even while idle, without going back to per-frame broadcasting. Mirrors WatchedEntry.
         if (currentTime > latestBroadcastTime + MAX_TIME_WITHOUT_BROADCAST)
         {
             if (currentTime > latestBroadcastTime + MAX_TIME_WITHOUT_BROADCAST + SAFETY_BROADCAST_WINDOW)

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -77,17 +77,17 @@ public class PlayerMovementBroadcaster : MonoBehaviour
 
         SubRoot subRoot = Player.main.GetCurrentSub();
 
-        // If in a subroot the position will be relative to the subroot
-        if (subRoot)
+        // If in a base the position/rotation is sent relative to the base, matching what RemotePlayer.UpdatePosition
+        // expects (it only converts back from local to world space for SubRoot.isBase). Vehicles (e.g. Cyclops) are
+        // intentionally excluded here since the receiver doesn't convert those back either.
+        if (subRoot && subRoot.isBase)
         {
-            // Rotate relative player position relative to the subroot (else there are problems with respawning)
             Transform subRootTransform = subRoot.transform;
             Quaternion undoVehicleAngle = subRootTransform.rotation.GetInverse();
             currentPosition = currentPosition - subRootTransform.position;
             currentPosition = undoVehicleAngle * currentPosition;
             bodyRotation = undoVehicleAngle * bodyRotation;
             aimingRotation = undoVehicleAngle * aimingRotation;
-            currentPosition = subRootTransform.TransformPoint(currentPosition);
         }
 
         if (!ShouldBroadcastMovement(currentPosition, bodyRotation, playerVelocity))


### PR DESCRIPTION
## Linked Issues / Context

Addresses #2705

## Description of Change

Movement data was being synced far more often than necessary: `PlayerMovementBroadcaster` sent a `PlayerMovement` packet on every single `Update()` frame, uncapped, regardless of whether the player was actually moving. Velocity was already part of the packet, so the main remaining bandwidth win was to stop sending when nothing meaningful changed.

**`PlayerMovementBroadcaster`** now mirrors the threshold/safety-window pattern already used for vehicles (`WatchedEntry`):
- Packets are capped at the existing 30 Hz rate (`MovementBroadcaster.BROADCAST_PERIOD`) instead of sending every rendered frame.
- Packets are skipped entirely while the position/rotation delta since the last sent packet stays below a small threshold.
- Once the player comes to a full stop (velocity below a small threshold), exactly **one** final packet is sent so remote clients settle on the stopped state, then broadcasting stops completely until the player moves again.
- If the player has residual velocity without net displacement past the threshold yet (e.g. oscillating in place), a periodic resync (5s window + short safety grace period, same constants as `WatchedEntry`) still corrects any drift accumulating on remote machines — but only while not standing still, per the issue's request.

**`PlayerMovement`**'s delivery method changes from `UNRELIABLE_SEQUENCED` to `RELIABLE_ORDERED_LAST` ("last packet only", but guaranteed delivery — same as already used for `PlayerStats`), so that final "stopped" packet can't silently get dropped, which would otherwise leave remote players sliding indefinitely.

**`RemotePlayer.UpdatePosition`** derives its velocity-correction time window from the actual elapsed time since the previous packet instead of assuming a fixed `Time.fixedDeltaTime` cadence, since packets can now arrive at irregular intervals (or not at all while idle).

Additionally, while play-testing this change, we found that `MovementHelper.GetCorrectedVelocity`/`GetCorrectedAngularVelocity` compute a "keep nudging towards target" velocity that's only ever exactly zero by coincidence — under the old every-frame-packet model this self-corrected within one frame, but once a stopped player stops sending packets entirely, any left-over non-zero result from the last correction got applied by physics forever, causing remote players to drift or spin in place indefinitely after coming to rest. `RemotePlayer.UpdatePosition` now recognizes a (near) zero incoming velocity as an explicit "I've stopped" signal and snaps directly to the reported position/rotation with both velocities hard-zeroed in that case, instead of running the generic corrective-velocity math.

## Validation

Manually tested with 2 clients (host + client) over an extended session:
- Normal walking/swimming movement: smooth, no jitter or rubber-banding, indistinguishable from before the change.
- Coming to a stop: remote player correctly settles and stays still (this required the `RemotePlayer.UpdatePosition` fix above after an initial test revealed the endless-drift/spin bug described there).
- One remaining minor cosmetic artifact: turning to face a new direction and then immediately stopping can cause the remote view to keep rotating for a couple of milliseconds (network latency for that final packet) before snapping to the correct final orientation. This is standard extrapolation/latency behavior and was judged not worth the added physics-interaction complexity (temporarily toggling kinematic state, coroutine-driven interpolation) to smooth out further.

Given this touches core movement netcode, further testing (in-game, different network conditions, vehicles/base entry edge cases) by maintainers/other players before merging is still recommended.

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

🤖 This code was created with the help of AI.