### PR TITLE
Changes to broadcasting health and death updates

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/EntityMetadata.cs
@@ -47,6 +47,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
 [ProtoInclude(88, typeof(PrecursorDisableGunTerminalMetadata))]
 [ProtoInclude(89, typeof(OxygenMetadata))]
 [ProtoInclude(90, typeof(BulkheadDoorMetadata))]
+[ProtoInclude(91, typeof(LiveMixinMetadata))]
 public abstract class EntityMetadata
 {
 

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/LiveMixinMetadata.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Metadata/LiveMixinMetadata.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.Serialization;
+using BinaryPack.Attributes;
+
+namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+
+[Serializable, DataContract]
+public class LiveMixinMetadata : EntityMetadata
+{
+    [DataMember(Order = 1)]
+    public float Health { get; set; }
+
+    [IgnoreConstructor]
+    protected LiveMixinMetadata()
+    {
+        // Constructor for serialisation
+    }
+
+    public LiveMixinMetadata(float health)
+    {
+        Health = health;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(LiveMixinMetadata)} Health: {Health}]";
+    }
+}

--- a/NitroxClient/GameLogic/LiveMixinManager.cs
+++ b/NitroxClient/GameLogic/LiveMixinManager.cs
@@ -90,9 +90,16 @@ public class LiveMixinManager
         // We catch the exceptions here because we don't want IsRemoteHealthChanging to be stuck to true
         try
         {
-            if (difference < 0)
+            if (remoteHealth <= 0f)
             {
-                liveMixin.TakeDamage(difference, position, damageType);
+                // it seems that going through TakeDamage to reach 0 isn't reliable all the time
+                // so we can just call Kill() directly
+                liveMixin.Kill(damageType);
+            }
+            else if (difference < 0)
+            {
+                // TakeDamage expects a positive magnitude to subtract
+                liveMixin.TakeDamage(Math.Abs(difference), position, damageType);
             }
             else
             {

--- a/NitroxClient/GameLogic/Spawning/Metadata/Extractor/LiveMixinMetadataExtractor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Extractor/LiveMixinMetadataExtractor.cs
@@ -1,0 +1,20 @@
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Extractor;
+
+/// <summary>
+/// Vehicles/cyclops already sync health through their own metadata.
+/// </summary>
+public class LiveMixinMetadataExtractor : EntityMetadataExtractor<LiveMixin, LiveMixinMetadata>
+{
+    public override LiveMixinMetadata Extract(LiveMixin liveMixin)
+    {
+        if (Resolve<LiveMixinManager>().IsWhitelistedUpdateType(liveMixin))
+        {
+            return null;
+        }
+
+        return new(liveMixin.health);
+    }
+}

--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/LiveMixinMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/LiveMixinMetadataProcessor.cs
@@ -1,0 +1,23 @@
+using NitroxClient.Communication;
+using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using Nitrox.Model.Subnautica.Packets;
+using UnityEngine;
+
+namespace NitroxClient.GameLogic.Spawning.Metadata.Processor;
+
+public class LiveMixinMetadataProcessor : EntityMetadataProcessor<LiveMixinMetadata>
+{
+    public override void ProcessMetadata(GameObject gameObject, LiveMixinMetadata metadata)
+    {
+        if (!gameObject.TryGetComponent(out LiveMixin liveMixin))
+        {
+            Log.Error($"[{nameof(LiveMixinMetadataProcessor)}] Couldn't find LiveMixin on {gameObject}");
+            return;
+        }
+        using (PacketSuppressor<EntityMetadataUpdate>.Suppress())
+        {
+            Resolve<LiveMixinManager>().SyncRemoteHealth(liveMixin, metadata.Health);
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/LiveMixin_AddHealth_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LiveMixin_AddHealth_Patch.cs
@@ -91,8 +91,13 @@ public sealed partial class LiveMixin_AddHealth_Patch : NitroxPatch, IDynamicPat
 
     private static void HandleGenericEntity(LiveMixin victim)
     {
-        // Let others know if we have a lock on this entity
-        if (!CanBroadcast || !victim.TryGetIdOrWarn(out NitroxId id) || !Resolve<SimulationOwnership>().HasAnyLockType(id))
+        if (!CanBroadcast || !victim.TryGetIdOrWarn(out NitroxId id))
+        {
+            return;
+        }
+        
+        //same vibe as LiveMixin_TakeDamage_Patch.BroadcastDefaultTookDamage
+        if (Resolve<LiveMixinManager>().IsWhitelistedUpdateType(victim) && !Resolve<SimulationOwnership>().HasAnyLockType(id))
         {
             return;
         }

--- a/NitroxPatcher/Patches/Dynamic/LiveMixin_TakeDamage_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/LiveMixin_TakeDamage_Patch.cs
@@ -88,15 +88,23 @@ public sealed partial class LiveMixin_TakeDamage_Patch : NitroxPatch, IDynamicPa
 
     private static void BroadcastDefaultTookDamage(LiveMixin liveMixin)
     {
-        // Let others know if we have a lock on this entity
-        if (liveMixin.TryGetIdOrWarn(out NitroxId id) && Resolve<SimulationOwnership>().HasAnyLockType(id))
+        if (!liveMixin.TryGetIdOrWarn(out NitroxId id))
         {
-            Optional<EntityMetadata> metadata = Resolve<EntityMetadataManager>().Extract(liveMixin.gameObject);
+            return;
+        }
 
-            if (metadata.HasValue)
-            {
-                Resolve<Entities>().BroadcastMetadataUpdate(id, metadata.Value);
-            }
+        // Unlike vehicles (gated by ShouldApplyNextHealthUpdate above), creatures apply every attacker's damage locally with no lock check
+        // so every attacker should also broadcast the result.
+        if (Resolve<LiveMixinManager>().IsWhitelistedUpdateType(liveMixin) && !Resolve<SimulationOwnership>().HasAnyLockType(id))
+        {
+            return;
+        }
+
+        Optional<EntityMetadata> metadata = Resolve<EntityMetadataManager>().Extract(liveMixin.gameObject);
+
+        if (metadata.HasValue)
+        {
+            Resolve<Entities>().BroadcastMetadataUpdate(id, metadata.Value);
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
Fixes #2510 

## Description of Change

Adds a collection of changes to allow the syncing of creature deaths to clients from the server

## Validation

1. Start a server
2. join with 2 clients
3. kill the creature together (both do damage)
4. Observe the creature dies on both clients

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This code was created with the help of AI. 
Specifically scanning through decompiled functions, which surfaced a bug with how we used liveMixin.TakeDamage
