### PR TITLE
Add configurable key bind for the ping action

### DIFF
--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -84,7 +84,6 @@
     "Nitrox_Settings_HigherForUnstable_Tooltip": "Give a higher value for unstable connections",
     "Nitrox_Settings_Keybind_FocusDiscord": "Focus on the Discord invite window",
     "Nitrox_Settings_Keybind_OpenChat": "Open chat",
-    "Nitrox_Settings_Keybind_Ping": "Place ping",
     "Nitrox_Settings_LatencyUpdatePeriod": "Latency update period (s)",
     "Nitrox_Settings_OfflineClockSyncDuration": "Clock sync procedure duration (s)",
     "Nitrox_Settings_Privacy": "Privacy",

--- a/Nitrox.Assets.Subnautica/LanguageFiles/en.json
+++ b/Nitrox.Assets.Subnautica/LanguageFiles/en.json
@@ -84,6 +84,7 @@
     "Nitrox_Settings_HigherForUnstable_Tooltip": "Give a higher value for unstable connections",
     "Nitrox_Settings_Keybind_FocusDiscord": "Focus on the Discord invite window",
     "Nitrox_Settings_Keybind_OpenChat": "Open chat",
+    "Nitrox_Settings_Keybind_Ping": "Place ping",
     "Nitrox_Settings_LatencyUpdatePeriod": "Latency update period (s)",
     "Nitrox_Settings_OfflineClockSyncDuration": "Clock sync procedure duration (s)",
     "Nitrox_Settings_Privacy": "Privacy",

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindingManager.cs
@@ -11,6 +11,7 @@ public static class KeyBindingManager
     public static List<KeyBinding> KeyBindings =
     [
         new ChatKeyBindingAction(),
-        new DiscordFocusBindingAction()
+        new DiscordFocusBindingAction(),
+        new PingKeyBindingAction()
     ];
 }

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
@@ -4,7 +4,7 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
 internal sealed class PingKeyBindingAction : KeyBinding
 {
-    public PingKeyBindingAction() : base("Nitrox_Settings_Keybind_Ping", "p") { }
+    public PingKeyBindingAction() : base("Nitrox_Settings_Keybind_Ping", "<Mouse>/middleButton") { }
 
     public override void Execute(InputAction.CallbackContext _)
     {

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
@@ -1,9 +1,8 @@
-using NitroxClient.MonoBehaviours;
 using UnityEngine.InputSystem;
 
 namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
 
-public class PingKeyBindingAction : KeyBinding
+internal sealed class PingKeyBindingAction : KeyBinding
 {
     public PingKeyBindingAction() : base("Nitrox_Settings_Keybind_Ping", "p") { }
 

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/Actions/PingKeyBindingAction.cs
@@ -1,0 +1,14 @@
+using NitroxClient.MonoBehaviours;
+using UnityEngine.InputSystem;
+
+namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings.Actions;
+
+public class PingKeyBindingAction : KeyBinding
+{
+    public PingKeyBindingAction() : base("Nitrox_Settings_Keybind_Ping", "p") { }
+
+    public override void Execute(InputAction.CallbackContext _)
+    {
+        PlayerPingManager.RequestPing();
+    }
+}

--- a/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Input/KeyBindings/KeyBinding.cs
@@ -5,6 +5,12 @@ namespace NitroxClient.MonoBehaviours.Gui.Input.KeyBindings;
 public abstract class KeyBinding(string buttonLabel, string defaultKeyboardKey, string defaultControllerKey = null)
 {
     public string ButtonLabel { get; init; } = buttonLabel;
+
+    /// <summary>
+    ///     Default binding for the keyboard/mouse scheme. Either a bare key name (e.g. "p"), which is resolved
+    ///     against the keyboard (i.e. "&lt;Keyboard&gt;/p"), or a full Input System control path
+    ///     (e.g. "&lt;Mouse&gt;/middleButton") to bind to a different device.
+    /// </summary>
     public string DefaultKeyboardKey { get; init; } = defaultKeyboardKey;
     public string DefaultControllerKey { get; init; } = defaultControllerKey;
 

--- a/NitroxClient/MonoBehaviours/PlayerPingManager.cs
+++ b/NitroxClient/MonoBehaviours/PlayerPingManager.cs
@@ -44,19 +44,29 @@ internal sealed class PlayerPingManager : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetMouseButtonDown(2))
-        {
-            queuedRaycastHit = RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE);
-            if (queuedRaycastHit == null)
-            {
-                // Invalid ping raycast so we play an error sound.
-                FMODEmitterController.PlayEventOneShot(PING_FAIL_SOUND, 3, Player.main.transform.position);
-            }
-        }
         if (queuedRaycastHit is { } hit && CanCreatePing())
         {
             queuedRaycastHit = null;
             CreatePing(hit.point + hit.normal * 0.5f, hit.collider.gameObject);
+        }
+    }
+
+    public static void RequestPing()
+    {
+        if (!instance)
+        {
+            return;
+        }
+        instance.RequestPingInternal();
+    }
+
+    private void RequestPingInternal()
+    {
+        queuedRaycastHit = RaycastHelper.GetClosestHitFromAim(MAX_PING_DISTANCE);
+        if (queuedRaycastHit == null)
+        {
+            // Invalid ping raycast so we play an error sound.
+            FMODEmitterController.PlayEventOneShot(PING_FAIL_SOUND, 3, Player.main.transform.position);
         }
     }
 

--- a/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/GameInputSystem_Initialize_Patch.cs
@@ -27,8 +27,10 @@ public partial class GameInputSystem_Initialize_Patch : NitroxPatch, IPersistent
 
             if (!string.IsNullOrEmpty(keyBinding.DefaultKeyboardKey))
             {
+                // A bare key name is resolved against the keyboard, a "<Device>/..." path (e.g. mouse buttons) is used as-is.
                 // See GameInputSystem.bindingsKeyboard definition
-                GameInputSystem.bindingsKeyboard.Add(button, $"<Keyboard>/{keyBinding.DefaultKeyboardKey}");
+                string bindingPath = keyBinding.DefaultKeyboardKey[0] == '<' ? keyBinding.DefaultKeyboardKey : $"<Keyboard>/{keyBinding.DefaultKeyboardKey}";
+                GameInputSystem.bindingsKeyboard.Add(button, bindingPath);
             }
             if (!string.IsNullOrEmpty(keyBinding.DefaultControllerKey))
             {


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2821

## Description of Change

- Added `PingKeyBindingAction`, registered in `KeyBindingManager`, so ping is now a proper Nitrox key bind (default: `MiddleMouseButton`)
- `PlayerPingManager` no longer polls the middle mouse button directly; it now exposes a `RequestPing()` entry point invoked by the key bind action.
- The Nitrox_Settings_Keybind_Ping string is not added to en.json — it will be added via Weblate (see below).
- Localization (for Weblate): New string to add — Nitrox_Settings_Keybind_Ping = "Place ping"

## Validation

- Built `NitroxClient` and `NitroxPatcher` successfully.
- Tested in-game: pinging works on the new default key (`MiddleMouseButton`).
- Tested in-game: pinging still works after rebinding to a different key via the options menu.

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

🤖 This code was created with the help of AI.
