### PR TITLE
[MacOS] Improved SetFullAccessToCurrentUser for bundled .app

### DIFF
--- a/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
+++ b/Nitrox.Launcher/Models/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static partial class ServiceCollectionExtensions
             .AddHostedSingletonService<StopAvaloniaOnHostExitService>()
             .AddHostedSingletonService<PreventMultipleAppInstancesService>()
             .AddHostedSingletonService<WriteGrpcPortFileService>()
+            .AddHostedSingletonService<TroubleshootService>()
             .AddSingleton<ServerService>()
             .AddSingleton<DialogService>()
             .AddSingleton<StorageService>()

--- a/Nitrox.Launcher/Models/Services/TroubleshootService.cs
+++ b/Nitrox.Launcher/Models/Services/TroubleshootService.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Nitrox.Launcher.Models.Utils;
+using Nitrox.Model.Core;
+using Nitrox.Model.Helper;
+using Nitrox.Model.Platforms.OS.Shared;
+
+namespace Nitrox.Launcher.Models.Services;
+
+/// <summary>
+///     Checks if the launcher environment has problems and guides the user to solve them.
+/// </summary>
+internal sealed class TroubleshootService : IHostedLifecycleService
+{
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StartedAsync(CancellationToken cancellationToken)
+    {
+        if (!FileSystem.Instance.SetFullAccessToCurrentUser(NitroxUser.ExecutableRootPath))
+        {
+            LauncherNotifier.Warning($"{NitroxEnvironment.AppName} files might not be accessible by the game. Check that this program isn't running from a zip file, OneDrive or Program Files.");
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/OptionsViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -81,7 +82,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
         await Task.Run(() => SetTargetedSubnauticaPath(SelectedGame.PathToGame), cancellationToken).ContinueWithHandleError(ex => LauncherNotifier.Error(ex.Message));
     }
 
-    private void SetTargetedSubnauticaPath(string path)
+    private static void SetTargetedSubnauticaPath(string path)
     {
         if (!Directory.Exists(path))
         {
@@ -89,12 +90,18 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
         }
 
         PirateDetection.TriggerOnDirectory(path);
-        if (!FileSystem.Instance.IsWritable(Directory.GetCurrentDirectory()) || !FileSystem.Instance.IsWritable(path))
+
+        if (!FileSystem.Instance.IsWritable(path))
         {
-            // TODO: Move this check to another place where Nitrox installation can be verified. (i.e: another page on the launcher in order to check permissions, network setup, ...)
-            if (!FileSystem.Instance.SetFullAccessToCurrentUser(Directory.GetCurrentDirectory()) || !FileSystem.Instance.SetFullAccessToCurrentUser(path))
+            // Targeted game directory needs to be writable (Nitrox patches files into it)
+            if (!FileSystem.Instance.SetFullAccessToCurrentUser(path))
             {
-                LauncherNotifier.Error("Restart Nitrox Launcher as admin to allow Nitrox to change permissions as needed. This is only needed once. Nitrox will close after this message.");
+                LauncherNotifier.Error(
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        ? "Restart Nitrox Launcher as admin to allow Nitrox to change permissions as needed. This is only needed once."
+                        : $"Unable to set permissions on the directories at '{path}'. Please grant read and write permissions so Nitrox can work properly."
+                );
+
                 return;
             }
         }
@@ -191,7 +198,7 @@ internal partial class OptionsViewModel(IKeyValueStore keyValueStore, StorageSer
         }
         keyValueStore.SetIsMultipleGameInstancesAllowed(value);
     }
-    
+
     partial void OnUseBigPictureModeChanged(bool value)
     {
         if (value)

--- a/Nitrox.Model/Platforms/OS/MacOS/MacFileSystem.cs
+++ b/Nitrox.Model/Platforms/OS/MacOS/MacFileSystem.cs
@@ -14,4 +14,9 @@ public sealed class MacFileSystem : FileSystem
     {
         return PosixFileSystemPermissions.SetFullAccessToCurrentUser(directory);
     }
+
+    public bool IsRootDirectory(string directory)
+    {
+        return PosixFileSystemPermissions.IsRootDirectory(directory);
+    }
 }

--- a/Nitrox.Model/Platforms/OS/Shared/FileSystem.cs
+++ b/Nitrox.Model/Platforms/OS/Shared/FileSystem.cs
@@ -75,7 +75,7 @@ public abstract class FileSystem
     /// </summary>
     /// <param name="fileName">File or program name to get the full path from.</param>
     /// <returns></returns>
-    public string GetFullPath(string fileName)
+    public string? GetFullPath(string fileName)
     {
         if (File.Exists(fileName))
         {
@@ -142,7 +142,7 @@ public abstract class FileSystem
     /// <param name="replaceFile">If true, overwrites the file matching the output path.</param>
     /// <returns>Full path to the newly created zip or null if no files are found to zip.</returns>
     /// <exception cref="IOException">If zip file already exists.</exception>
-    public string ZipFilesInDirectory(string dir, string outputPath = null, string fileSearchPattern = "*", bool replaceFile = false)
+    public string? ZipFilesInDirectory(string dir, string? outputPath = null, string fileSearchPattern = "*", bool replaceFile = false)
     {
         if (string.IsNullOrWhiteSpace(dir))
         {
@@ -260,11 +260,11 @@ public abstract class FileSystem
         {
             return false;
         }
+
         string randFileName = Path.GetRandomFileName();
         try
         {
-            File.Create(Path.Combine(directory, randFileName)).Close();
-            File.Delete(Path.Combine(directory, randFileName));
+            File.Create(Path.Combine(directory, randFileName), 1, FileOptions.DeleteOnClose).Dispose();
             return true;
         }
         catch

--- a/Nitrox.Model/Platforms/OS/Shared/PosixFileSystemPermissions.cs
+++ b/Nitrox.Model/Platforms/OS/Shared/PosixFileSystemPermissions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 
 namespace Nitrox.Model.Platforms.OS.Shared;
 
@@ -9,22 +10,62 @@ internal static class PosixFileSystemPermissions
 {
     public static bool SetFullAccessToCurrentUser(string directory)
     {
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return false;
+        }
+
+        // Don't try to execute anything on root folder ("/")
+        if (IsRootDirectory(directory))
+        {
+            Log.Error($"Tried to set full access to current user on root directory '{directory}'");
+            return false;
+        }
+
         try
         {
-            string escapedPath = directory.Replace("\"", "\\\"");
-            using Process process = Process.Start(new ProcessStartInfo
+            string path = Path.GetFullPath(directory);
+            string escapedPath = path.Replace("\"", "\\\"");
+
+            using Process? process = Process.Start(new ProcessStartInfo
             {
                 FileName = "chmod",
                 Arguments = $"-R u+rwX \"{escapedPath}\"",
                 RedirectStandardError = true,
                 UseShellExecute = false,
-            })!;
-            process.WaitForExit();
+            });
+
+            if (process is null)
+            {
+                return false;
+            }
+
+            if (!process.HasExited)
+            {
+                process.WaitForExit();
+            }
+
             return process.ExitCode == 0;
         }
         catch
         {
+            Log.Warn($"Failed to set full access of '{directory}' to current user");
             return false;
         }
+    }
+
+    public static bool IsRootDirectory(string path)
+    {
+        string? root = Path.GetPathRoot(path);
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            return false;
+        }
+
+        return string.Equals(
+            path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            System.StringComparison.Ordinal
+            );
     }
 }

--- a/Nitrox.Model/Platforms/OS/Unix/UnixFileSystem.cs
+++ b/Nitrox.Model/Platforms/OS/Unix/UnixFileSystem.cs
@@ -14,4 +14,9 @@ public sealed class UnixFileSystem : FileSystem
     {
         return PosixFileSystemPermissions.SetFullAccessToCurrentUser(directory);
     }
+
+    public bool IsRootDirectory(string directory)
+    {
+        return PosixFileSystemPermissions.IsRootDirectory(directory);
+    }
 }

--- a/Nitrox.Test/Model/Platforms/OS/MacOS/MacFileSystemTest.cs
+++ b/Nitrox.Test/Model/Platforms/OS/MacOS/MacFileSystemTest.cs
@@ -1,5 +1,4 @@
 using System.Runtime.Versioning;
-using Nitrox.Model.Platforms.OS.MacOS;
 using Nitrox.Test.Model.Platforms;
 
 namespace Nitrox.Model.Platforms.OS.MacOS;
@@ -11,13 +10,16 @@ public class MacFileSystemTest
     [OSTestMethod(OperatingSystems.OSX)]
     public void SetFullAccessToCurrentUser_ShouldMakeReadOnlyDirectoryWritable()
     {
+        // Arrange
         MacFileSystem fileSystem = new();
         string tempDir = Path.Combine(Path.GetTempPath(), $"NitroxTest_{Guid.NewGuid():N}");
+
+        // Act
         Directory.CreateDirectory(tempDir);
         File.SetUnixFileMode(tempDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
-
         bool result = fileSystem.SetFullAccessToCurrentUser(tempDir);
 
+        // Assert
         result.Should().BeTrue();
         fileSystem.IsWritable(tempDir).Should().BeTrue();
 
@@ -27,11 +29,44 @@ public class MacFileSystemTest
     [OSTestMethod(OperatingSystems.OSX)]
     public void SetFullAccessToCurrentUser_ShouldReturnFalseForNonexistentDirectory()
     {
+        // Arrange
         MacFileSystem fileSystem = new();
         string fakePath = Path.Combine(Path.GetTempPath(), $"NitroxTest_nonexistent_{Guid.NewGuid():N}");
 
+        // Act
         bool result = fileSystem.SetFullAccessToCurrentUser(fakePath);
 
+        // Assert
         result.Should().BeFalse();
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void SetFullAccessToCurrentUser_ShouldReturnFalseForRootDirectory()
+    {
+        // Arrange
+        MacFileSystem fileSystem = new();
+
+        // Act
+        bool result = fileSystem.SetFullAccessToCurrentUser("/");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [OSTestMethod(OperatingSystems.OSX)]
+    public void IsRootDirectory_SanityCheck()
+    {
+        // Arrange
+        MacFileSystem fileSystem = new();
+
+        // Act & Assert
+        fileSystem.IsRootDirectory(null!).Should().BeFalse();
+        fileSystem.IsRootDirectory("").Should().BeFalse();
+        fileSystem.IsRootDirectory(" ").Should().BeFalse();
+        fileSystem.IsRootDirectory("/").Should().BeTrue();
+        fileSystem.IsRootDirectory("//").Should().BeTrue();
+        fileSystem.IsRootDirectory("///").Should().BeTrue();
+        fileSystem.IsRootDirectory("/tmp/").Should().BeFalse();
+        fileSystem.IsRootDirectory("/Users/").Should().BeFalse();
     }
 }

--- a/Nitrox.Test/Model/Platforms/OS/Unix/UnixFileSystemTest.cs
+++ b/Nitrox.Test/Model/Platforms/OS/Unix/UnixFileSystemTest.cs
@@ -1,5 +1,4 @@
 using System.Runtime.Versioning;
-using Nitrox.Model.Platforms.OS.Unix;
 using Nitrox.Test.Model.Platforms;
 
 namespace Nitrox.Model.Platforms.OS.Unix;
@@ -33,5 +32,35 @@ public class UnixFileSystemTest
         bool result = fileSystem.SetFullAccessToCurrentUser(fakePath);
 
         result.Should().BeFalse();
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void SetFullAccessToCurrentUser_ShouldReturnFalseForRootDirectory()
+    {
+        // Arrange
+        UnixFileSystem fileSystem = new();
+
+        // Act
+        bool result = fileSystem.SetFullAccessToCurrentUser("/");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void IsRootDirectory_SanityCheck()
+    {
+        // Arrange
+        UnixFileSystem fileSystem = new();
+
+        // Act & Assert
+        fileSystem.IsRootDirectory(null!).Should().BeFalse();
+        fileSystem.IsRootDirectory("").Should().BeFalse();
+        fileSystem.IsRootDirectory(" ").Should().BeFalse();
+        fileSystem.IsRootDirectory("/").Should().BeTrue();
+        fileSystem.IsRootDirectory("//").Should().BeTrue();
+        fileSystem.IsRootDirectory("///").Should().BeTrue();
+        fileSystem.IsRootDirectory("/tmp/").Should().BeFalse();
+        fileSystem.IsRootDirectory("/Users/").Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Description of Change

While bundling an experimental macOS version for a reddit user, I noticed some regressions on the behaviors

* Added safety measures to prevent triggering a recursive chmod on the root directory (`/`), Upon launching Nitrox.app from Finder app, it does trigger SetFullAccessToCurrentUser on the root directory. Causing the page to stop working, and popup permissions flowing on the user screen. (regressed by #2692)
* Removed logic that triggers SetFullAccessToCurrentUser on Nitrox Launcher directory, I'll bump the diagnosis page issue to replace that logic.

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has tests for the changes
- [ ] Has a linked issue
- [x] Has been tested in-game
- [x] Has been tested on macOS

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
