### PR TITLE
Fixed log file location while logging in wine

### DIFF
--- a/Nitrox.Model/Constants/NitroxConstants.cs
+++ b/Nitrox.Model/Constants/NitroxConstants.cs
@@ -2,6 +2,11 @@ namespace Nitrox.Model.Constants;
 
 public static class NitroxConstants
 {
+    /// <summary>
+    ///     The environment variable used for storing the home directory of the logged in operating system user.
+    /// </summary>
+    public const string HOST_HOME_ENV_VAR_NAME = "NITROX_HOST_HOME";
+
     public const string LAUNCHER_APP_NAME = "Nitrox.Launcher";
     public const string PLAYER_NAME_VALID_REGEX = @"^[ a-zA-Z0-9._-]{3,25}$";
 }

--- a/Nitrox.Model/Core/NitroxEnvironment.cs
+++ b/Nitrox.Model/Core/NitroxEnvironment.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Nitrox.Model.Platforms.OS.Windows.Internal;
 
 namespace Nitrox.Model.Core;
 
@@ -13,9 +14,8 @@ public static class NitroxEnvironment
 {
     private static bool hasSet;
     private static Assembly? executingAssembly;
-
     private static string? appName;
-
+    private static bool? isWine;
     private static Assembly ExecutingAssembly => executingAssembly ??= Assembly.GetExecutingAssembly();
     public static string ReleasePhase => IsReleaseMode ? "Alpha" : "InDev";
     public static Version Version => ExecutingAssembly.GetName().Version ?? new Version(1, 0);
@@ -141,6 +141,28 @@ public static class NitroxEnvironment
     }
 
     public static string AppName => appName ??= (Assembly.GetEntryAssembly()?.GetName().Name ?? Assembly.GetCallingAssembly().GetName().Name)?.Replace(".", " ") ?? "Nitrox Program";
+
+    /// <summary>
+    ///     Returns true if executing in a Wine environment.
+    /// </summary>
+    public static bool IsWine
+    {
+        get
+        {
+            if (isWine.HasValue)
+            {
+                return isWine.Value;
+            }
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                isWine = false;
+                return false;
+            }
+
+            isWine = !string.IsNullOrWhiteSpace(Win32Native.GetWineVersion());
+            return isWine.Value;
+        }
+    }
 
     public static string DotnetEnvironment
     {

--- a/Nitrox.Model/Helper/NitroxDirectory.cs
+++ b/Nitrox.Model/Helper/NitroxDirectory.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Core;
 
 namespace Nitrox.Model.Helper;
@@ -33,7 +34,7 @@ public static class NitroxDirectory
 
     static NitroxDirectory()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || NitroxEnvironment.IsWine)
         {
             implementation = new NitroxDirectoryUnix();
         }
@@ -61,10 +62,11 @@ public static class NitroxDirectory
                     return field;
                 }
 
-                string homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-                if (string.IsNullOrWhiteSpace(homePath))
+                // Environment variable is checked first in case user wants to override for the current process.
+                string homePath = Environment.GetEnvironmentVariable("HOME");
+                if (!Directory.Exists(homePath) || !Path.IsPathRooted(homePath))
                 {
-                    homePath = Environment.GetEnvironmentVariable("HOME");
+                    homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 }
                 if (!Directory.Exists(homePath))
                 {
@@ -75,31 +77,6 @@ public static class NitroxDirectory
                     throw new InvalidOperationException("User home directory is not given by the operating system");
                 }
                 return field = homePath;
-            }
-        }
-
-        protected string? WineHomePath
-        {
-            get
-            {
-                if (field != null)
-                {
-                    return field;
-                }
-
-                // On Linux + Wine: Environment.SpecialFolder.ApplicationData returns the Windows version, this bypasses that behaviour
-                string homeInWineEnv = Environment.GetEnvironmentVariable("WINEHOMEDIR");
-                if (homeInWineEnv is { Length: > 4 })
-                {
-                    string homeInWine = homeInWineEnv[4..]; // WINEHOMEDIR is prefixed with \??\
-                    if (Directory.Exists(homeInWine))
-                    {
-                        homeInWine = Path.Combine(homeInWine, ".config", "Nitrox");
-                        Directory.CreateDirectory(homeInWine); // Create it if it's not there (which should not happen in normal setups)
-                        return field = homeInWine;
-                    }
-                }
-                return field = null;
             }
         }
 
@@ -146,11 +123,6 @@ public static class NitroxDirectory
                     return field;
                 }
 
-                if (WineHomePath is { } winePath)
-                {
-                    Directory.CreateDirectory(winePath);
-                    return field = GetAsNitroxPath(WineHomePath);
-                }
                 if (UserSpecifiedDataPath is { } userPath)
                 {
                     Directory.CreateDirectory(userPath);
@@ -158,7 +130,6 @@ public static class NitroxDirectory
                 }
 
                 string? applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-
                 // Finalize path to end with "Nitrox".
                 applicationData = GetAsNitroxPath(applicationData);
                 Directory.CreateDirectory(applicationData);
@@ -190,6 +161,41 @@ public static class NitroxDirectory
     /// </summary>
     private class NitroxDirectoryUnix : NitroxDirectoryShared
     {
+        public override string HomePath
+        {
+            get
+            {
+                if (field != null)
+                {
+                    return field;
+                }
+
+                if (NitroxEnvironment.IsWine)
+                {
+                    string? result = Environment.GetEnvironmentVariable(NitroxConstants.HOST_HOME_ENV_VAR_NAME);
+                    result ??= NitroxEnvironment.CommandLineArgs.GetCommandArgs($"--{NitroxConstants.HOST_HOME_ENV_VAR_NAME.ToLower().Replace('_', '-')}").FirstOrDefault();
+                    result = result?.Replace('/', '\\');
+                    if (result is { Length: >= 2 })
+                    {
+                        if (char.IsLetter(result[0]) && result[1] == ':')
+                        {
+                            result = $"Z{result[1..]}";
+                        }
+                        else
+                        {
+                            result = $"Z:{result}";
+                        }
+                    }
+                    if (Directory.Exists(result) && Path.IsPathRooted(result))
+                    {
+                        return field = result;
+                    }
+                }
+
+                return field = base.HomePath;
+            }
+    }
+
         public override string ConfigPath
         {
             get
@@ -274,7 +280,7 @@ public static class NitroxDirectory
             }
         }
 
-        protected virtual string GetXdgPath(XdgDirectory directory) =>
+        protected virtual string GetXdgDefaultPath(XdgDirectory directory) =>
             directory switch
             {
                 XdgDirectory.DATA => Path.Combine(HomePath, ".local", "share"),
@@ -286,12 +292,6 @@ public static class NitroxDirectory
 
         private string GetXdgPathIfNotWineOrUserGiven(XdgDirectory directory, params string[] folderNames)
         {
-            if (WineHomePath is { } winePath)
-            {
-                winePath = Path.Combine([GetAsNitroxPath(winePath), ..folderNames]);
-                Directory.CreateDirectory(winePath);
-                return winePath;
-            }
             if (UserSpecifiedDataPath is { } userPath)
             {
                 userPath = Path.Combine([userPath, ..folderNames]);
@@ -304,7 +304,7 @@ public static class NitroxDirectory
             {
                 return xdgPath;
             }
-            xdgPath = GetXdgPath(directory);
+            xdgPath = GetXdgDefaultPath(directory);
             xdgPath = Path.Combine([GetAsNitroxPath(xdgPath), ..folderNames]);
             Directory.CreateDirectory(xdgPath);
             return xdgPath;
@@ -331,7 +331,7 @@ public static class NitroxDirectory
 
     private class NitroxDirectoryMacOS : NitroxDirectoryUnix
     {
-        protected override string GetXdgPath(XdgDirectory directory) =>
+        protected override string GetXdgDefaultPath(XdgDirectory directory) =>
             directory switch
             {
                 XdgDirectory.DATA => Path.Combine(HomePath, "Library", "Application Support"),

--- a/Nitrox.Model/Platforms/OS/Windows/Internal/Win32Native.cs
+++ b/Nitrox.Model/Platforms/OS/Windows/Internal/Win32Native.cs
@@ -4,10 +4,10 @@ using System.Text;
 
 namespace Nitrox.Model.Platforms.OS.Windows.Internal;
 
-internal static class Win32Native
+internal static partial class Win32Native
 {
     /// <summary>
-    /// https://learn.microsoft.com/en-us/windows/win32/shell/assocf_str
+    ///     https://learn.microsoft.com/en-us/windows/win32/shell/assocf_str
     /// </summary>
     [Flags]
     public enum AssocF : uint
@@ -99,6 +99,18 @@ internal static class Win32Native
     public static bool IsTrusted(string fileName)
     {
         return WinVerifyTrust(fileName) == 0;
+    }
+
+    public static string GetWineVersion()
+    {
+        try
+        {
+            return WineGetVersion();
+        }
+        catch (Exception)
+        {
+            return "";
+        }
     }
 
     private static uint WinVerifyTrust(string fileName)
@@ -237,6 +249,15 @@ internal static class Win32Native
     [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
     internal static extern IntPtr SetWindowLongPtr64(HandleRef hWnd, int nIndex, long dwNewLong);
 
+    [return: MarshalAs(UnmanagedType.LPTStr)]
+#if NET
+    [LibraryImport("ntdll.dll", EntryPoint = "wine_get_version")]
+    private static partial string WineGetVersion();
+#else
+    [DllImport("ntdll.dll", EntryPoint = "wine_get_version")]
+    private static extern string WineGetVersion();
+#endif
+
     [Flags]
     public enum WS : long
     {
@@ -359,10 +380,7 @@ internal static class Win32Native
 
         public static implicit operator IntPtr(UnmanagedPointer ptr) => ptr.m_ptr;
 
-        ~UnmanagedPointer()
-        {
-            Dispose(false);
-        }
+        public void Dispose() => Dispose(true);
 
         private void Dispose(bool disposing)
         {
@@ -387,6 +405,9 @@ internal static class Win32Native
             }
         }
 
-        public void Dispose() => Dispose(true);
+        ~UnmanagedPointer()
+        {
+            Dispose(false);
+        }
     }
 }

--- a/Nitrox.Model/Platforms/Store/Discord.cs
+++ b/Nitrox.Model/Platforms/Store/Discord.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
 using Nitrox.Model.Platforms.OS.Shared;
@@ -24,7 +25,7 @@ public sealed class Discord : IGamePlatform
         return await Task.FromResult(
             ProcessEx.Start(
                 pathToGameExe,
-                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
+                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath), (NitroxConstants.HOST_HOME_ENV_VAR_NAME, NitroxDirectory.HomePath)],
                 Path.GetDirectoryName(pathToGameExe),
                 launchArguments
             )

--- a/Nitrox.Model/Platforms/Store/EpicGames.cs
+++ b/Nitrox.Model/Platforms/Store/EpicGames.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
 using Nitrox.Model.Platforms.OS.Shared;
@@ -35,7 +36,7 @@ public sealed class EpicGames : IGamePlatform
         return await Task.FromResult(
             ProcessEx.Start(
                 pathToGameExe,
-                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
+                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath), (NitroxConstants.HOST_HOME_ENV_VAR_NAME, NitroxDirectory.HomePath)],
                 Path.GetDirectoryName(pathToGameExe),
                 $"-EpicPortal -epicuserid=0 {launchArguments}")
         );

--- a/Nitrox.Model/Platforms/Store/HeroicGames.cs
+++ b/Nitrox.Model/Platforms/Store/HeroicGames.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.InstallationFinders;
 using Nitrox.Model.Platforms.Discovery.InstallationFinders.Core;
@@ -73,6 +74,7 @@ public sealed class HeroicGames : IGamePlatform
             startInfo = new ProcessStartInfo("xdg-open", $"\"{launchCmd}\"");
         }
         startInfo.Environment.Add(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath);
+        startInfo.Environment.Add(NitroxConstants.HOST_HOME_ENV_VAR_NAME, NitroxDirectory.HomePath);
 
         Log.Info($"Starting game with heroic uri: {startInfo.FileName} {startInfo.Arguments}");
         return await Task.FromResult(ProcessEx.From(startInfo));

--- a/Nitrox.Model/Platforms/Store/Standalone.cs
+++ b/Nitrox.Model/Platforms/Store/Standalone.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.OS.Shared;
 
@@ -12,7 +13,7 @@ public static class Standalone
         return Task.FromResult(
             ProcessEx.Start(
                 pathToGameExe,
-                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath)],
+                [(NitroxUser.LAUNCHER_PATH_ENV_KEY, NitroxUser.LauncherPath), (NitroxConstants.HOST_HOME_ENV_VAR_NAME, NitroxDirectory.HomePath)],
                 Path.GetDirectoryName(pathToGameExe),
                 launchArguments
             )

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Helper;
 using Nitrox.Model.Platforms.Discovery.Models;
 using Nitrox.Model.Platforms.OS.Shared;
@@ -269,7 +270,7 @@ public sealed class Steam : IGamePlatform
         // Start game through Steam so Steam Overlay loads properly. TODO: HACK - this way should be removed if we add a call SteamAPI_Init before Unity Engine shows graphics, see https://partner.steamgames.com/doc/features/overlay.
         if (!skipSteam)
         {
-            args = $@"-applaunch {steamAppId} --nitrox ""{launcherPath}"" {args}";
+            args = $@"-applaunch {steamAppId} --nitrox ""{launcherPath}"" --{NitroxConstants.HOST_HOME_ENV_VAR_NAME.ToLower().Replace('_', '-')} ""{NitroxDirectory.HomePath}"" {args}";
             if (bigPictureMode)
             {
                 // Keep Steam client minimized but active in background to maintain overlay functionality
@@ -293,6 +294,7 @@ public sealed class Steam : IGamePlatform
             EnvironmentVariables =
             {
                 [NitroxUser.LAUNCHER_PATH_ENV_KEY] = launcherPath,
+                [NitroxConstants.HOST_HOME_ENV_VAR_NAME] = NitroxDirectory.HomePath,
                 ["SteamGameId"] = steamAppId.ToString(),
                 ["SteamAppId"] = steamAppId.ToString(), // Primary Steam API var
                 ["STEAM_OVERLAY"] = "1", // Force enable Steam overlay

--- a/Nitrox.Test/Model/ExtensionsTests.cs
+++ b/Nitrox.Test/Model/ExtensionsTests.cs
@@ -93,6 +93,7 @@ public class ExtensionsTest
         new[] { "blabla", "--other=test", "--nitrox", @"C:\a\path" }.GetCommandArgs("--other").Should().BeEquivalentTo("test");
         new[] { "blabla", "--other=test", "other2", "--nitrox", @"C:\a\path" }.GetCommandArgs("--other").Should().BeEquivalentTo("test");
         new[] { "blabla", "--other", "test", "other2", "--nitrox", @"C:\a\path" }.GetCommandArgs("--other").Should().BeEquivalentTo("test", "other2");
+        new[] { "blabla", "--other", "test", "other2", "--nitrox-host-home", "/home/steamuser" }.GetCommandArgs("--nitrox-host-home").Should().BeEquivalentTo("/home/steamuser");
     }
 
     [Flags]

--- a/NitroxClient/MonoBehaviours/Discord/DiscordClient.cs
+++ b/NitroxClient/MonoBehaviours/Discord/DiscordClient.cs
@@ -40,7 +40,7 @@ public class DiscordClient : MonoBehaviour
             return;
         }
 
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINEPREFIX"))) // Is wine environment
+        if (NitroxEnvironment.IsWine)
         {
             Log.Warn("[Discord] Unable to start RPC inside wine environment");
             return;


### PR DESCRIPTION
Passed `NITROX_HOST_HOME` and `--nitrox-host-home <path>` to game process so that logs can be written to home of OS user instead of wine home user.

This should be tested on Windows if game still loads as normal and not throws an error in player.log.