### PR TITLE
Sync and persist Thermal Plant temperature #1979

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -47,6 +47,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
 [ProtoInclude(88, typeof(PrecursorDisableGunTerminalMetadata))]
 [ProtoInclude(89, typeof(OxygenMetadata))]
 [ProtoInclude(90, typeof(BulkheadDoorMetadata))]
+[ProtoInclude(91, typeof(ThermalPlantMetadata))]
 public abstract class EntityMetadata
 {
 

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -46,6 +46,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata
     [ProtoInclude(87, typeof(BlueprintHandTargetMetadata))]
     [ProtoInclude(88, typeof(PrecursorDisableGunTerminalMetadata))]
     [ProtoInclude(89, typeof(OxygenMetadata))]
+    [ProtoInclude(90, typeof(ThermalPlantMetadata))]
     public abstract class EntityMetadata
     {
     }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/ThermalPlantMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/ThermalPlantMetadata.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable]
+[DataContract]
+public class ThermalPlantMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public float Temperature { get; }
+
+    [IgnoreConstructor]
+    protected ThermalPlantMetadata()
+    {
+        // Constructor for serialization. Has to be "protected" for json serialization.
+    }
+
+    public ThermalPlantMetadata(float temperature)
+    {
+        Temperature = temperature;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(ThermalPlantMetadata)} {nameof(Temperature)}: {Temperature}]";
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/EntityMetadataUpdateProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/EntityMetadataUpdateProcessor.cs
@@ -45,6 +45,10 @@ internal sealed class EntityMetadataUpdateProcessor(PlayerManager playerManager,
         {
             PlayerMetadata playerMetadata => ProcessPlayerMetadata(sendingPlayer, entity, playerMetadata),
 
+            // temperature is a ratchet (see ThermalPlant.QueryTemperature's Mathf.Max), so drop stale updates instead of
+            // relaying them: every client near a thermal plant reports the same rise, and only the first one is news
+            ThermalPlantMetadata thermalPlantMetadata => entity.Metadata is not ThermalPlantMetadata currentMetadata || thermalPlantMetadata.Temperature > currentMetadata.Temperature,
+
             // Allow metadata updates from any player by default
             _ => true
         };

--- a/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
@@ -356,6 +356,9 @@ internal sealed class WorldServiceTest
             case BulkheadDoorMetadata metadata when entityAfter.Metadata is BulkheadDoorMetadata metadataAfter:
                 Assert.AreEqual(metadata.Opened, metadataAfter.Opened);
                 break;
+            case ThermalPlantMetadata metadata when entityAfter.Metadata is ThermalPlantMetadata metadataAfter:
+                Assert.AreEqual(metadata.Temperature, metadataAfter.Temperature);
+                break;
             default:
                 Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.Metadata?.GetType().Name} - {entityAfter.Metadata?.GetType().Name}");
                 break;

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/ThermalPlantMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/ThermalPlantMetadataExtractor.cs
@@ -1,0 +1,12 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+public class ThermalPlantMetadataExtractor : EntityMetadataExtractor<ThermalPlant, ThermalPlantMetadata>
+{
+    public override ThermalPlantMetadata Extract(ThermalPlant thermalPlant)
+    {
+        return new(thermalPlant.temperature);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/ThermalPlantMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/ThermalPlantMetadataProcessor.cs
@@ -1,0 +1,20 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class ThermalPlantMetadataProcessor : EntityMetadataProcessor<ThermalPlantMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, ThermalPlantMetadata metadata)
+    {
+        if (!gameObject.TryGetComponent(out ThermalPlant thermalPlant))
+        {
+            Log.Error($"[{nameof(ThermalPlantMetadataProcessor)}] Could not find ThermalPlant component on {gameObject.name}");
+            return;
+        }
+
+        // temperature is a ratchet value in the base game (only ever increases), so we never want to apply a lower value here
+        thermalPlant.temperature = Mathf.Max(thermalPlant.temperature, metadata.Temperature);
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/ThermalPlant_QueryTemperature_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ThermalPlant_QueryTemperature_Patch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Nitrox.Model.DataStructures;
 using NitroxClient.GameLogic;
@@ -19,12 +20,13 @@ public sealed partial class ThermalPlant_QueryTemperature_Patch : NitroxPatch, I
 
     public static void Postfix(ThermalPlant __instance, float __state)
     {
-        // temperature only ever increases (see ThermalPlant.QueryTemperature's Mathf.Max), so this only fires on genuine progress
-        if (__instance.temperature <= __state || !__instance.TryGetNitroxId(out NitroxId entityId))
+        // temperature only ever increases (see ThermalPlant.QueryTemperature's Mathf.Max). Broadcast only once per whole
+        // degree gained: the water temperature creeps toward its daily peak in ever smaller steps, so without this every
+        // nearby client would send a near-duplicate update every QueryTemperature tick. Power output only depends on
+        // Mathf.InverseLerp(25, 100, temperature), so sub-degree changes don't matter.
+        if (Math.Floor(__instance.temperature) > Math.Floor(__state) && __instance.TryGetNitroxId(out NitroxId entityId))
         {
-            return;
+            Resolve<Entities>().EntityMetadataChanged(__instance, entityId);
         }
-
-        Resolve<Entities>().EntityMetadataChanged(__instance, entityId);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/ThermalPlant_QueryTemperature_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/ThermalPlant_QueryTemperature_Patch.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Nitrox.Model.DataStructures;
+using NitroxClient.GameLogic;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Broadcasts and persists <see cref="ThermalPlant.temperature"/> whenever it rises, so thermal plants keep generating
+/// power (and the temperature reached is remembered) across respawns and server restarts instead of resetting to 0.
+/// </summary>
+public sealed partial class ThermalPlant_QueryTemperature_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((ThermalPlant t) => t.QueryTemperature());
+
+    public static void Prefix(ThermalPlant __instance, out float __state)
+    {
+        __state = __instance.temperature;
+    }
+
+    public static void Postfix(ThermalPlant __instance, float __state)
+    {
+        // temperature only ever increases (see ThermalPlant.QueryTemperature's Mathf.Max), so this only fires on genuine progress
+        if (__instance.temperature <= __state || !__instance.TryGetNitroxId(out NitroxId entityId))
+        {
+            return;
+        }
+
+        Resolve<Entities>().EntityMetadataChanged(__instance, entityId);
+    }
+}


### PR DESCRIPTION
Fixes #1979

## Problem

Both symptoms in the issue trace back to the same gap: Nitrox never synced or persisted `ThermalPlant.temperature`, so it always resets to its default (0) whenever the module is (re)spawned — e.g. on a server restart, or (in a live session) whenever the module's GameObject is recreated.

`temperature` is a ratchet value (`Mathf.Max`, only ever goes up) and only crosses the `AddPower()` threshold of 25 once a player has physically loaded the vent's cell (which registers the vent's `EcoTarget` so `WaterTemperatureSimulation.GetTemperature` can apply its heat bonus). Losing the accumulated value on every reload is why the plant stops generating power until someone swims back over and "reloads" the temperature by proximity.

As discussed on the issue with @dartasen, this PR is scoped to the temperature part only. `PowerSource.power` sync/restore is a separate, broader problem (existing `// TODO: Have synced/restored power` in `ModuleEntitySpawner`/`InteriorPieceEntitySpawner`) and is intentionally left untouched here.

## Fix

Added `ThermalPlant.temperature` to Nitrox's existing entity metadata sync/persistence pipeline (same pattern used for `Oxygen`, `FruitPlant`, etc.):

- New `ThermalPlantMetadata` (+ `[ProtoInclude]` entry on `EntityMetadata`).
- New `ThermalPlantMetadataExtractor` / `ThermalPlantMetadataProcessor` (extract on spawn/construction, restore with `Mathf.Max(current, restored)` to preserve the ratchet semantics).
- New Harmony patch on `ThermalPlant.QueryTemperature` that broadcasts an `EntityMetadataUpdate` whenever `temperature` actually increases.

Since `EntityMetadataUpdate` is already persisted server-side (`entity.Metadata`) and re-applied to every client on spawn, this means: the first time any connected player ever swims near a given vent, the resulting temperature gets synced to everyone and survives server restarts — no one needs to revisit the vent again afterwards.

## Residual limitation

A thermal plant whose vent has never been visited by any player since it was built will still start cold until someone visits it once. This is a one-time cold start rather than the recurring "resets every restart" bug, and matches single-player behavior the first time the plant is placed.

## Checklist

- [x] PR rebased on top of master at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [ ] Has been tested in-game
- [ ] Has been tested on Windows/Linux/macOS (for cross-platform code)

🤖 This code was created with the help of AI.
