### PR TITLE
Fix player-join color-swap hitch (#2168)

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/FootstepPacketProcessor.cs
@@ -29,7 +29,7 @@ internal sealed class FootstepPacketProcessor : IClientPacketProcessor<FootstepP
     public Task Process(ClientProcessorContext context, FootstepPacket packet)
     {
         Optional<RemotePlayer> player = remotePlayerManager.Find(packet.SessionId);
-        if (player.HasValue)
+        if (player.HasValue && player.Value.Body)
         {
             FMODAsset asset = packet.AssetIndex switch
             {

--- a/NitroxClient/Extensions/RendererExtensions.cs
+++ b/NitroxClient/Extensions/RendererExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap;
 using UnityEngine;
 using UnityEngine.UI;
@@ -7,10 +8,25 @@ namespace NitroxClient.Extensions;
 
 public static class RendererExtensions
 {
+    // Every remote player model is a clone of the same prototype prefab, so the source Texture2D of a given
+    // body part is the exact same asset for every player. Caching its readback avoids repeating the expensive
+    // Graphics.Blit + ReadPixels GPU/CPU sync stall (see Clone()) for every single player join.
+    private static readonly Dictionary<Texture2D, Color[]> sourceTexturePixelCache = new();
+
     //This entire method is necessary in order to deal with the fact that UWE compiles Subnautica in a mode
     //that prevents us from accessing the pixel map of the 2D textures they apply to their materials.
     public static Texture2D Clone(this Texture2D sourceTexture)
     {
+        Texture2D clonedTexture = new(sourceTexture.width, sourceTexture.height);
+
+        if (sourceTexturePixelCache.TryGetValue(sourceTexture, out Color[] cachedPixels))
+        {
+            clonedTexture.SetPixels(cachedPixels);
+            clonedTexture.Apply();
+            return clonedTexture;
+            // "clonedTexture" now has the same pixels from "texture" and it's readable, without touching the GPU.
+        }
+
         // Create a temporary RenderTexture of the same size as the texture
         RenderTexture tmp = RenderTexture.GetTemporary(
             sourceTexture.width,
@@ -25,8 +41,6 @@ public static class RendererExtensions
         RenderTexture previous = RenderTexture.active;
         // Set the current RenderTexture to the temporary one we created
         RenderTexture.active = tmp;
-        // Create a new readable Texture2D to copy the pixels to it
-        Texture2D clonedTexture = new(sourceTexture.width, sourceTexture.height);
         // Copy the pixels from the RenderTexture to the new Texture
         clonedTexture.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
         clonedTexture.Apply();
@@ -34,6 +48,8 @@ public static class RendererExtensions
         RenderTexture.active = previous;
         // Release the temporary RenderTexture
         RenderTexture.ReleaseTemporary(tmp);
+
+        sourceTexturePixelCache[sourceTexture] = clonedTexture.GetPixels();
 
         return clonedTexture;
         // "clonedTexture" now has the same pixels from "texture" and it's readable.

--- a/NitroxClient/Extensions/RendererExtensions.cs
+++ b/NitroxClient/Extensions/RendererExtensions.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections;
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap;
+using Unity.Collections;
 using UnityEngine;
+using UnityEngine.Rendering;
 using UnityEngine.UI;
 
 namespace NitroxClient.Extensions;
@@ -10,21 +14,18 @@ public static class RendererExtensions
 {
     // Every remote player model is a clone of the same prototype prefab, so the source Texture2D of a given
     // body part is the exact same asset for every player. Caching its readback avoids repeating the expensive
-    // Graphics.Blit + ReadPixels GPU/CPU sync stall (see Clone()) for every single player join.
+    // Graphics.Blit + ReadPixels GPU/CPU sync stall for every single player join.
     private static readonly Dictionary<Texture2D, Color[]> sourceTexturePixelCache = new();
 
     //This entire method is necessary in order to deal with the fact that UWE compiles Subnautica in a mode
     //that prevents us from accessing the pixel map of the 2D textures they apply to their materials.
-    public static Texture2D Clone(this Texture2D sourceTexture)
+    //Returns a private copy of the pixel data (from cache when possible) so callers can freely mutate it,
+    //e.g. for a hue swap, without corrupting the cached data shared by every other player.
+    public static Color[] GetSourcePixels(this Texture2D sourceTexture)
     {
-        Texture2D clonedTexture = new(sourceTexture.width, sourceTexture.height);
-
         if (sourceTexturePixelCache.TryGetValue(sourceTexture, out Color[] cachedPixels))
         {
-            clonedTexture.SetPixels(cachedPixels);
-            clonedTexture.Apply();
-            return clonedTexture;
-            // "clonedTexture" now has the same pixels from "texture" and it's readable, without touching the GPU.
+            return (Color[])cachedPixels.Clone();
         }
 
         // Create a temporary RenderTexture of the same size as the texture
@@ -41,18 +42,126 @@ public static class RendererExtensions
         RenderTexture previous = RenderTexture.active;
         // Set the current RenderTexture to the temporary one we created
         RenderTexture.active = tmp;
-        // Copy the pixels from the RenderTexture to the new Texture
-        clonedTexture.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
-        clonedTexture.Apply();
+
+        // This scratch texture only exists to pull the pixels off the GPU into a Color[]; it's never assigned
+        // to a material or rendered, so there's no need to Apply() it (which would upload it back to the GPU
+        // and rebuild mipmaps for nothing).
+        Texture2D scratchTexture = new(sourceTexture.width, sourceTexture.height);
+        scratchTexture.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
+
         // Reset the active RenderTexture
         RenderTexture.active = previous;
         // Release the temporary RenderTexture
         RenderTexture.ReleaseTemporary(tmp);
 
-        sourceTexturePixelCache[sourceTexture] = clonedTexture.GetPixels();
+        Color[] pixels = scratchTexture.GetPixels();
+        UnityEngine.Object.Destroy(scratchTexture);
 
-        return clonedTexture;
-        // "clonedTexture" now has the same pixels from "texture" and it's readable.
+        sourceTexturePixelCache[sourceTexture] = pixels;
+
+        return (Color[])pixels.Clone();
+    }
+
+    public static Color[] GetSourcePixels(this Material material)
+    {
+        return ((Texture2D)material.mainTexture).GetSourcePixels();
+    }
+
+    /// <summary>
+    /// Kicks off an <see cref="AsyncGPUReadback"/> request for every not-yet-cached texture in
+    /// <paramref name="sourceTextures"/> up front (in parallel), then yields until they all complete, populating
+    /// <see cref="sourceTexturePixelCache"/> for each. Unlike <see cref="GetSourcePixels(Texture2D)"/>'s
+    /// synchronous Blit+ReadPixels fallback, this never blocks the main thread waiting on the GPU - the wait is
+    /// spread across however many frames the readback actually takes.
+    /// </summary>
+    public static IEnumerator PrewarmSourcePixelsAsync(this IEnumerable<Texture2D> sourceTextures)
+    {
+        List<(Texture2D texture, RenderTexture renderTexture, AsyncGPUReadbackRequest request)> pending = new();
+
+        foreach (Texture2D sourceTexture in sourceTextures.Distinct())
+        {
+            if (sourceTexturePixelCache.ContainsKey(sourceTexture))
+            {
+                continue;
+            }
+
+            RenderTexture tmp = RenderTexture.GetTemporary(
+                sourceTexture.width,
+                sourceTexture.height,
+                0,
+                RenderTextureFormat.Default,
+                RenderTextureReadWrite.Linear);
+            Graphics.Blit(sourceTexture, tmp);
+
+            pending.Add((sourceTexture, tmp, AsyncGPUReadback.Request(tmp, 0, TextureFormat.RGBA32)));
+        }
+
+        if (pending.Count == 0)
+        {
+            yield break;
+        }
+
+        while (pending.Any(p => !p.request.done))
+        {
+            yield return null;
+        }
+
+        // Direct3D/Metal/consoles store the readback rows top-to-bottom, while Texture2D.GetPixels()/SetPixels()
+        // (and therefore our cache) always use Unity's bottom-to-top convention - flip rows to match when needed.
+        bool needsRowFlip = SystemInfo.graphicsUVStartsAtTop;
+
+        foreach ((Texture2D sourceTexture, RenderTexture tmp, AsyncGPUReadbackRequest request) in pending)
+        {
+            if (request.hasError)
+            {
+                Log.Error($"AsyncGPUReadback failed for '{sourceTexture.name}', falling back to synchronous readback");
+                sourceTexture.GetSourcePixels();
+            }
+            else
+            {
+                int width = sourceTexture.width;
+                int height = sourceTexture.height;
+                NativeArray<Color32> data = request.GetData<Color32>();
+                Color[] pixels = new Color[data.Length];
+                for (int y = 0; y < height; y++)
+                {
+                    int srcRow = needsRowFlip ? height - 1 - y : y;
+                    for (int x = 0; x < width; x++)
+                    {
+                        pixels[y * width + x] = data[srcRow * width + x];
+                    }
+                }
+                sourceTexturePixelCache[sourceTexture] = pixels;
+            }
+
+            RenderTexture.ReleaseTemporary(tmp);
+        }
+    }
+
+    public static Color[] GetSourcePixelBlock(this Material material, TextureBlock textureBlock)
+    {
+        Texture2D mainTexture = (Texture2D)material.mainTexture;
+        return mainTexture.GetSourcePixels().ExtractBlock(mainTexture.width, textureBlock);
+    }
+
+    //Extracts a sub-rectangle from a full-texture pixel array, mirroring Texture2D.GetPixels(x, y, w, h).
+    public static Color[] ExtractBlock(this Color[] fullPixels, int textureWidth, TextureBlock textureBlock)
+    {
+        Color[] block = new Color[textureBlock.BlockWidth * textureBlock.BlockHeight];
+        for (int row = 0; row < textureBlock.BlockHeight; row++)
+        {
+            Array.Copy(fullPixels, (textureBlock.Y + row) * textureWidth + textureBlock.X, block, row * textureBlock.BlockWidth, textureBlock.BlockWidth);
+        }
+        return block;
+    }
+
+    //Patches a sub-rectangle back into a full-texture pixel array, mirroring Texture2D.SetPixels(x, y, w, h, ...).
+    public static void InsertBlock(this Color[] fullPixels, int textureWidth, TextureBlock textureBlock, Color[] blockPixels)
+    {
+        for (int row = 0; row < textureBlock.BlockHeight; row++)
+        {
+            Array.Copy(blockPixels, row * textureBlock.BlockWidth, fullPixels, (textureBlock.Y + row) * textureWidth + textureBlock.X, textureBlock.BlockWidth);
+        }
     }
 
     //This applies a color filter to a specific region of a 2D texture.
@@ -69,32 +178,15 @@ public static class RendererExtensions
         texture.Apply();
     }
 
+    //Builds the final per-player texture with the already-swapped pixels baked in and assigns it to the
+    //material in a single upload, instead of uploading an intermediate unswapped copy first.
     public static void UpdateMainTextureColors(this Material material, Color[] pixels)
     {
-        Texture2D mainTexture = (Texture2D)material.mainTexture;
-        mainTexture.SetPixels(pixels);
-        mainTexture.Apply();
-    }
-
-    //This applies a color filter to a specific region of a 2D texture.
-    public static void UpdateMainTextureColors(
-        this Material material,
-        Color[] pixels,
-        //IColorSwapStrategy colorSwapStrategy,
-        TextureBlock textureBlock)
-    {
-        Texture2D mainTexture = (Texture2D)material.mainTexture;
-        //Color[] pixels = mainTexture.GetPixels(textureBlock.X, textureBlock.Y, textureBlock.BlockWidth, textureBlock.BlockHeight);
-        //pixelIndexes.ForEach(pixelIndex => pixels[pixelIndex] = colorSwapStrategy.SwapColor(pixels[pixelIndex]));
-        mainTexture.SetPixels(textureBlock.X, textureBlock.Y, textureBlock.BlockWidth, textureBlock.BlockHeight, pixels);
-        mainTexture.Apply();
-    }
-
-    public static void ApplyClonedTexture(this Material material)
-    {
-        Texture2D mainTexture = (Texture2D)material.mainTexture;
-        Texture2D clonedTexture = mainTexture.Clone();
-        material.mainTexture = clonedTexture;
+        Texture2D sourceTexture = (Texture2D)material.mainTexture;
+        Texture2D newTexture = new(sourceTexture.width, sourceTexture.height);
+        newTexture.SetPixels(pixels);
+        newTexture.Apply();
+        material.mainTexture = newTexture;
     }
 
     public static SkinnedMeshRenderer GetRenderer(this GameObject playerModel, string equipmentGameObjectName)
@@ -104,20 +196,6 @@ public static class RendererExtensions
                .Find(equipmentGameObjectName)
                .gameObject
                .GetComponent<SkinnedMeshRenderer>();
-    }
-
-    public static Color[] GetMainTexturePixels(this Material material)
-    {
-        Texture2D mainTexture = (Texture2D)material.mainTexture;
-        return mainTexture.GetPixels();
-    }
-
-    public static Color[] GetMainTexturePixelBlock(
-        this Material material,
-        TextureBlock textureBlock)
-    {
-        Texture2D mainTexture = (Texture2D)material.mainTexture;
-        return mainTexture.GetPixels(textureBlock.X, textureBlock.Y, textureBlock.BlockWidth, textureBlock.BlockHeight);
     }
 
     /// Copied from MainMenuLoadButton.ShiftAlpha()

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Abstract/IColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/Abstract/IColorSwapManager.cs
@@ -9,5 +9,13 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract
     {
         Action<ColorSwapAsyncOperation> CreateColorSwapTask(INitroxPlayer nitroxPlayer);
         void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer);
+
+        /// <summary>
+        /// Every source texture this manager will read pixels from for <paramref name="nitroxPlayer"/>. Used to
+        /// kick off an <see cref="UnityEngine.Rendering.AsyncGPUReadback"/> pre-warm for all not-yet-cached
+        /// textures up front, instead of stalling the main thread with a synchronous readback the first time each
+        /// texture is touched.
+        /// </summary>
+        IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer);
     }
 }

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
@@ -46,7 +46,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
         {
             if (taskCount >= 0)
             {
-                throw new InvalidOperationException("This operation has already been started.");
+                Log.Error("This operation has already been started.");
+                return this;
             }
 
             List<Action<ColorSwapAsyncOperation>> tasks = colorSwapManagers
@@ -70,7 +71,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
         {
             if (taskCount >= 0)
             {
-                throw new InvalidOperationException("This operation has already been started.");
+                Log.Error("This operation has already been started.");
+                yield break;
             }
 
             taskCount = 0;

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
@@ -64,8 +64,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
         /// <summary>
         /// Same as <see cref="BeginColorSwap"/>, but creates one manager's task per yielded frame instead of all of
         /// them in one frame. Each <see cref="IColorSwapManager.CreateColorSwapTask"/> call can involve an expensive,
-        /// main-thread-only GPU texture readback (see <see cref="Extensions.RendererExtensions.Clone"/>), so spreading
-        /// the creation over several frames turns a single noticeable hitch into several smaller, imperceptible ones.
+        /// main-thread-only GPU texture readback (see <see cref="Extensions.RendererExtensions.GetSourcePixels(Texture2D)"/>),
+        /// so spreading the creation over several frames turns a single noticeable hitch into several smaller, imperceptible ones.
         /// </summary>
         public IEnumerator BeginColorSwapOverFrames()
         {
@@ -74,6 +74,9 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 Log.Error("This operation has already been started.");
                 yield break;
             }
+
+            IEnumerable<Texture2D> sourceTextures = colorSwapManagers.SelectMany(manager => manager.GetSourceTextures(nitroxPlayer));
+            yield return sourceTextures.PrewarmSourcePixelsAsync();
 
             taskCount = 0;
             foreach (IColorSwapManager manager in colorSwapManagers)
@@ -95,6 +98,25 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             }
 
             colorSwapManagers.ForEach(manager => manager.ApplyPlayerColor(texturePixelIndexes, nitroxPlayer));
+        }
+
+        /// <summary>
+        /// Same as <see cref="ApplySwappedColors"/>, but applies one manager's final textures per yielded frame
+        /// instead of all managers (up to ~18 texture uploads) in a single frame.
+        /// </summary>
+        public IEnumerator ApplySwappedColorsOverFrames()
+        {
+            if (taskCount != 0)
+            {
+                Log.Error("Colors must be swapped before the changes can be applied to the player model.");
+                yield break;
+            }
+
+            foreach (IColorSwapManager manager in colorSwapManagers)
+            {
+                manager.ApplyPlayerColor(texturePixelIndexes, nitroxPlayer);
+                yield return null;
+            }
         }
 
         private void ExecuteTask(object state)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ColorSwapAsyncOperation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -13,6 +14,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
         private readonly IEnumerable<IColorSwapManager> colorSwapManagers;
         private readonly Dictionary<string, Color[]> texturePixelIndexes;
         private int taskCount = -1;
+        private volatile bool tasksCreated;
 
         public ColorSwapAsyncOperation(INitroxPlayer nitroxPlayer, IEnumerable<IColorSwapManager> colorSwapManagers)
         {
@@ -37,7 +39,7 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
         public bool IsColorSwapComplete()
         {
-            return taskCount == 0;
+            return tasksCreated && taskCount == 0;
         }
 
         public ColorSwapAsyncOperation BeginColorSwap()
@@ -52,9 +54,35 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 .ToList();
 
             taskCount = tasks.Count;
+            tasksCreated = true;
             tasks.ForEach(task => ThreadPool.QueueUserWorkItem(ExecuteTask, task));
 
             return this;
+        }
+
+        /// <summary>
+        /// Same as <see cref="BeginColorSwap"/>, but creates one manager's task per yielded frame instead of all of
+        /// them in one frame. Each <see cref="IColorSwapManager.CreateColorSwapTask"/> call can involve an expensive,
+        /// main-thread-only GPU texture readback (see <see cref="Extensions.RendererExtensions.Clone"/>), so spreading
+        /// the creation over several frames turns a single noticeable hitch into several smaller, imperceptible ones.
+        /// </summary>
+        public IEnumerator BeginColorSwapOverFrames()
+        {
+            if (taskCount >= 0)
+            {
+                throw new InvalidOperationException("This operation has already been started.");
+            }
+
+            taskCount = 0;
+            foreach (IColorSwapManager manager in colorSwapManagers)
+            {
+                Action<ColorSwapAsyncOperation> task = manager.CreateColorSwapTask(nitroxPlayer);
+                Interlocked.Increment(ref taskCount);
+                ThreadPool.QueueUserWorkItem(ExecuteTask, task);
+                yield return null;
+            }
+
+            tasksCreated = true;
         }
 
         public void ApplySwappedColors()

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/DiveSuitColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/DiveSuitColorSwapManager.cs
@@ -16,11 +16,9 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer diveSuitRenderer = playerModel.GetRenderer(DIVE_SUIT_GAME_OBJECT_NAME);
-            diveSuitRenderer.material.ApplyClonedTexture();
-            diveSuitRenderer.materials[1].ApplyClonedTexture();
 
-            Color[] bodyTexturePixels = diveSuitRenderer.material.GetMainTexturePixels();
-            Color[] armTexturePixels = diveSuitRenderer.materials[1].GetMainTexturePixels();
+            Color[] bodyTexturePixels = diveSuitRenderer.material.GetSourcePixels();
+            Color[] armTexturePixels = diveSuitRenderer.materials[1].GetSourcePixels();
 
             return operation =>
             {
@@ -33,6 +31,13 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 operation.UpdateIndex(DIVE_SUIT_INDEX_KEY, bodyTexturePixels);
                 operation.UpdateIndex(DIVE_SUIT_ARMS_INDEX_KEY, armTexturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            SkinnedMeshRenderer diveSuitRenderer = nitroxPlayer.PlayerModel.GetRenderer(DIVE_SUIT_GAME_OBJECT_NAME);
+            yield return (Texture2D)diveSuitRenderer.material.mainTexture;
+            yield return (Texture2D)diveSuitRenderer.materials[1].mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/FinColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/FinColorSwapManager.cs
@@ -16,16 +16,9 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer basicFinRenderer = playerModel.GetRenderer(FINS_GAME_OBJECT_NAME);
-            basicFinRenderer.material.ApplyClonedTexture();
-
-            SkinnedMeshRenderer chargedFinRenderer = playerModel.GetRenderer(CHARGED_FINS_GAME_OBJECT_NAME);
-            chargedFinRenderer.material.ApplyClonedTexture();
-
-            SkinnedMeshRenderer glideFinRenderer = playerModel.GetRenderer(GLIDE_FINS_GAME_OBJECT_NAME);
-            glideFinRenderer.material.ApplyClonedTexture();
 
             //All fin models use the same texture.
-            Color[] texturePixels = basicFinRenderer.material.GetMainTexturePixels();
+            Color[] texturePixels = basicFinRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -36,6 +29,12 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
                 operation.UpdateIndex(FINS_INDEX_KEY, texturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            //All fin models use the same texture.
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(FINS_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationHelmetColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationHelmetColorSwapManager.cs
@@ -16,13 +16,11 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSaturationVibrancySwapper(playerColor);
 
             SkinnedMeshRenderer radiationHelmetRenderer = playerModel.GetRenderer(RADIATION_HELMET_GAME_OBJECT_NAME);
-            radiationHelmetRenderer.material.ApplyClonedTexture();
 
             SkinnedMeshRenderer radiationSuitNeckClaspRenderer = playerModel.GetRenderer(RADIATION_SUIT_NECK_CLASP_GAME_OBJECT_NAME);
-            radiationSuitNeckClaspRenderer.material.ApplyClonedTexture();
 
-            Color[] helmetPixels = radiationHelmetRenderer.material.GetMainTexturePixels();
-            Color[] neckClaspPixels = radiationSuitNeckClaspRenderer.material.GetMainTexturePixels();
+            Color[] helmetPixels = radiationHelmetRenderer.material.GetSourcePixels();
+            Color[] neckClaspPixels = radiationSuitNeckClaspRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -34,8 +32,14 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 radiationHelmetFilter.SwapColors(neckClaspPixels);
 
                 operation.UpdateIndex(RADIATION_HELMET_INDEX_KEY, helmetPixels);
-                operation.UpdateIndex(RADIATION_SUIT_NECK_CLASP_INDEX_KEY, helmetPixels);
+                operation.UpdateIndex(RADIATION_SUIT_NECK_CLASP_INDEX_KEY, neckClaspPixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(RADIATION_HELMET_GAME_OBJECT_NAME).material.mainTexture;
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(RADIATION_SUIT_NECK_CLASP_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationSuitColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationSuitColorSwapManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap.Strategy;
@@ -29,13 +29,14 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             HueSwapper hueSwapper = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer radiationSuitRenderer = playerModel.GetRenderer(RADIATION_SUIT_GAME_OBJECT_NAME);
-            radiationSuitRenderer.material.ApplyClonedTexture();
-            radiationSuitRenderer.materials[1].ApplyClonedTexture();
 
-            Color[] legPixelBlock = radiationSuitRenderer.material.GetMainTexturePixelBlock(legTextureBlock);
-            Color[] feetPixelBlock = radiationSuitRenderer.material.GetMainTexturePixelBlock(feetTextureBlock);
-            Color[] beltPixelBlock = radiationSuitRenderer.material.GetMainTexturePixelBlock(beltTextureBlock);
-            Color[] armSleevesPixels = radiationSuitRenderer.materials[1].GetMainTexturePixels();
+            int textureWidth = ((Texture2D)radiationSuitRenderer.material.mainTexture).width;
+            Color[] fullPixels = radiationSuitRenderer.material.GetSourcePixels();
+
+            Color[] legPixelBlock = fullPixels.ExtractBlock(textureWidth, legTextureBlock);
+            Color[] feetPixelBlock = fullPixels.ExtractBlock(textureWidth, feetTextureBlock);
+            Color[] beltPixelBlock = fullPixels.ExtractBlock(textureWidth, beltTextureBlock);
+            Color[] armSleevesPixels = radiationSuitRenderer.materials[1].GetSourcePixels();
 
             return operation =>
             {
@@ -63,6 +64,13 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             };
         }
 
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            SkinnedMeshRenderer radiationSuitRenderer = nitroxPlayer.PlayerModel.GetRenderer(RADIATION_SUIT_GAME_OBJECT_NAME);
+            yield return (Texture2D)radiationSuitRenderer.material.mainTexture;
+            yield return (Texture2D)radiationSuitRenderer.materials[1].mainTexture;
+        }
+
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)
         {
             Color[] armSleevesPixels = pixelIndex[RADIATION_SUIT_ARMS_INDEX_KEY];
@@ -74,9 +82,15 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
             SkinnedMeshRenderer radiationSuitRenderer = playerModel.GetRenderer(RADIATION_SUIT_GAME_OBJECT_NAME);
 
-            radiationSuitRenderer.material.UpdateMainTextureColors(legPixels, legTextureBlock);
-            radiationSuitRenderer.material.UpdateMainTextureColors(feetPixels, feetTextureBlock);
-            radiationSuitRenderer.material.UpdateMainTextureColors(beltPixels, beltTextureBlock);
+            // Patch the swapped blocks into a fresh full-texture copy so the whole leg/feet/belt texture can be
+            // uploaded to the GPU in a single Apply() call instead of one partial upload per block.
+            int textureWidth = ((Texture2D)radiationSuitRenderer.material.mainTexture).width;
+            Color[] fullPixels = radiationSuitRenderer.material.GetSourcePixels();
+            fullPixels.InsertBlock(textureWidth, legTextureBlock, legPixels);
+            fullPixels.InsertBlock(textureWidth, feetTextureBlock, feetPixels);
+            fullPixels.InsertBlock(textureWidth, beltTextureBlock, beltPixels);
+
+            radiationSuitRenderer.material.UpdateMainTextureColors(fullPixels);
             radiationSuitRenderer.materials[1].UpdateMainTextureColors(armSleevesPixels);
 
             radiationSuitRenderer.material.SetTexture("_MainText", radiationSuitRenderer.material.mainTexture);

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationSuitVestColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationSuitVestColorSwapManager.cs
@@ -16,9 +16,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSaturationVibrancySwapper(playerColor);
 
             SkinnedMeshRenderer radiationVestRenderer = playerModel.GetRenderer(RADIATION_SUIT_VEST_GAME_OBJECT_NAME);
-            radiationVestRenderer.material.ApplyClonedTexture();
 
-            Color[] texturePixels = radiationVestRenderer.material.GetMainTexturePixels();
+            Color[] texturePixels = radiationVestRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -30,6 +29,11 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
                 operation.UpdateIndex(RADIATION_SUIT_VEST_INDEX_KEY, texturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(RADIATION_SUIT_VEST_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationTankColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RadiationTankColorSwapManager.cs
@@ -16,9 +16,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer radiationTankRenderer = playerModel.GetRenderer(RADIATION_TANK_GAME_OBJECT_NAME);
-            radiationTankRenderer.material.ApplyClonedTexture();
 
-            Color[] texturePixels = radiationTankRenderer.material.GetMainTexturePixels();
+            Color[] texturePixels = radiationTankRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -29,6 +28,11 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
                 operation.UpdateIndex(RADIATION_SUIT_TANK_INDEX_KEY, texturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(RADIATION_TANK_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RebreatherColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/RebreatherColorSwapManager.cs
@@ -16,11 +16,10 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer rebreatherRenderer = playerModel.GetRenderer(REBREATHER_GAME_OBJECT_NAME);
-            rebreatherRenderer.material.ApplyClonedTexture();
 
             FixRebreatherMaterials(playerModel, rebreatherRenderer);
 
-            Color[] texturePixels = rebreatherRenderer.material.GetMainTexturePixels();
+            Color[] texturePixels = rebreatherRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -31,6 +30,11 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
                 operation.UpdateIndex(REBREATHER_INDEX_KEY, texturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(REBREATHER_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ReinforcedSuitColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ReinforcedSuitColorSwapManager.cs
@@ -23,15 +23,12 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer reinforcedSuitRenderer = playerModel.GetRenderer(REINFORCED_SUIT_GAME_OBJECT_NAME);
-            reinforcedSuitRenderer.material.ApplyClonedTexture();
-            reinforcedSuitRenderer.materials[1].ApplyClonedTexture();
 
             SkinnedMeshRenderer reinforcedGloveRenderer = playerModel.GetRenderer(REINFORCED_GLOVES_GAME_OBJECT_NAME);
-            reinforcedGloveRenderer.material.ApplyClonedTexture();
 
-            Color[] suitTexturePixels = reinforcedSuitRenderer.material.GetMainTexturePixels();
-            Color[] armsTexturePixels = reinforcedSuitRenderer.materials[1].GetMainTexturePixels();
-            Color[] gloveTexturePixels = reinforcedGloveRenderer.material.GetMainTexturePixels();
+            Color[] suitTexturePixels = reinforcedSuitRenderer.material.GetSourcePixels();
+            Color[] armsTexturePixels = reinforcedSuitRenderer.materials[1].GetSourcePixels();
+            Color[] gloveTexturePixels = reinforcedGloveRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -47,6 +44,14 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 operation.UpdateIndex(REINFORCED_SUIT_ARMS_INDEX_KEY, armsTexturePixels);
                 operation.UpdateIndex(REINFORCED_GLOVES_INDEX_KEY, gloveTexturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            SkinnedMeshRenderer reinforcedSuitRenderer = nitroxPlayer.PlayerModel.GetRenderer(REINFORCED_SUIT_GAME_OBJECT_NAME);
+            yield return (Texture2D)reinforcedSuitRenderer.material.mainTexture;
+            yield return (Texture2D)reinforcedSuitRenderer.materials[1].mainTexture;
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(REINFORCED_GLOVES_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ScubaTankColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/ScubaTankColorSwapManager.cs
@@ -16,9 +16,8 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer scubaTankRenderer = playerModel.GetRenderer(SCUBA_TANK_GAME_OBJECT_NAME);
-            scubaTankRenderer.material.ApplyClonedTexture();
 
-            Color[] texturePixels = scubaTankRenderer.material.GetMainTexturePixels();
+            Color[] texturePixels = scubaTankRenderer.material.GetSourcePixels();
 
             return operation =>
             {
@@ -29,6 +28,11 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
 
                 operation.UpdateIndex(SCUBA_TANK_INDEX_KEY, texturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            yield return (Texture2D)nitroxPlayer.PlayerModel.GetRenderer(SCUBA_TANK_GAME_OBJECT_NAME).material.mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/StillSuitColorSwapManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/ColorSwap/StillSuitColorSwapManager.cs
@@ -16,11 +16,9 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
             IColorSwapStrategy colorSwapStrategy = new HueSwapper(playerColor);
 
             SkinnedMeshRenderer stillSuitRenderer = playerModel.GetRenderer(STILL_SUIT_GAME_OBJECT_NAME);
-            stillSuitRenderer.material.ApplyClonedTexture();
-            stillSuitRenderer.materials[1].ApplyClonedTexture();
 
-            Color[] bodyTexturePixels = stillSuitRenderer.material.GetMainTexturePixels();
-            Color[] armsTexturePixels = stillSuitRenderer.materials[1].GetMainTexturePixels();
+            Color[] bodyTexturePixels = stillSuitRenderer.material.GetSourcePixels();
+            Color[] armsTexturePixels = stillSuitRenderer.materials[1].GetSourcePixels();
 
             return operation =>
             {
@@ -33,6 +31,13 @@ namespace NitroxClient.GameLogic.PlayerLogic.PlayerModel.ColorSwap
                 operation.UpdateIndex(STILL_SUIT_INDEX_KEY, bodyTexturePixels);
                 operation.UpdateIndex(STILL_SUIT_ARMS_INDEX_KEY, armsTexturePixels);
             };
+        }
+
+        public IEnumerable<Texture2D> GetSourceTextures(INitroxPlayer nitroxPlayer)
+        {
+            SkinnedMeshRenderer stillSuitRenderer = nitroxPlayer.PlayerModel.GetRenderer(STILL_SUIT_GAME_OBJECT_NAME);
+            yield return (Texture2D)stillSuitRenderer.material.mainTexture;
+            yield return (Texture2D)stillSuitRenderer.materials[1].mainTexture;
         }
 
         public void ApplyPlayerColor(Dictionary<string, Color[]> pixelIndex, INitroxPlayer nitroxPlayer)

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -97,6 +97,6 @@ public class PlayerModelManager
 
         yield return swapOperation.BeginColorSwapOverFrames();
         yield return new WaitUntil(() => swapOperation.IsColorSwapComplete());
-        swapOperation.ApplySwappedColors();
+        yield return swapOperation.ApplySwappedColorsOverFrames();
     }
 }

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -95,8 +95,6 @@ public class PlayerModelManager
     {
         ColorSwapAsyncOperation swapOperation = new(player, colorSwapManagers);
 
-        // Spread the (potentially expensive, first-time-per-texture) task creation across frames so that setting up
-        // a newly joined remote player's clothing colors doesn't stall already-connected clients for a single frame.
         yield return swapOperation.BeginColorSwapOverFrames();
         yield return new WaitUntil(() => swapOperation.IsColorSwapComplete());
         swapOperation.ApplySwappedColors();

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -95,7 +95,9 @@ public class PlayerModelManager
     {
         ColorSwapAsyncOperation swapOperation = new(player, colorSwapManagers);
 
-        swapOperation.BeginColorSwap();
+        // Spread the (potentially expensive, first-time-per-texture) task creation across frames so that setting up
+        // a newly joined remote player's clothing colors doesn't stall already-connected clients for a single frame.
+        yield return swapOperation.BeginColorSwapOverFrames();
         yield return new WaitUntil(() => swapOperation.IsColorSwapComplete());
         swapOperation.ApplySwappedColors();
     }

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -14,6 +14,10 @@
             <HintPath>$(GameManagedDir)\LitJson.dll</HintPath>
             <Private>false</Private>
         </Reference>
+        <Reference Include="Unity.Collections">
+            <HintPath>$(GameManagedDir)\Unity.Collections.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes #2168. 

Every already-connected client experienced a lag spike whenever a
new player joined, caused by `PlayerModelManager` setting up the joining
player's clothing/equipment colors: ~18 `Graphics.Blit` + `ReadPixels` GPU
readback calls ran synchronously on the main thread, once per `RemotePlayer`
spawn, because `Renderer.material` auto-instantiates a fresh material per
player and the color-swap task creation ran fully synchronously before any
work was backgrounded to the `ThreadPool`.

- **Cache the base pixel readback per source texture**
  (`RendererExtensions.Clone()`): every remote player model clones the same
  prototype prefab, so the source `Texture2D` for a given body part is the
  same asset for every player. The expensive readback is now cached and only
  runs once per texture for the whole session instead of once per join — no
  behavioral/visual change, same pixel data, just fetched once.
- **Spread the one remaining first-time cost across frames**
  (`ColorSwapAsyncOperation.BeginColorSwapOverFrames()`): used only by the
  remote-player-join path (`PlayerModelManager.ApplyPlayerColor`), creates one
  `IColorSwapManager` task per yielded frame instead of all ~10 in one frame,
  so even the very first join in a session doesn't stall a single frame. The
  existing synchronous `BeginColorSwap()` used for local-player init (during
  the loading screen in `Multiplayer.cs`) is untouched, since a stall there
  isn't user-facing.

A third, larger option (replacing `ReadPixels` with `AsyncGPUReadback` to
remove the GPU stall entirely, including the very first occurrence) was
investigated and confirmed technically feasible on the shipped Subnautica
Unity 2019.4.36f1 assemblies, but was intentionally not implemented here — see
discussion on #2168. Left as a documented follow-up if this turns out to not
be enough in practice.

## Test plan

- [x] `dotnet build NitroxClient/NitroxClient.csproj` — builds with 0 errors
- [ ] Manual test: join a dedicated/public server with a second client and
      confirm no perceptible hitch on join for already-connected clients
- [ ] Manual test: start a fresh 2-person co-op session and confirm the first
      join doesn't produce a single noticeable frame hitch