### PR TITLE
Fix battery duplication when picking up a batteryless tool (#2668)

### DIFF
--- a/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
+++ b/NitroxClient/GameLogic/Helper/BatteryChildEntityHelper.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.MonoBehaviours;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
 using UnityEngine;
 using UWE;
 
@@ -12,37 +14,118 @@ namespace NitroxClient.GameLogic.Helper;
 
 /// <summary>
 /// Vehicles and items are created without a battery loaded into them. Subnautica usually spawns these in async; however, this
-/// is disabled in nitrox so we can properly tag the id. Here we create the installed battery (with a new NitroxId) and have the 
+/// is disabled in nitrox so we can properly tag the id. Here we create the installed battery (with a new NitroxId) and have the
 /// entity spawner take care of loading it in.
 /// </summary>
 public static class BatteryChildEntityHelper
 {
     private static readonly Lazy<Entities> entities = new (() => NitroxServiceLocator.LocateService<Entities>());
+    private static readonly Lazy<EntityMetadataManager> defaultMetadataManager = new (() => NitroxServiceLocator.LocateService<EntityMetadataManager>());
 
-    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId)
+    /// <summary>
+    /// Tracks installed batteries as soon as they're known (spawn dispatched), keyed by the owning entity's id and the
+    /// <see cref="EnergyMixin"/>'s component index. This bridges the (usually sub-frame, but non-zero) window between an
+    /// <see cref="InstalledBatteryEntity"/> being known and its backing GameObject actually finishing its (async) spawn and
+    /// being wired into <see cref="EnergyMixin.batterySlot"/>. Without this, a pickup happening in that window - most notably
+    /// another player picking up a just-received dropped item - would wrongly conclude the tool has no battery.
+    /// </summary>
+    private static readonly Dictionary<(NitroxId ParentId, int ComponentIndex), InstalledBatteryEntity> pendingInstalledBatteries = [];
+
+    /// <summary>
+    /// Overload for callers (e.g. vehicle construction) that don't have an <see cref="EntityMetadataManager"/> instance at hand.
+    /// </summary>
+    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId, bool allowDefaultBattery = true)
+    {
+        TryPopulateInstalledBattery(gameObject, toPopulate, parentId, defaultMetadataManager.Value, allowDefaultBattery);
+    }
+
+    public static void TryPopulateInstalledBattery(GameObject gameObject, List<Entity> toPopulate, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery = true)
     {
         if (gameObject.TryGetComponent(out EnergyMixin energyMixin))
         {
-            PopulateInstalledBattery(energyMixin, toPopulate, parentId);
+            PopulateInstalledBatteryInternal(energyMixin, toPopulate, parentId, entityMetadataManager, allowDefaultBattery);
         }
     }
 
+    /// <remarks>Used to unconditionally populate a fresh default battery for a given EnergyMixin, e.g. a cyclops BatterySource during vehicle construction.</remarks>
     public static void PopulateInstalledBattery(EnergyMixin energyMixin, List<Entity> toPopulate, NitroxId parentId)
     {
-        EnergyMixin[] components = NitroxEntity.RequireObjectFrom(parentId).GetAllComponentsInChildren<EnergyMixin>();
-        int componentIndex = 0;
-        for (int i = 0; i < components.Length; i++)
-        {
-            if (components[i] == energyMixin)
-            {
-                componentIndex = i;
-                break;
-            }
-        }
+        PopulateInstalledBatteryInternal(energyMixin, toPopulate, parentId, defaultMetadataManager.Value, allowDefaultBattery: true);
+    }
 
+    private static void PopulateInstalledBatteryInternal(EnergyMixin energyMixin, List<Entity> toPopulate, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery)
+    {
+        int componentIndex = GetComponentIndex(energyMixin, parentId);
+        InventoryItem storedItem = energyMixin.batterySlot?.storedItem;
+
+        if (storedItem?.item)
+        {
+            // Reflect the actual currently-installed battery (its real id, tech type and metadata/charge) instead of
+            // assuming a default one. This is what makes dropping/picking up a tool with a real battery installed
+            // (including by a different player than the one who installed it) preserve that exact battery.
+            NitroxId batteryId = NitroxEntity.GetIdOrGenerateNew(storedItem.item.gameObject);
+            Optional<EntityMetadata> metadata = entityMetadataManager.Extract(storedItem.item.gameObject);
+            toPopulate.Add(new InstalledBatteryEntity(componentIndex, batteryId, storedItem.item.GetTechType().ToDto(), metadata.OrNull(), parentId, []));
+            ForgetPendingInstalledBattery(parentId, componentIndex);
+        }
+        else if (TryGetPendingInstalledBattery(parentId, componentIndex, out InstalledBatteryEntity pendingBattery))
+        {
+            toPopulate.Add(pendingBattery);
+        }
+        else if (allowDefaultBattery)
+        {
+            PopulateDefaultInstalledBattery(energyMixin, componentIndex, toPopulate, parentId);
+        }
+        // Otherwise: no battery installed, and none allowed to be assumed (e.g. an already-known, previously-emptied tool).
+    }
+
+    private static void PopulateDefaultInstalledBattery(EnergyMixin energyMixin, int componentIndex, List<Entity> toPopulate, NitroxId parentId)
+    {
         InstalledBatteryEntity installedBattery = new(componentIndex, new NitroxId(), energyMixin.defaultBattery.ToDto(), null, parentId, []);
         toPopulate.Add(installedBattery);
 
         CoroutineHost.StartCoroutine(entities.Value.SpawnEntityAsync(installedBattery));
+    }
+
+    /// <summary>
+    /// Records that the given <see cref="InstalledBatteryEntity"/> is about to be spawned in, before waiting on any
+    /// asynchronous spawn of its backing GameObject.
+    /// </summary>
+    public static void RegisterPendingInstalledBattery(InstalledBatteryEntity installedBattery)
+    {
+        pendingInstalledBatteries[(installedBattery.ParentId, installedBattery.ComponentIndex)] = installedBattery;
+    }
+
+    /// <summary>
+    /// Forgets a previously pending installed battery, whether because its spawn finished (its state is now correctly
+    /// reflected by <see cref="EnergyMixin.batterySlot"/>) or because it was actually removed from its slot.
+    /// </summary>
+    public static void ForgetPendingInstalledBattery(NitroxId parentId, int componentIndex)
+    {
+        pendingInstalledBatteries.Remove((parentId, componentIndex));
+    }
+
+    public static void ForgetPendingInstalledBattery(EnergyMixin energyMixin, NitroxId parentId)
+    {
+        ForgetPendingInstalledBattery(parentId, GetComponentIndex(energyMixin, parentId));
+    }
+
+    private static bool TryGetPendingInstalledBattery(NitroxId parentId, int componentIndex, out InstalledBatteryEntity installedBattery)
+    {
+        return pendingInstalledBatteries.TryGetValue((parentId, componentIndex), out installedBattery);
+    }
+
+    private static int GetComponentIndex(EnergyMixin energyMixin, NitroxId parentId)
+    {
+        EnergyMixin[] components = NitroxEntity.RequireObjectFrom(parentId).GetAllComponentsInChildren<EnergyMixin>();
+        for (int i = 0; i < components.Length; i++)
+        {
+            if (components[i] == energyMixin)
+            {
+                return i;
+            }
+        }
+
+        return 0;
     }
 }

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -117,6 +117,8 @@ public class Items
 
         WorldEntity droppedItem;
         List<Entity> childrenEntities = GetPrefabChildren(gameObject, id, entityMetadataManager).ToList();
+        // Reflects the tool's actual current battery state (if any); never assumes a default one, since a dropped item always already exists.
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, childrenEntities, id, entityMetadataManager, allowDefaultBattery: false);
 
         // If the item is dropped in a WaterPark we need to handle it differently
         NitroxId parentId = null;
@@ -236,7 +238,10 @@ public class Items
     /// </summary>
     private InventoryItemEntity ConvertToInventoryEntityUntracked(GameObject gameObject, NitroxId parentId)
     {
-        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager);
+        // Entities that are already known by the server were already spawned before (e.g. dropped and picked back up), so their
+        // actual current battery state (which can be empty) must be preserved instead of assuming a freshly filled default battery.
+        bool isExistingEntity = gameObject.TryGetNitroxId(out NitroxId existingId) && entities.IsKnownEntity(existingId);
+        InventoryItemEntity inventoryItemEntity = ConvertToInventoryItemEntity(gameObject, parentId, entityMetadataManager, !isExistingEntity);
 
         // Some picked up entities are not known by the server for several reasons.  First it can be picked up via a spawn item command.  Another
         // example is that some obects are not 'real' objects until they are clicked and end up spawning a prefab.  For example, the fire extinguisher
@@ -251,7 +256,7 @@ public class Items
         return inventoryItemEntity;
     }
 
-    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager)
+    public static InventoryItemEntity ConvertToInventoryItemEntity(GameObject gameObject, NitroxId parentId, EntityMetadataManager entityMetadataManager, bool allowDefaultBattery = true)
     {
         NitroxId itemId = NitroxEntity.GetIdOrGenerateNew(gameObject); // id may not exist, create if missing
         string classId = gameObject.RequireComponent<PrefabIdentifier>().ClassId;
@@ -260,7 +265,7 @@ public class Items
         List<Entity> children = GetPrefabChildren(gameObject, itemId, entityMetadataManager).ToList();
 
         InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), metadata.OrNull(), parentId, children);
-        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId);
+        BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId, entityMetadataManager, allowDefaultBattery);
 
         return inventoryItemEntity;
     }

--- a/NitroxClient/GameLogic/Spawning/InstalledBatteryEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InstalledBatteryEntitySpawner.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Nitrox.Model.DataStructures;
 using NitroxClient.Communication;
+using NitroxClient.GameLogic.Helper;
 using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
 using NitroxClient.MonoBehaviours;
@@ -22,12 +23,16 @@ public class InstalledBatteryEntitySpawner : SyncEntitySpawner<InstalledBatteryE
             result.Set(Optional.Empty);
             yield break;
         }
+        // Record this battery as known before waiting on its (potentially multi-frame) prefab spawn, so a pickup
+        // happening in that window doesn't wrongly conclude the tool has no battery.
+        BatteryChildEntityHelper.RegisterPendingInstalledBattery(entity);
 
         TaskResult<GameObject> prefabResult = new();
         yield return DefaultWorldEntitySpawner.RequestPrefab(entity.TechType.ToUnity(), prefabResult);
         GameObject gameObject = GameObjectExtensions.InstantiateWithId(prefabResult.Get(), entity.Id);
 
         SetupObject(gameObject, energyMixin);
+        BatteryChildEntityHelper.ForgetPendingInstalledBattery(entity.ParentId, entity.ComponentIndex);
 
         result.Set(gameObject);
     }
@@ -43,10 +48,12 @@ public class InstalledBatteryEntitySpawner : SyncEntitySpawner<InstalledBatteryE
             Log.Error(errorLog);
             return true;
         }
+        BatteryChildEntityHelper.RegisterPendingInstalledBattery(entity);
 
         GameObject gameObject = GameObjectExtensions.SpawnFromPrefab(prefab, entity.Id);
 
         SetupObject(gameObject, energyMixin);
+        BatteryChildEntityHelper.ForgetPendingInstalledBattery(entity.ParentId, entity.ComponentIndex);
 
         result.Set(gameObject);
         return true;

--- a/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnRemoveItem_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EnergyMixin_OnRemoveItem_Patch.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using NitroxClient.GameLogic.Helper;
+using NitroxClient.MonoBehaviours;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Local-only bookkeeping: keeps <see cref="BatteryChildEntityHelper"/>'s pending-installed-battery tracking in sync
+/// with actual battery removals, so a later pickup doesn't resurrect a battery that isn't there anymore. This does not
+/// broadcast anything over the network; item battery state is still fully (re-)derived on pickup/drop, as before.
+/// </summary>
+public sealed partial class EnergyMixin_OnRemoveItem_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((EnergyMixin t) => t.OnRemoveItem(default(InventoryItem)));
+
+    public static void Postfix(EnergyMixin __instance, InventoryItem item)
+    {
+        NitroxEntity parent = __instance.gameObject.FindAncestor<NitroxEntity>();
+        if (item == null || !parent)
+        {
+            return;
+        }
+
+        BatteryChildEntityHelper.ForgetPendingInstalledBattery(__instance, parent.Id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2668 — battery-powered tools (Flashlight, Scanner, Seaglide, etc.) duplicated a fully-charged battery whenever an emptied tool was dropped and picked back up.

## Root cause

`Items.ConvertToInventoryItemEntity` unconditionally called `BatteryChildEntityHelper.TryPopulateInstalledBattery`, which always created a brand-new default (fully charged) `InstalledBatteryEntity` for any object with an `EnergyMixin`, regardless of whether a battery was actually installed. Since Nitrox disables Subnautica's own default-battery auto-spawn (`EnergyMixin_SpawnDefaultAsync_Patch`), this was needed for freshly crafted items — but it was also wrongly applied to already-known items being picked back up, silently re-filling any empty battery slot.

## Related prior attempt (#2752)

A previous fix (#2752) addressed the basic case but was closed unmerged: [@Measurity](https://github.com/Measurity) found that it broke the cross-player case — if Player A drops a tool with a battery installed and Player B picks it up, Player B would receive the tool without its battery.

That regression came from a second, separate gap: `Items.Dropped()` never captured the currently-installed battery at all when converting an item to a `WorldEntity`, and the receiving client's `InstalledBatteryEntity` spawn (for a battery coming from another player) is asynchronous, so a pickup performed in that narrow window would see an empty `EnergyMixin.batterySlot`.

## Fix

- `Items.ConvertToInventoryEntityUntracked` now distinguishes between genuinely new objects (e.g. freshly crafted — still allowed a default battery) and already-known objects (dropped/picked up before — only reflect their real current battery state, never assume one).
- `Items.Dropped()` now also reflects the tool's actual currently-installed battery (if any) when converting it to a `WorldEntity`, instead of silently losing that information on drop.
- `BatteryChildEntityHelper.TryPopulateInstalledBattery` now checks the live `EnergyMixin.batterySlot.storedItem` first and, if present, reuses that battery's real id/tech type/charge instead of fabricating a new default one. It only falls back to creating a default battery for genuinely new objects with no battery at all.
- Added a small pending-battery registry (`BatteryChildEntityHelper` + `InstalledBatteryEntitySpawner`) that closes the short window between an `InstalledBatteryEntity` being received over the network and its backing GameObject finishing its (async) spawn into `EnergyMixin.batterySlot`. This is what makes the cross-player pickup case (Measurity's finding above) work correctly.
- Added a local-only `EnergyMixin_OnRemoveItem_Patch` that clears that pending-battery bookkeeping when a battery is actually removed from a slot, so a later pickup can't resurrect a battery that isn't there anymore. This patch does not broadcast anything over the network.

## Test plan

Tested manually with 2 Windows clients:
- [x] Craft a battery-powered tool, remove its battery, drop it, pick it back up → stays batteryless (original exploit fixed).
- [x] Craft a new battery-powered tool → still receives its intended default battery (no regression).
- [x] Player A drops a tool with a battery installed, Player B picks it up → Player B correctly receives the tool with its battery (Measurity's regression fixed).
