### PR TITLE
Removed protobuf save option from server

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,6 +15,20 @@
         </ItemGroup>
     </Target>
 
+    <!-- Allows for weak project references (these are references without code access but will copy files) -->
+    <Target Name="SetModuleReferencesAsPrivate"
+            AfterTargets="AssignProjectConfiguration"
+            BeforeTargets="ResolveProjectReferences">
+        <ItemGroup>
+            <ProjectReferenceWithConfiguration
+                Condition="%(ProjectReferenceWithConfiguration.IsWeakReference) == 'true'">
+                <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+                <OutputItemType>Content</OutputItemType>
+                <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            </ProjectReferenceWithConfiguration>
+        </ItemGroup>
+    </Target>
+
     <Target Name="_NitroxEmbedAssemblyInfo" AfterTargets="GetAssemblyAttributes" DependsOnTargets="PrepareForBuild;_CreateGitShortHashCacheFile">
         <PropertyGroup>
             <_GitShortHash Condition="'$(_GitShortHash)' == '' and Exists('$(_GitShortHashFilePath)')">$([System.IO.File]::ReadAllText('$(_GitShortHashFilePath)').Trim())</_GitShortHash>

--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -17,6 +17,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Nitrox.Launcher.Models.Exceptions;
 using Nitrox.Model.Configuration;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures.GameLogic;
 using Nitrox.Model.Helper;
@@ -160,9 +161,8 @@ internal sealed partial class ServerEntry : ObservableObject
         Directory.CreateDirectory(saveDir);
 
         SubnauticaServerOptions config = NitroxConfig.Load<SubnauticaServerOptions>(saveDir);
-        string fileEnding = ".json";
 
-        await File.WriteAllTextAsync(Path.Combine(saveDir, $"Version{fileEnding}"), (string?)null);
+        await File.WriteAllTextAsync(Path.Combine(saveDir, $"Version{NitroxConstants.SAVE_FILE_ENDING}"), (string?)null);
         config.GameMode = saveGameMode;
         NitroxConfig.CreateFile(saveDir, config);
 
@@ -210,9 +210,8 @@ internal sealed partial class ServerEntry : ObservableObject
         }
 
         SubnauticaServerOptions config = NitroxConfig.Load<SubnauticaServerOptions>(saveDir);
-        string fileEnding = ".json";
 
-        string saveFileVersion = Path.Combine(saveDir, $"Version{fileEnding}");
+        string saveFileVersion = Path.Combine(saveDir, $"Version{NitroxConstants.SAVE_FILE_ENDING}");
         if (!File.Exists(saveFileVersion))
         {
             Log.Warn($"Tried loading invalid save directory at '{saveDir}', Version file is missing");
@@ -253,15 +252,15 @@ internal sealed partial class ServerEntry : ObservableObject
         AllowCommands = !config.DisableConsole;
         AllowPvP = config.PvpEnabled;
         AllowKeepInventory = config.KeepInventoryOnDeath;
-        IsNewServer = !File.Exists(Path.Combine(saveDir, $"PlayerData{fileEnding}"));
+        IsNewServer = !File.Exists(Path.Combine(saveDir, $"PlayerData{NitroxConstants.SAVE_FILE_ENDING}"));
         Version = serverVersion;
-        LastAccessedTime = File.GetLastWriteTime(File.Exists(Path.Combine(saveDir, $"PlayerData{fileEnding}"))
+        LastAccessedTime = File.GetLastWriteTime(File.Exists(Path.Combine(saveDir, $"PlayerData{NitroxConstants.SAVE_FILE_ENDING}"))
                                                      ?
                                                      // This file is affected by server saving
-                                                     Path.Combine(saveDir, $"PlayerData{fileEnding}")
+                                                     Path.Combine(saveDir, $"PlayerData{NitroxConstants.SAVE_FILE_ENDING}")
                                                      :
                                                      // If the above file doesn't exist (server was never ran), use the Version file instead
-                                                     Path.Combine(saveDir, $"Version{fileEnding}"));
+                                                     Path.Combine(saveDir, $"Version{NitroxConstants.SAVE_FILE_ENDING}"));
         return true;
     }
 

--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -23,8 +23,6 @@ using Nitrox.Model.Helper;
 using Nitrox.Model.Logger;
 using Nitrox.Model.Platforms.OS.Shared;
 using Nitrox.Model.Serialization;
-using Nitrox.Model.Server;
-using Nitrox.Server.Subnautica.Models.Serialization;
 
 namespace Nitrox.Launcher.Models.Design;
 
@@ -162,12 +160,7 @@ internal sealed partial class ServerEntry : ObservableObject
         Directory.CreateDirectory(saveDir);
 
         SubnauticaServerOptions config = NitroxConfig.Load<SubnauticaServerOptions>(saveDir);
-        string fileEnding = config.SerializerMode switch
-        {
-            ServerSerializerMode.JSON => ServerJsonSerializer.FILE_ENDING,
-            ServerSerializerMode.PROTOBUF => ServerProtoBufSerializer.FILE_ENDING,
-            _ => throw new NotImplementedException()
-        };
+        string fileEnding = ".json";
 
         await File.WriteAllTextAsync(Path.Combine(saveDir, $"Version{fileEnding}"), (string?)null);
         config.GameMode = saveGameMode;
@@ -217,12 +210,7 @@ internal sealed partial class ServerEntry : ObservableObject
         }
 
         SubnauticaServerOptions config = NitroxConfig.Load<SubnauticaServerOptions>(saveDir);
-        string fileEnding = config.SerializerMode switch
-        {
-            ServerSerializerMode.JSON => ServerJsonSerializer.FILE_ENDING,
-            ServerSerializerMode.PROTOBUF => ServerProtoBufSerializer.FILE_ENDING,
-            _ => throw new NotImplementedException()
-        };
+        string fileEnding = ".json";
 
         string saveFileVersion = Path.Combine(saveDir, $"Version{fileEnding}");
         if (!File.Exists(saveFileVersion))
@@ -234,26 +222,16 @@ internal sealed partial class ServerEntry : ObservableObject
         Version serverVersion;
         await using (FileStream stream = new(saveFileVersion, FileMode.Open, FileAccess.Read, FileShare.Read))
         {
-            switch (config.SerializerMode)
+            SaveFileVersion versionModel;
+            try
             {
-                case ServerSerializerMode.JSON:
-                    SaveFileVersion versionModel;
-                    try
-                    {
-                        versionModel = JsonSerializer.Deserialize<SaveFileVersion>(stream);
-                    }
-                    catch (Exception)
-                    {
-                        versionModel = new SaveFileVersion(NitroxEnvironment.Version);
-                    }
-                    serverVersion = versionModel.Version;
-                    break;
-                case ServerSerializerMode.PROTOBUF:
-                    serverVersion = new ServerProtoBufSerializer(null).Deserialize<SaveFileVersion>(stream)?.Version ?? NitroxEnvironment.Version;
-                    break;
-                default:
-                    throw new NotImplementedException();
+                versionModel = JsonSerializer.Deserialize<SaveFileVersion>(stream);
             }
+            catch (Exception)
+            {
+                versionModel = new SaveFileVersion(NitroxEnvironment.Version);
+            }
+            serverVersion = versionModel.Version;
         }
 
         string prevName = Name;

--- a/Nitrox.Launcher/Nitrox.Launcher.csproj
+++ b/Nitrox.Launcher/Nitrox.Launcher.csproj
@@ -67,8 +67,9 @@
 
     <!-- Project references not to be code-linked with app, but are used by app as content files. See https://github.com/dotnet/msbuild/issues/4795#issuecomment-1443879474  -->
     <ItemGroup>
-        <!-- TODO: Fix server project reference so there's no code access (launcher should never call server exe code). -->
-        <ProjectReference Include="..\Nitrox.Server.Subnautica\Nitrox.Server.Subnautica.csproj" />
+        <ProjectReference Include="..\Nitrox.Server.Subnautica\Nitrox.Server.Subnautica.csproj" >
+            <IsWeakReference>true</IsWeakReference>
+        </ProjectReference>
         <ProjectReference Include="..\NitroxPatcher\NitroxPatcher.csproj">
             <Name>NitroxPatcher472</Name>
             <SetTargetFramework>TargetFramework=net472</SetTargetFramework>

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -32,7 +32,7 @@ internal partial class ManageServerViewModel : RoutableViewModelBase
     private readonly string[] advancedSettingsDeniedFields =
     [
         "password", "filename", nameof(Config.ServerPort), nameof(Config.MaxConnections), nameof(Config.PortForward), nameof(Config.SaveInterval), nameof(Config.Seed), nameof(Config.GameMode), nameof(Config.DisableConsole),
-        nameof(Config.LanDiscovery), nameof(Config.DefaultPlayerPerm), nameof(Config.KeepInventoryOnDeath), nameof(Config.PvpEnabled), nameof(Config.SerializerMode)
+        nameof(Config.LanDiscovery), nameof(Config.DefaultPlayerPerm), nameof(Config.KeepInventoryOnDeath), nameof(Config.PvpEnabled)
     ];
 
     private readonly DialogService dialogService;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/NitroxTechType.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/NitroxTechType.cs
@@ -11,8 +11,6 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic;
 /// <remarks>
 ///     Shim tech type model to bridge the gap between original subnautica and BZ.
 /// </remarks>
-[Serializable]
-[DataContract]
 public class NitroxTechType : IEquatable<NitroxTechType>
 {
     [DataMember(Order = 1)]
@@ -29,14 +27,14 @@ public class NitroxTechType : IEquatable<NitroxTechType>
         Name = name;
     }
 
-    public static NitroxTechType None { get; } = new NitroxTechType("None");
+    public static NitroxTechType None { get; } = new("None");
 
     public override string ToString()
     {
         return Name;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
         {
@@ -56,7 +54,7 @@ public class NitroxTechType : IEquatable<NitroxTechType>
         return Equals((NitroxTechType)obj);
     }
 
-    public bool Equals(NitroxTechType other)
+    public bool Equals(NitroxTechType? other)
     {
         if (ReferenceEquals(null, other))
         {

--- a/Nitrox.Model/Configuration/SubnauticaServerOptions.cs
+++ b/Nitrox.Model/Configuration/SubnauticaServerOptions.cs
@@ -76,9 +76,6 @@ public sealed partial class SubnauticaServerOptions
     public bool PvpEnabled { get; set; } = true;
     public bool AutoSave { get; set; } = true;
 
-    [PropertyDescription("Possible values:", typeof(ServerSerializerMode))]
-    public ServerSerializerMode SerializerMode { get; set; } = ServerSerializerMode.JSON;
-
     [PropertyDescription("When true, will reject any build actions detected as desynced")]
     public bool SafeBuilding { get; set; } = true;
 

--- a/Nitrox.Model/Constants/NitroxConstants.cs
+++ b/Nitrox.Model/Constants/NitroxConstants.cs
@@ -4,4 +4,5 @@ public static class NitroxConstants
 {
     public const string LAUNCHER_APP_NAME = "Nitrox.Launcher";
     public const string PLAYER_NAME_VALID_REGEX = @"^[ a-zA-Z0-9._-]{3,25}$";
+    public const string SAVE_FILE_ENDING = ".json";
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntityData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/EntityData.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 
-[DataContract]
 public class EntityData
 {
-    [DataMember(Order = 1)]
     public List<Entity> Entities = [];
 
     public static EntityData From(List<Entity> entities)

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/GlobalRootData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/GlobalRootData.cs
@@ -1,14 +1,11 @@
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 
-[DataContract]
 public class GlobalRootData
 {
-    [DataMember(Order = 1)]
-    public List<GlobalRootEntity> Entities = new();
+    public List<GlobalRootEntity> Entities = [];
 
     public static GlobalRootData From(List<GlobalRootEntity> entities)
     {

--- a/Nitrox.Server.Subnautica/Models/GameLogic/GameData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/GameData.cs
@@ -1,29 +1,22 @@
-using System.Runtime.Serialization;
 using Nitrox.Server.Subnautica.Models.GameLogic.Unlockables;
 
-namespace Nitrox.Server.Subnautica.Models.GameLogic
+namespace Nitrox.Server.Subnautica.Models.GameLogic;
+
+internal sealed class GameData
 {
-    [Serializable]
-    [DataContract]
-    internal sealed class GameData
+    public PdaStateData PDAState { get; set; }
+
+    public StoryGoalData StoryGoals { get; set; }
+
+    public StoryTimingData StoryTiming { get; set; }
+
+    public static GameData From(PdaManager pdaManager, StoryGoalData storyGoals, StoryScheduler storyScheduler, StoryManager storyManager, TimeService timeService)
     {
-        [DataMember(Order = 1)]
-        public PdaStateData PDAState { get; set; }
-
-        [DataMember(Order = 2)]
-        public StoryGoalData StoryGoals { get; set; }
-
-        [DataMember(Order = 3)]
-        public StoryTimingData StoryTiming { get; set; }
-
-        public static GameData From(PdaManager pdaManager, StoryGoalData storyGoals, StoryScheduler storyScheduler, StoryManager storyManager, TimeService timeService)
+        return new GameData
         {
-            return new GameData
-            {
-                PDAState = pdaManager.GetPdaStateCopy(),
-                StoryGoals = StoryGoalData.From(storyGoals, storyScheduler),
-                StoryTiming = StoryTimingData.From(storyManager, timeService)
-            };
-        }
+            PDAState = pdaManager.GetPdaStateCopy(),
+            StoryGoals = StoryGoalData.From(storyGoals, storyScheduler),
+            StoryTiming = StoryTimingData.From(storyManager, timeService)
+        };
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Players/PersistedPlayerData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Players/PersistedPlayerData.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.DataStructures.GameLogic;
@@ -9,61 +8,43 @@ using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic.Players;
 
-[DataContract]
 internal sealed class PersistedPlayerData
 {
-    [DataMember(Order = 1)]
     public string Name { get; set; }
 
-    [DataMember(Order = 2)]
     public List<NitroxTechType> UsedItems { get; set; } = [];
 
-    [DataMember(Order = 3)]
     public Optional<NitroxId>[] QuickSlotsBindingIds { get; set; } = [];
 
-    [DataMember(Order = 4)]
     public Dictionary<string, NitroxId> EquippedItems { get; set; } = [];
 
-    [DataMember(Order = 5)]
     public PeerId Id { get; set; }
 
-    [DataMember(Order = 6)]
     public NitroxVector3 SpawnPosition { get; set; }
 
-    [DataMember(Order = 7)]
     public NitroxQuaternion SpawnRotation { get; set; }
 
-    [DataMember(Order = 8)]
     public PlayerStatsData CurrentStats { get; set; }
 
-    [DataMember(Order = 9)]
     public SubnauticaGameMode GameMode { get; set; }
 
-    [DataMember(Order = 10)]
     public NitroxId SubRootId { get; set; }
 
-    [DataMember(Order = 11)]
     public Perms Permissions { get; set; }
 
-    [DataMember(Order = 12)]
     public NitroxId NitroxId { get; set; }
 
-    [DataMember(Order = 13)]
     public bool IsPermaDeath { get; set; }
 
     /// <summary>
     /// Those goals are unlocked individually (e.g. opening PDA, eating, picking up a fire extinguisher for the first time)
     /// </summary>
-    [DataMember(Order = 15)]
     public Dictionary<string, float> PersonalCompletedGoalsWithTimestamp { get; set; } = [];
 
-    [DataMember(Order = 16)]
-    public SubnauticaPlayerPreferences PlayerPreferences { get; set; }
+    public SubnauticaPlayerPreferences? PlayerPreferences { get; set; }
 
-    [DataMember(Order = 17)]
     public bool InPrecursor { get; set; }
 
-    [DataMember(Order = 18)]
     public bool DisplaySurfaceWater { get; set; }
 
     public Player ToPlayer()

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Players/PlayerData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Players/PlayerData.cs
@@ -1,25 +1,21 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
-namespace Nitrox.Server.Subnautica.Models.GameLogic.Players
+namespace Nitrox.Server.Subnautica.Models.GameLogic.Players;
+
+internal sealed class PlayerData
 {
-    [DataContract]
-    internal sealed class PlayerData
+    public List<PersistedPlayerData> Players = [];
+
+    public List<Player> GetPlayers()
     {
-        [DataMember(Order = 1)]
-        public List<PersistedPlayerData> Players = [];
+        return Players.Select(playerData => playerData.ToPlayer()).ToList();
+    }
 
-        public List<Player> GetPlayers()
-        {
-            return Players.Select(playerData => playerData.ToPlayer()).ToList();
-        }
+    public static PlayerData From(IEnumerable<Player> players)
+    {
+        List<PersistedPlayerData> persistedPlayers = players.Select(PersistedPlayerData.FromPlayer).ToList();
 
-        public static PlayerData From(IEnumerable<Player> players)
-        {
-            List<PersistedPlayerData> persistedPlayers = players.Select(PersistedPlayerData.FromPlayer).ToList();
-
-            return new PlayerData { Players = persistedPlayers };
-        }
+        return new PlayerData { Players = persistedPlayers };
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/StoryScheduler.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/StoryScheduler.cs
@@ -6,11 +6,10 @@ using Nitrox.Server.Subnautica.Models.Packets.Core;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic
 {
-    internal class StoryScheduler(IPacketSender packetSender, PdaManager pdaManager, StoryManager storyManager, TimeService timeService, PlayerManager playerManager)
+    internal class StoryScheduler(IPacketSender packetSender, PdaManager pdaManager, StoryManager storyManager, TimeService timeService)
     {
         private readonly IPacketSender packetSender = packetSender;
         private readonly PdaManager pdaManager = pdaManager;
-        private readonly PlayerManager playerManager = playerManager;
         private readonly ThreadSafeDictionary<string, NitroxScheduledGoal> scheduledStories = [];
         private readonly StoryManager storyManager = storyManager;
         private readonly TimeService timeService = timeService;

--- a/Nitrox.Server.Subnautica/Models/GameLogic/StoryTimingData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/StoryTimingData.cs
@@ -1,42 +1,32 @@
-using System.Runtime.Serialization;
+namespace Nitrox.Server.Subnautica.Models.GameLogic;
 
-namespace Nitrox.Server.Subnautica.Models.GameLogic
+internal sealed class StoryTimingData
 {
-    [Serializable]
-    [DataContract]
-    internal sealed class StoryTimingData
+    /// <summary>
+    ///     Game time elapsed in seconds.
+    /// </summary>
+    public double ElapsedSeconds { get; set; }
+
+    public double? AuroraCountdownTime { get; set; }
+
+    public double? AuroraWarningTime { get; set; }
+
+    /// <summary>
+    ///     Time elapsed in real-time. In seconds.
+    /// </summary>
+    public double RealTimeElapsed { get; set; }
+
+    public double? AuroraRealExplosionTime { get; set; }
+
+    public static StoryTimingData From(StoryManager storyManager, TimeService timeService)
     {
-        /// <summary>
-        ///     Game time elapsed in seconds.
-        /// </summary>
-        [DataMember(Order = 1)]
-        public double ElapsedSeconds { get; set; }
-
-        [DataMember(Order = 2)]
-        public double? AuroraCountdownTime { get; set; }
-
-        [DataMember(Order = 3)]
-        public double? AuroraWarningTime { get; set; }
-
-        /// <summary>
-        ///     Time elapsed in real-time. In seconds.
-        /// </summary>
-        [DataMember(Order = 4)]
-        public double RealTimeElapsed { get; set; }
-
-        [DataMember(Order = 5)]
-        public double? AuroraRealExplosionTime { get; set; }
-
-        public static StoryTimingData From(StoryManager storyManager, TimeService timeService)
+        return new StoryTimingData
         {
-            return new StoryTimingData
-            {
-                ElapsedSeconds = timeService.GameTime.TotalSeconds,
-                AuroraCountdownTime = storyManager.AuroraCountdownTimeMs,
-                AuroraWarningTime = storyManager.AuroraWarningTimeMs,
-                RealTimeElapsed = timeService.ActiveTime.TotalSeconds,
-                AuroraRealExplosionTime = storyManager.AuroraRealExplosionTime.TotalSeconds
-            };
-        }
+            ElapsedSeconds = timeService.GameTime.TotalSeconds,
+            AuroraCountdownTime = storyManager.AuroraCountdownTimeMs,
+            AuroraWarningTime = storyManager.AuroraWarningTimeMs,
+            RealTimeElapsed = timeService.ActiveTime.TotalSeconds,
+            AuroraRealExplosionTime = storyManager.AuroraRealExplosionTime.TotalSeconds
+        };
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Unlockables/PdaStateData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Unlockables/PdaStateData.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 
@@ -11,7 +10,6 @@ namespace Nitrox.Server.Subnautica.Models.GameLogic.Unlockables;
 /// <remarks>
 ///     Important: Keep <see cref="GetFullCopy" /> in sync with any code changes!
 /// </remarks>
-[DataContract]
 internal sealed record PdaStateData
 {
     /// <summary>
@@ -20,22 +18,18 @@ internal sealed record PdaStateData
     ///     The KnownTech construct uses both <see cref='KnownTechEntryAdd.EntryCategory.KNOWN'>KnownTech.knownTech</see> and
     ///     <see cref='KnownTechEntryAdd.EntryCategory.ANALYZED'>KnownTech.analyzedTech</see>
     /// </summary>
-    [DataMember(Order = 1)]
     public List<NitroxTechType> KnownTechTypes { get; } = [];
 
-    [DataMember(Order = 2)]
     public List<NitroxTechType> AnalyzedTechTypes { get; } = [];
 
     /// <summary>
     ///     Gets or sets the log of story events present in the PDA
     /// </summary>
-    [DataMember(Order = 3)]
     public List<PDALogEntry> PdaLog { get; } = [];
 
     /// <summary>
     ///     Gets or sets the entries that show up the the PDA's Encyclopedia
     /// </summary>
-    [DataMember(Order = 4)]
     public List<string> EncyclopediaEntries { get; } = [];
 
     /// <summary>
@@ -46,19 +40,16 @@ internal sealed record PdaStateData
     ///     or not.
     ///     We can therefore use it as a list.
     /// </remarks>
-    [DataMember(Order = 5)]
     public HashSet<NitroxId> ScannerFragments { get; } = [];
 
     /// <summary>
     ///     Partially unlocked PDA entries (e.g. fragments)
     /// </summary>
-    [DataMember(Order = 6)]
     public List<PDAEntry> ScannerPartial { get; } = [];
 
     /// <summary>
     ///     Fully unlocked PDA entries
     /// </summary>
-    [DataMember(Order = 7)]
     public HashSet<NitroxTechType> ScannerComplete { get; } = [];
 
     /// <summary>

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Unlockables/StoryGoalData.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Unlockables/StoryGoalData.cs
@@ -1,19 +1,14 @@
-using System.Runtime.Serialization;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 
 namespace Nitrox.Server.Subnautica.Models.GameLogic.Unlockables;
 
-[DataContract]
 internal sealed class StoryGoalData
 {
-    [DataMember(Order = 1)]
     public ThreadSafeSet<string> CompletedGoals { get; } = [];
 
-    [DataMember(Order = 2)]
     public ThreadSafeQueue<string> RadioQueue { get; } = [];
 
-    [DataMember(Order = 3)]
     public ThreadSafeList<NitroxScheduledGoal> ScheduledGoals { get; set; } = [];
 
     public static StoryGoalData From(StoryGoalData storyGoals, StoryScheduler storyScheduler)

--- a/Nitrox.Server.Subnautica/Models/Serialization/ServerJsonSerializer.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/ServerJsonSerializer.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Nitrox.Model.Constants;
 using Nitrox.Model.Platforms.OS.Shared;
 using Nitrox.Server.Subnautica.Models.Serialization.Json;
 
@@ -8,8 +9,6 @@ namespace Nitrox.Server.Subnautica.Models.Serialization;
 
 public sealed class ServerJsonSerializer : IServerSerializer
 {
-    public const string FILE_ENDING = ".json";
-
     private readonly JsonSerializer serializer;
 
     public ServerJsonSerializer(ILogger<ServerJsonSerializer> logger)
@@ -31,7 +30,7 @@ public sealed class ServerJsonSerializer : IServerSerializer
         serializer.Converters.Add(new StringEnumConverter());
     }
 
-    public string FileEnding => FILE_ENDING;
+    public string FileEnding => NitroxConstants.SAVE_FILE_ENDING;
 
     public void Serialize(Stream stream, object o)
     {

--- a/Nitrox.Server.Subnautica/Models/Serialization/World/PersistedWorldData.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/PersistedWorldData.cs
@@ -1,30 +1,23 @@
-using System.Runtime.Serialization;
 using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
 using Nitrox.Server.Subnautica.Models.GameLogic.Players;
 
-namespace Nitrox.Server.Subnautica.Models.Serialization.World
+namespace Nitrox.Server.Subnautica.Models.Serialization.World;
+
+internal class PersistedWorldData
 {
-    [DataContract]
-    internal class PersistedWorldData
+    public WorldData? WorldData { get; set; }
+
+    public PlayerData? PlayerData { get; set; }
+
+    public GlobalRootData? GlobalRootData { get; set; }
+
+    public EntityData? EntityData { get; set; }
+
+    public bool IsValid()
     {
-        [DataMember(Order = 1)]
-        public WorldData? WorldData { get; set; }
-
-        [DataMember(Order = 2)]
-        public PlayerData? PlayerData { get; set; }
-
-        [DataMember(Order = 3)]
-        public GlobalRootData? GlobalRootData { get; set; }
-
-        [DataMember(Order = 4)]
-        public EntityData? EntityData { get; set; }
-
-        public bool IsValid()
-        {
-            return WorldData?.IsValid() == true &&
-                   PlayerData != null &&
-                   GlobalRootData != null &&
-                   EntityData != null;
-        }
+        return WorldData?.IsValid() == true &&
+               PlayerData != null &&
+               GlobalRootData != null &&
+               EntityData != null;
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Serialization/World/WorldData.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/WorldData.cs
@@ -1,27 +1,21 @@
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Nitrox.Model.DataStructures;
 using Nitrox.Server.Subnautica.Models.GameLogic;
 
-namespace Nitrox.Server.Subnautica.Models.Serialization.World
+namespace Nitrox.Server.Subnautica.Models.Serialization.World;
+
+internal class WorldData
 {
-    [DataContract]
-    internal class WorldData
+    public List<NitroxInt3>? ParsedBatchCells { get; set; } = [];
+
+    public GameData? GameData { get; set; }
+
+    [Obsolete("Use server.cfg seed instead - TODO: delete this but keep backward compat via save upgrade")]
+    public string? Seed { get; set; }
+
+    public bool IsValid()
     {
-        [DataMember(Order = 1)]
-        public List<NitroxInt3>? ParsedBatchCells { get; set; } = [];
-
-        [DataMember(Order = 2)]
-        public GameData? GameData { get; set; }
-
-        [Obsolete("Use server.cfg seed instead - TODO: delete this but keep backward compat via save upgrade")]
-        [DataMember(Order = 3)]
-        public string? Seed { get; set; }
-
-        public bool IsValid()
-        {
-            return ParsedBatchCells != null &&
-                   GameData != null;
-        }
+        return ParsedBatchCells != null &&
+               GameData != null;
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Serialization/World/WorldService.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/WorldService.cs
@@ -23,14 +23,12 @@ internal class WorldService : IHostedService
     private readonly BatchEntitySpawner batchEntitySpawner;
     private readonly EntityRegistry entityRegistry;
     private readonly EscapePodManager escapePodManager;
-    private readonly ServerJsonSerializer jsonSerializer;
     private readonly ILogger<WorldService> logger;
     private readonly IOptions<SubnauticaServerOptions> options;
     private readonly PdaManager pdaManager;
     private readonly PlayerManager playerManager;
 
     private readonly TaskCompletionSource<bool> hasFinishedLoadingTcs = new();
-    private readonly SubnauticaServerProtoBufSerializer protoBufSerializer;
     private readonly SaveService saveService;
     private readonly IOptions<ServerStartOptions> startOptions;
     private readonly StoryManager storyManager;
@@ -42,7 +40,6 @@ internal class WorldService : IHostedService
     private string FileEnding => Serializer?.FileEnding ?? "";
 
     public WorldService(
-        SubnauticaServerProtoBufSerializer protoBufSerializer,
         ServerJsonSerializer jsonSerializer,
         IOptions<SubnauticaServerOptions> options,
         IEnumerable<SaveDataUpgrade> upgrades,
@@ -59,8 +56,6 @@ internal class WorldService : IHostedService
         IOptions<ServerStartOptions> startOptions,
         ILogger<WorldService> logger)
     {
-        this.protoBufSerializer = protoBufSerializer;
-        this.jsonSerializer = jsonSerializer;
         this.options = options;
         this.upgrades = upgrades.ToArray();
         this.batchEntitySpawner = batchEntitySpawner;
@@ -76,7 +71,7 @@ internal class WorldService : IHostedService
         this.startOptions = startOptions;
         this.logger = logger;
 
-        UpdateSerializer(options.Value.SerializerMode);
+        Serializer = jsonSerializer;
     }
 
     public async Task<bool> SaveAsync(string saveDir, CancellationToken cancellationToken)
@@ -152,8 +147,6 @@ internal class WorldService : IHostedService
         Validate.NotNull(serverSerializer, "Serializer cannot be null");
         Serializer = serverSerializer;
     }
-
-    internal void UpdateSerializer(ServerSerializerMode mode) => Serializer = mode == ServerSerializerMode.PROTOBUF ? protoBufSerializer : jsonSerializer;
 
     internal bool Save(PersistedWorldData persistedData, string saveDir)
     {
@@ -434,30 +427,23 @@ internal class WorldService : IHostedService
             return;
         }
 
-        if (options.Value.SerializerMode == ServerSerializerMode.PROTOBUF)
+        try
         {
-            logger.ZLogInformation($"Can't upgrade while using ProtoBuf as serializer");
-        }
-        else
-        {
-            try
+            foreach (SaveDataUpgrade upgrade in upgrades)
             {
-                foreach (SaveDataUpgrade upgrade in upgrades)
+                if (upgrade.TargetVersion > saveFileVersion.Version)
                 {
-                    if (upgrade.TargetVersion > saveFileVersion.Version)
-                    {
-                        upgrade.UpgradeSaveFiles(saveDir, FileEnding);
-                    }
+                    upgrade.UpgradeSaveFiles(saveDir, FileEnding);
                 }
             }
-            catch (Exception ex)
-            {
-                logger.ZLogError(ex, $"Error while upgrading save file.");
-                return;
-            }
-
-            Serializer.Serialize(Path.Combine(saveDir, $"Version{FileEnding}"), new SaveFileVersion());
-            logger.ZLogInformation($"Save file was upgraded to {NitroxEnvironment.Version:@Version}");
         }
+        catch (Exception ex)
+        {
+            logger.ZLogError(ex, $"Error while upgrading save file.");
+            return;
+        }
+
+        Serializer.Serialize(Path.Combine(saveDir, $"Version{FileEnding}"), new SaveFileVersion());
+        logger.ZLogInformation($"Save file was upgraded to {NitroxEnvironment.Version:@Version}");
     }
 }

--- a/Nitrox.Server.Subnautica/Services/StatusService.cs
+++ b/Nitrox.Server.Subnautica/Services/StatusService.cs
@@ -46,7 +46,6 @@ internal sealed class StatusService(
         SubnauticaServerOptions o = options.Value;
         logger.ZLogInformation($"Server started in {double.Round(appStartStopWatch.Elapsed.TotalSeconds, 3):@Seconds} seconds");
         logger.ZLogInformation($"Server is listening on port {o.ServerPort} UDP");
-        logger.ZLogInformation($"Using {o.SerializerMode} as save file serializer");
         logger.ZLogInformation($"Server Password: '{(string.IsNullOrWhiteSpace(o.ServerPassword) ? "" : o.ServerPassword):@password}'");
         logger.ZLogInformation($"Admin Password: '{(string.IsNullOrWhiteSpace(o.AdminPassword) ? "" : o.AdminPassword):@password}'");
         logger.ZLogInformation($"Autobackup: {(o.MaxBackups < 1 ? "DISABLED" : $"ENABLED (Max: {o.MaxBackups})")}");


### PR DESCRIPTION
Should be tested with Visual Studio.

Removed ProtoBuf save files as they cannot be upgraded and required server code access to work (as launcher needed to parse the save files).

## How to test

1. Start launcher
2. Try start server
3. It should start without errors

## Fix sourced from
- https://redirect.github.com/dotnet/msbuild/issues/1916#issuecomment-2031413812