### PR TITLE
Fix remote player equipment (e.g. rebreather) not showing in sessions with 3+ players

### DIFF
--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/Abstract/IEquipmentVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/Abstract/IEquipmentVisibilityHandler.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
 
 namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract
 {
     public interface IEquipmentVisibilityHandler
     {
-        void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment);
+        void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment);
     }
 }

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/DiveSuitVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/DiveSuitVisibilityHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -17,7 +18,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
             hands = playerModel.transform.Find(PlayerEquipmentConstants.NORMAL_HANDS_GAME_OBJECT_NAME).gameObject;
         }
 
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool headVisible = !currentEquipment.Contains(TechType.RadiationHelmet) && !currentEquipment.Contains(TechType.Rebreather);
             bool bodyVisible = !currentEquipment.Contains(TechType.RadiationSuit) &&

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/FinsVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/FinsVisibilityHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -23,7 +24,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
             glideFinsRoot = playerModel.transform.Find(PlayerEquipmentConstants.GLIDE_FINS_ROOT_GAME_OBJECT_NAME).gameObject;
         }
 
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool basicFinsVisible = currentEquipment.Contains(TechType.Fins);
             bool chargedFinsVisible = currentEquipment.Contains(TechType.SwimChargeFins);

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/RadiationSuitVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/RadiationSuitVisibilityHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -28,7 +29,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
 
         }
 
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool tankEquipped = currentEquipment.Contains(TechType.Tank) ||
                                 currentEquipment.Contains(TechType.DoubleTank) ||

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/ReinforcedSuitVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/ReinforcedSuitVisibilityHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -14,7 +15,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
             gloves = playerModel.transform.Find(PlayerEquipmentConstants.REINFORCED_GLOVES_GAME_OBJECT_NAME).gameObject;
             suit = playerModel.transform.Find(PlayerEquipmentConstants.REINFORCED_SUIT_GAME_OBJECT_NAME).gameObject;
         }
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool glovesVisible = currentEquipment.Contains(TechType.ReinforcedGloves);
             bool bodyVisible = currentEquipment.Contains(TechType.ReinforcedDiveSuit);

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/ScubaSuitVisibiliyHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/ScubaSuitVisibiliyHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -19,7 +20,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
             scubaTankTubes = playerModel.transform.Find(PlayerEquipmentConstants.SCUBA_TANK_TUBES_GAME_OBJECT_NAME).gameObject;
         }
 
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool tankEquipped = currentEquipment.Contains(TechType.Tank) ||
                                 currentEquipment.Contains(TechType.DoubleTank) ||

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/StillSuitVisibilityHandler.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Equipment/StillSuitVisibilityHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using UnityEngine;
 
@@ -12,7 +13,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment
         {
             stillSuit = playerModel.transform.Find(PlayerEquipmentConstants.STILL_SUIT_GAME_OBJECT_NAME).gameObject;
         }
-        public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+        public void UpdateEquipmentVisibility(IReadOnlyList<TechType> currentEquipment)
         {
             bool bodyVisible = currentEquipment.Contains(TechType.WaterFiltrationSuit);
 

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -14,7 +14,6 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel;
 public class PlayerModelManager
 {
     private readonly IEnumerable<IColorSwapManager> colorSwapManagers;
-    private List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers;
 
     public PlayerModelManager(IEnumerable<IColorSwapManager> colorSwapManagers)
     {
@@ -26,9 +25,15 @@ public class PlayerModelManager
         Multiplayer.Main.StartCoroutine(ApplyPlayerColor(player, colorSwapManagers));
     }
 
-    public void RegisterEquipmentVisibilityHandler(GameObject playerModel)
+    /// <remarks>
+    /// This manager is registered as a single shared instance (<c>InstancePerLifetimeScope</c>), so the returned handlers
+    /// must be kept by the caller (one list per remote player) instead of being cached here. Storing them on this manager
+    /// previously caused every remote player to share the same handler list, so only the most recently (re)spawned
+    /// remote player's equipment would ever be updated correctly.
+    /// </remarks>
+    public List<IEquipmentVisibilityHandler> RegisterEquipmentVisibilityHandler(GameObject playerModel)
     {
-        equipmentVisibilityHandlers = new List<IEquipmentVisibilityHandler>
+        return new List<IEquipmentVisibilityHandler>
         {
             new DiveSuitVisibilityHandler(playerModel),
             new ScubaSuitVisibilityHandler(playerModel),
@@ -39,7 +44,7 @@ public class PlayerModelManager
         };
     }
 
-    public void UpdateEquipmentVisibility(ReadOnlyCollection<TechType> currentEquipment)
+    public static void UpdateEquipmentVisibility(List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers, ReadOnlyCollection<TechType> currentEquipment)
     {
         foreach (IEquipmentVisibilityHandler equipmentVisibilityHandler in equipmentVisibilityHandlers)
         {

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment;
@@ -44,7 +43,7 @@ public class PlayerModelManager
         };
     }
 
-    public static void UpdateEquipmentVisibility(List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers, ReadOnlyCollection<TechType> currentEquipment)
+    public static void UpdateEquipmentVisibility(List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers, IReadOnlyList<TechType> currentEquipment)
     {
         foreach (IEquipmentVisibilityHandler equipmentVisibilityHandler in equipmentVisibilityHandlers)
         {

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -6,6 +6,7 @@ using NitroxClient.GameLogic.HUD;
 using NitroxClient.GameLogic.PlayerLogic;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
+using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Equipment.Abstract;
 using NitroxClient.MonoBehaviours;
 using NitroxClient.MonoBehaviours.Cyclops;
 using NitroxClient.MonoBehaviours.Gui.HUD;
@@ -32,6 +33,7 @@ public class RemotePlayer : INitroxPlayer
     private readonly PlayerModelManager playerModelManager;
     private readonly PlayerVitalsManager playerVitalsManager;
     private readonly FMODWhitelist fmodWhitelist;
+    private List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers;
 
     public PlayerContext PlayerContext { get; }
     public GameObject? Body { get; private set; }
@@ -100,7 +102,7 @@ public class RemotePlayer : INitroxPlayer
 
         CoroutineUtils.StartCoroutineSmart(playerModelManager.AttachPing(this));
         playerModelManager.BeginApplyPlayerColor(this);
-        playerModelManager.RegisterEquipmentVisibilityHandler(PlayerModel);
+        equipmentVisibilityHandlers = playerModelManager.RegisterEquipmentVisibilityHandler(PlayerModel);
         SetupBody();
         SetupSkyAppliers();
         SetupPlayerSounds();
@@ -394,7 +396,7 @@ public class RemotePlayer : INitroxPlayer
 
     public void UpdateEquipmentVisibility(List<TechType> equippedItems)
     {
-        playerModelManager.UpdateEquipmentVisibility(new ReadOnlyCollection<TechType>(equippedItems));
+        PlayerModelManager.UpdateEquipmentVisibility(equipmentVisibilityHandlers, new ReadOnlyCollection<TechType>(equippedItems));
     }
 
     /// <summary>

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures.GameLogic;
 using NitroxClient.GameLogic.HUD;
@@ -33,7 +32,7 @@ public class RemotePlayer : INitroxPlayer
     private readonly PlayerModelManager playerModelManager;
     private readonly PlayerVitalsManager playerVitalsManager;
     private readonly FMODWhitelist fmodWhitelist;
-    private List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers;
+    private List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers = [];
 
     public PlayerContext PlayerContext { get; }
     public GameObject? Body { get; private set; }
@@ -396,7 +395,7 @@ public class RemotePlayer : INitroxPlayer
 
     public void UpdateEquipmentVisibility(List<TechType> equippedItems)
     {
-        PlayerModelManager.UpdateEquipmentVisibility(equipmentVisibilityHandlers, new ReadOnlyCollection<TechType>(equippedItems));
+        PlayerModelManager.UpdateEquipmentVisibility(equipmentVisibilityHandlers, equippedItems);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #2359

## Problem

Since #2635, `RegisterEquipmentVisibilityHandler` is correctly called when each remote player spawns, yet the issue persisted: in sessions with multiple players (the reporters were four), some players are missing equipment on their model — most noticeably the rebreather, since its absence on the head is immediately obvious, whereas e.g. a wrong glove barely stands out. Testing with only one remote player (2 players total) never reproduced the bug — which is exactly what masked it during the earlier local verification.

## Root Cause

`PlayerModelManager` is registered in Autofac as `InstancePerLifetimeScope` (`ClientAutoFacRegistrar.cs`), meaning **a single instance is injected into every `RemotePlayer` object for the whole session** (`PlayerManager.cs:76`).

`PlayerModelManager` used to store the equipment visibility handlers in a single mutable field:

```csharp
private List<IEquipmentVisibilityHandler> equipmentVisibilityHandlers;

public void RegisterEquipmentVisibilityHandler(GameObject playerModel)
{
    equipmentVisibilityHandlers = new List<IEquipmentVisibilityHandler> { ... };
}
```

Each of these handlers (`ScubaSuitVisibilityHandler`, etc.) captures a reference to the `playerModel` GameObject it was constructed with via closure. Because `equipmentVisibilityHandlers` is a **shared** field, every remote player that (re)spawns (`RemotePlayer.InitializeGameObject` → `RegisterEquipmentVisibilityHandler`) overwrites that list for **every** player in the session.

Result: once `RemotePlayer.UpdateEquipmentVisibility(...)` is called for player A, the update actually lands on the model of whichever player was registered last (e.g. player D) — not on player A's own model. With exactly two players (1 local + 1 remote) there is never a second registration to overwrite the first, so the bug is invisible there. It only becomes visible from the third player onward, and reproducibly depends on join order — which explains why targeted testing with only a couple of people never caught it, while it showed up reliably in the real 4-player playtest.

## Fix

`equipmentVisibilityHandlers` is no longer kept on the shared `PlayerModelManager`; it now belongs to each individual `RemotePlayer`:

- `PlayerModelManager.RegisterEquipmentVisibilityHandler(...)` now returns the handler list instead of caching it internally.
- `PlayerModelManager.UpdateEquipmentVisibility(...)` is now a stateless static method that applies a given handler list.
- `RemotePlayer` holds its own `equipmentVisibilityHandlers` list and passes it in on every equipment update.

This makes it impossible for one remote player's spawn to overwrite another's handlers.

---

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [ ] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

🤖 This code was created with the help of AI.
