### PR TITLE
Fix VS Code launch config JSON

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,6 @@
             "osx": {
                 "program": "${workspaceFolder}/Nitrox.Server.Subnautica/bin/Debug/net10.0/Nitrox.Server.Subnautica"
             }
-        },
+        }
     ]
 }


### PR DESCRIPTION
## Summary
- remove the trailing comma from `.vscode/launch.json` so it parses as standard JSON
- keep the existing launch configurations unchanged

## Validation
- `for f in .vscode/*.json; do jq empty "$f"; done`
- `git diff --check`

<!-- 🤖 This code was created with the help of AI. -->