### PR TITLE
Sync base flood state so reconnecting players don't see it restart

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BaseFloodMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/BaseFloodMetadata.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable]
+[DataContract]
+public class BaseFloodMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public float[] FlatValueGrid { get; }
+
+    [IgnoreConstructor]
+    protected BaseFloodMetadata()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
+    public BaseFloodMetadata(float[] flatValueGrid)
+    {
+        FlatValueGrid = flatValueGrid;
+    }
+
+    public override string ToString()
+    {
+        return $"[BaseFloodMetadata FlatValueGrid.Length: {FlatValueGrid?.Length ?? 0}]";
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -149,6 +149,8 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
         yield return Yielders.WaitForEndOfFrame;
 
         yield return BuildEntitySpawner.SetupBase(buildEntity, @base, entities);
+        // SetupBase doesn't apply the base's own metadata (e.g. flood/water-level state), unlike the regular entity spawn path.
+        entityMetadataManager.ApplyMetadata(@base.gameObject, buildEntity.Metadata);
         yield return MoonpoolManager.RestoreMoonpools(buildEntity.ChildEntities.OfType<MoonpoolEntity>(), @base);
         yield return entities.SpawnBatchAsync(buildEntity.ChildEntities.OfType<PlayerEntity>().ToList<Entity>(), false, false);
 

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/BaseFloodMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/BaseFloodMetadataExtractor.cs
@@ -1,0 +1,14 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+public class BaseFloodMetadataExtractor : EntityMetadataExtractor<BaseFloodSim, BaseFloodMetadata>
+{
+    public override BaseFloodMetadata Extract(BaseFloodSim entity)
+    {
+        // The serializer argument isn't actually used by BaseFloodSim's implementation; it only (re)computes flatValueGrid from the current simulation state.
+        entity.OnProtoSerialize(null);
+        return new(entity.flatValueGrid);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/BaseFloodMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/BaseFloodMetadataProcessor.cs
@@ -1,0 +1,52 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class BaseFloodMetadataProcessor : EntityMetadataProcessor<BaseFloodMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, BaseFloodMetadata metadata)
+    {
+        BaseFloodSim baseFloodSim = gameObject.GetComponent<BaseFloodSim>();
+
+        if (!baseFloodSim)
+        {
+            Log.Error($"Could not find BaseFloodSim on {gameObject.name}");
+            return;
+        }
+
+        float[] incoming = metadata.FlatValueGrid;
+        // The base's geometry may have changed (or not finished (re)building yet) since this snapshot was captured elsewhere,
+        // in which case the array no longer maps to the same cells. Applying it regardless would throw inside BaseFloodSim's
+        // own restore logic (index mismatch) and permanently break its Update() loop (no more leaks/flooding) from then on.
+        if (incoming == null || incoming.Length != baseFloodSim.shape.Size)
+        {
+            return;
+        }
+
+        // Refresh flatValueGrid from the currently-simulated state so we can compare fairly before deciding to overwrite it.
+        baseFloodSim.OnProtoSerialize(null);
+        if (Sum(incoming) <= Sum(baseFloodSim.flatValueGrid))
+        {
+            // The local simulation is already at least as flooded as this (possibly network-delayed) snapshot. Skip applying it,
+            // otherwise a client that's already actively simulating this base would keep getting its progress reset backwards
+            // by other players' periodic updates. This still lets a freshly (re)joined client - whose own simulation starts
+            // from empty - catch up to the real, more-flooded state.
+            return;
+        }
+
+        baseFloodSim.flatValueGrid = incoming;
+        baseFloodSim.OnProtoDeserialize(null);
+    }
+
+    private static float Sum(float[] values)
+    {
+        float total = 0f;
+        foreach (float value in values)
+        {
+            total += value;
+        }
+        return total;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/BaseFloodSim_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BaseFloodSim_Update_Patch.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using NitroxClient.GameLogic;
+using Nitrox.Model.DataStructures;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Periodically (throttled) broadcasts a base's current flood/water-level state, so that it can be restored for
+/// players who (re)join later instead of them seeing the base's interior flooding restart from empty.
+/// </summary>
+public sealed partial class BaseFloodSim_Update_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((BaseFloodSim t) => t.Update());
+
+    public static void Postfix(BaseFloodSim __instance)
+    {
+        if (!__instance.IsInitialized() || !__instance.baseComp || !__instance.baseComp.TryGetIdOrWarn(out NitroxId id))
+        {
+            return;
+        }
+
+        Resolve<Entities>().EntityMetadataChangedThrottled(__instance, id, 2f);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2808 — reconnecting players saw their base's flooding restart from empty, while players who stayed connected kept seeing the actual, progressed water level.

## Root cause

`BaseFloodSim`'s per-cell water levels are purely local simulation state on each client - there was no synchronization at all. `BuildingResyncProcessor` rebuilds the base from scratch on reconnect (as already established for the related leak-sync fix in #2769), but never restored any water level afterward, so the newly-rebuilt `BaseFloodSim` always started at zero and had to gradually re-simulate flooding from there.

## Fix

- New `BaseFloodMetadata` entity metadata type carrying the base's flood grid, using `BaseFloodSim`'s own `OnProtoSerialize`/`OnProtoDeserialize` methods (the same ones vanilla Subnautica uses for its own save-game persistence) - no reflection needed.
- A throttled broadcast (`BaseFloodSim_Update_Patch`) periodically shares the current flood state, reusing the existing `EntityMetadataChangedThrottled` mechanism also used for e.g. battery charge and sub name color.
- The processor only applies a received update if it represents *at least as much* flooding as what's already simulated locally, and only if the grid size still matches the base's current shape. This prevents an already-actively-simulating client from having its progress periodically reset backwards by another player's (possibly slightly stale) broadcast, while still letting a freshly (re)joining client - whose own simulation starts empty - catch up to the real state.
- `BuildingResyncProcessor.OverwriteBase` now explicitly applies the base's stored metadata after rebuilding it, since that path (unlike the normal entity spawn path) doesn't do so automatically.

## Test plan

Tested manually with 2 clients:
- [x] Base floods normally for players who stay connected (no regression - an earlier iteration of this fix caused flooding to stall entirely; fixed by the "only apply if it represents more flooding" check above).
- [x] Player disconnects while a base is actively flooding, reconnects later, and now sees the same progressed water level as the player who stayed connected, instead of it restarting from empty.
- [x] FloodState survives both reconnects and full server restarts on both clients - whether the water level is currently rising or falling, it stays in sync between both clients throughout.

🤖 This code was created with the help of AI.