### PR TITLE
Fix ProcessEx warning

### DIFF
--- a/Nitrox.Model/Platforms/OS/Shared/ProcessEx.cs
+++ b/Nitrox.Model/Platforms/OS/Shared/ProcessEx.cs
@@ -240,7 +240,7 @@ public class ProcessEx : IDisposable
             try
             {
                 result = selector(procEx);
-                if (result is not Process or ProcessEx)
+                if (result is not (Process or ProcessEx))
                 {
                     procEx?.Dispose();
                 }


### PR DESCRIPTION
## Description of Change

Fixes a warning that was hidding a serious pattern problem, this API is not used so it is not a problem for now.

## PR Checklist

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [ ] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/macOS (if applicable) (for cross-platform code)