### PR TITLE
Fix sign/locker rename and color sync, keep color button's true color visible

### DIFF
--- a/NitroxClient/GameLogic/Spawning/Metadata/Processor/EntitySignMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/Processor/EntitySignMetadataProcessor.cs
@@ -16,6 +16,11 @@ public class EntitySignMetadataProcessor : EntityMetadataProcessor<EntitySignMet
             sign.elementsState = metadata.Elements;
             sign.scaleIndex = metadata.ScaleIndex;
             sign.SetBackground(metadata.Background);
+
+            // TMP_InputField.text (set above via sign.text) doesn't force its visible mesh to redraw
+            // when set from script instead of by typing. ForceLabelUpdate() is TextMeshPro's own
+            // escape hatch for exactly this "set from code, doesn't redraw" case.
+            sign.inputField.ForceLabelUpdate();
         }
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_ColorButtonAlwaysVisible_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_ColorButtonAlwaysVisible_Patch.cs
@@ -1,0 +1,123 @@
+using System.Reflection;
+using HarmonyLib;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Originally a SubmersedVR-only fix, moved here because neither half of the underlying problem
+/// is VR-specific: vanilla hides the locker/sign color-cycle button (ColorSelector, and its child
+/// Indicator -- the only visible part) outside the interstitial edit state via
+/// SetElementsMode(false)'s editOnly array, exposing the locker's own static base texture
+/// underneath instead -- which has a plain white circle painted on it, lined up with the button's
+/// position, confirmed this session via live testing and AssetRipper prefab data. That's true for
+/// flat-mouse and gamepad players exactly as much as VR players; it has nothing to do with how the
+/// button gets clicked. Moving it here means every player sees the true current color at all
+/// times, not just SubmersedVR users, and SubmersedVR no longer needs its own duplicate copy.
+/// </summary>
+internal static class ColorButtonAlwaysVisibleHelper
+{
+    private static readonly MethodInfo UpdateColorMethod = AccessTools.Method(typeof(uGUI_SignInput), "UpdateColor");
+
+    internal static GameObject FindColorSelector(uGUI_SignInput signInput)
+    {
+        foreach (Transform t in signInput.GetComponentsInChildren<Transform>(true))
+        {
+            if (t.name == "ColorSelector")
+            {
+                return t.gameObject;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Order matters: reactivating a Button's GameObject fires Unity's own Selectable.OnEnable
+    /// -> DoStateTransition, which immediately tints targetGraphic (Indicator) to m_NormalColor
+    /// (near-white, per the prefab's Button component) -- SetActive(true) must run before
+    /// UpdateColor() or that tint silently wins and undoes the color just set.
+    /// </summary>
+    internal static void ShowAndRefreshColor(uGUI_SignInput signInput)
+    {
+        GameObject colorSelector = FindColorSelector(signInput);
+        if (colorSelector != null)
+        {
+            colorSelector.SetActive(true);
+        }
+        UpdateColorMethod?.Invoke(signInput, null);
+    }
+}
+
+/// <summary>
+/// Keeps the color button visible from the moment a locker/sign spawns, not just after the first
+/// time it's selected -- SetElementsMode(false) in uGUI_SignInput.Awake deactivates ColorSelector
+/// before OnSelect/OnDeselect below ever get a chance to run.
+/// </summary>
+public sealed partial class uGUI_SignInput_Awake_ShowColorButton_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = AccessTools.Method(typeof(uGUI_SignInput), "Awake");
+
+    public static void Postfix(uGUI_SignInput __instance)
+    {
+        ColorButtonAlwaysVisibleHelper.ShowAndRefreshColor(__instance);
+    }
+}
+
+/// <summary>
+/// Re-shows and re-colors the button after vanilla's own OnDeselect body (SetElementsMode(false))
+/// deactivates it -- see ColorButtonAlwaysVisibleHelper's doc comment for the full reasoning.
+/// </summary>
+public sealed partial class uGUI_SignInput_OnDeselect_ShowColorButton_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_SignInput t) => t.OnDeselect());
+
+    public static void Postfix(uGUI_SignInput __instance)
+    {
+        ColorButtonAlwaysVisibleHelper.ShowAndRefreshColor(__instance);
+    }
+}
+
+/// <summary>
+/// The Label GameObject's BoxCollider (what vanilla's own physics-raycast HandTarget targeting
+/// hits to trigger ColoredLabel.OnHandClick/select) doesn't extend far enough to cover where
+/// ColorSelector renders -- confirmed via the prefab's own collider bounds vs. the button's
+/// computed position, and via live testing: clicking directly on the now-always-visible button
+/// outside edit mode fell through to whatever collider sits behind it (the locker's own
+/// storage-open trigger) instead of selecting the label. Widens the *live Component* at runtime,
+/// not the prefab asset on disk, to encapsulate the button's actual world-space footprint via
+/// RectTransform.GetWorldCorners + Transform.InverseTransformPoint rather than hand-derived
+/// local-space offsets -- this avoids repeating a world/local coordinate mistake made earlier
+/// this session doing that kind of math by hand for this same button.
+/// </summary>
+public sealed partial class uGUI_SignInput_Awake_ExtendColliderForColorButton_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = AccessTools.Method(typeof(uGUI_SignInput), "Awake");
+
+    public static void Postfix(uGUI_SignInput __instance)
+    {
+        GameObject colorSelector = ColorButtonAlwaysVisibleHelper.FindColorSelector(__instance);
+        if (colorSelector == null)
+        {
+            return;
+        }
+
+        BoxCollider labelCollider = __instance.GetComponentInParent<BoxCollider>();
+        RectTransform colorSelectorRect = colorSelector.GetComponent<RectTransform>();
+        if (labelCollider == null || colorSelectorRect == null)
+        {
+            return;
+        }
+
+        Vector3[] worldCorners = new Vector3[4];
+        colorSelectorRect.GetWorldCorners(worldCorners);
+
+        Bounds bounds = new(labelCollider.center, labelCollider.size);
+        foreach (Vector3 worldCorner in worldCorners)
+        {
+            bounds.Encapsulate(labelCollider.transform.InverseTransformPoint(worldCorner));
+        }
+
+        labelCollider.center = bounds.center;
+        labelCollider.size = bounds.size;
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SignInput_OnDeselect_Patch.cs
@@ -1,21 +1,134 @@
 using System.Reflection;
+using NitroxClient.Extensions;
 using NitroxClient.GameLogic;
+using Nitrox.Model.Core;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
+using TMPro;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
+/// <summary>
+/// Shared broadcast logic for uGUI_SignInput_OnDeselect_Patch and
+/// TMPInputField_DeactivateInputField_SignBroadcast_Patch below, plus the session-tracking flag
+/// that lets OnDeselect know whether DeactivateInputField already sent this edit's final state.
+/// </summary>
+internal static class SignBroadcastHelper
+{
+    /// <summary>
+    /// Set by TMPInputField_DeactivateInputField_SignBroadcast_Patch whenever it broadcasts (i.e.
+    /// text was actively edited and committed this session); reset by
+    /// uGUI_SignInput_OnSelect_ResetBroadcastFlag_Patch whenever a label is (re)selected. Lets
+    /// uGUI_SignInput_OnDeselect_Patch skip broadcasting redundantly -- with a sign.text read
+    /// directly at OnDeselect time, which carries the staleness risk documented on that patch --
+    /// whenever DeactivateInputField already sent the correct, freshly-committed state.
+    /// </summary>
+    internal static bool TextBroadcastAlreadySentThisSession;
+
+    internal static void BroadcastCurrentState(uGUI_SignInput sign, string logContext)
+    {
+        PrefabIdentifier parentIdentifier = sign.gameObject.FindAncestor<PrefabIdentifier>();
+        if (!parentIdentifier)
+        {
+            Log.Warn($"{logContext} broadcast on {sign.gameObject.GetFullHierarchyPath()}: no PrefabIdentifier ancestor found, broadcast skipped, text=\"{sign.text}\" lost.");
+            return;
+        }
+        if (!parentIdentifier.TryGetIdOrWarn(out NitroxId id))
+        {
+            Log.Warn($"{logContext} broadcast on {sign.gameObject.GetFullHierarchyPath()}: PrefabIdentifier found but no NitroxId, broadcast skipped, text=\"{sign.text}\" lost.");
+            return;
+        }
+
+        EntitySignMetadata metadata = new(sign.text, sign.colorIndex, sign.scaleIndex, sign.elementsState, sign.IsBackground());
+        NitroxServiceLocator.LocateService<Entities>().BroadcastMetadataUpdate(id, metadata);
+    }
+}
+
+/// <summary>
+/// Resets SignBroadcastHelper's session flag whenever a label is (re)selected, so
+/// uGUI_SignInput_OnDeselect_Patch's own broadcast-skip logic reflects only what happened during
+/// *this* edit session, not a stale flag left over from a previous one.
+/// </summary>
+public sealed partial class uGUI_SignInput_OnSelect_ResetBroadcastFlag_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_SignInput t) => t.OnSelect(default));
+
+    public static void Postfix()
+    {
+        SignBroadcastHelper.TextBroadcastAlreadySentThisSession = false;
+    }
+}
+
+/// <summary>
+/// Real broadcast trigger for edits that never touched the text field -- e.g. a click directly on
+/// the color-cycle button, which changes colorIndex via ToggleColor() without ever calling
+/// TMP_InputField.ActivateInputField()/DeactivateInputField(). Without this, color-only changes
+/// never sync to other clients, since the only other broadcast trigger fires on text-field
+/// deactivation.
+///
+/// Safe to read sign.text directly here specifically *because* this only runs when
+/// DeactivateInputField did NOT already broadcast this session (see
+/// SignBroadcastHelper.TextBroadcastAlreadySentThisSession) -- meaning the text field was never
+/// activated at all during this edit, so there is no in-flight commit for OnDeselect to race
+/// against. That race is real for the "text was just typed" case DeactivateInputField already
+/// covers (see that patch's own doc comment), not for the "text was never touched" case this
+/// method is scoped to.
+/// </summary>
 public sealed partial class uGUI_SignInput_OnDeselect_Patch : NitroxPatch, IDynamicPatch
 {
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_SignInput t) => t.OnDeselect());
 
     public static void Postfix(uGUI_SignInput __instance)
     {
-        PrefabIdentifier parentIdentifier = __instance.gameObject.FindAncestor<PrefabIdentifier>();
-        if (parentIdentifier && parentIdentifier.TryGetIdOrWarn(out NitroxId id))
+        if (SignBroadcastHelper.TextBroadcastAlreadySentThisSession)
         {
-            EntitySignMetadata metadata = new(__instance.text, __instance.colorIndex, __instance.scaleIndex, __instance.elementsState, __instance.IsBackground());
-            Resolve<Entities>().BroadcastMetadataUpdate(id, metadata);
+            return;
         }
+
+        SignBroadcastHelper.BroadcastCurrentState(__instance, "OnDeselect");
+    }
+}
+
+/// <summary>
+/// The real sign/locker rename broadcast trigger, moved here from uGUI_SignInput.OnDeselect()
+/// after confirming that method can read the text field before TMP_InputField has finished
+/// committing the player's just-typed value, causing a rename to require two edits before it
+/// visibly took effect for other clients. DeactivateInputField's own text parameter/state is what
+/// SubmersedVR's VirtualKeyboard.cs relies on to know editing is truly done (it patches this same
+/// method to clear its keyboard callback), so it's the right point to treat the field's text as
+/// final.
+/// </summary>
+public sealed partial class TMPInputField_DeactivateInputField_SignBroadcast_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((TMP_InputField t) => t.DeactivateInputField(default));
+
+    public static void Postfix(TMP_InputField __instance)
+    {
+        uGUI_SignInput sign = __instance.GetComponentInParent<uGUI_SignInput>();
+        if (!sign || sign.inputField != __instance)
+        {
+            return;
+        }
+
+        SignBroadcastHelper.TextBroadcastAlreadySentThisSession = true;
+        SignBroadcastHelper.BroadcastCurrentState(sign, "DeactivateInputField");
+    }
+}
+
+/// <summary>
+/// Broadcasts a color change immediately, live while still in the interstitial edit state, instead
+/// of only once the player deselects, so other clients see color cycling happen in real time
+/// rather than only after the fact. Safe to read sign.text here: ToggleColor() is only ever reached
+/// via the color button's own click (mouse/gamepad/VR canvas raycast dispatch), never concurrently
+/// with text entry, so there's no in-flight text commit to race against the way
+/// DeactivateInputField's own broadcast has to guard for.
+/// </summary>
+public sealed partial class uGUI_SignInput_ToggleColor_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((uGUI_SignInput t) => t.ToggleColor());
+
+    public static void Postfix(uGUI_SignInput __instance)
+    {
+        SignBroadcastHelper.BroadcastCurrentState(__instance, "ToggleColor");
     }
 }


### PR DESCRIPTION
## Summary
- Sign/locker renames required two edits to show up for other players (and would revert to the previous value on resync): `uGUI_SignInput.OnDeselect` can read the text field before `TMP_InputField` has finished committing the just-typed value, so the broadcast sent the *previous* edit's text. Moves the real broadcast trigger to `TMP_InputField.DeactivateInputField`, which reliably has the final committed text.
- Force-refreshes the TMP label's mesh after a remote update is applied — `TMP_InputField.text` doesn't always redraw when set from script instead of by typing, so a remote rename could apply correctly (confirmed via logging) while the local client kept showing the old text.
- Color-only changes (e.g. clicking just the color-cycle button, never touching the text field) never synced to other clients at all, since the only broadcast trigger fired on text-field deactivation. Adds a broadcast on `uGUI_SignInput.ToggleColor()` for immediate sync while still editing, plus a fallback on `OnDeselect` that's gated to never fire redundantly (and never risk reading a stale, uncommitted text value the `DeactivateInputField` trigger already handled correctly).
- Fixes the color-cycle button's dot always showing white outside edit mode instead of the locker's actual current color — vanilla deactivates the button's GameObject entirely when not editing, exposing the locker's static base texture (which has a plain white circle painted where the dot sits) underneath. Keeps it active but non-interactive outside edit mode (`graphicRaycaster.enabled` still gates real interactivity) so it always shows the true color.
- Widens the label's collider to actually cover where the color button renders — it previously sat entirely outside the label's own collider bounds, so clicking directly on it fell through to the locker's storage-open trigger instead of selecting the label.
## Mods I've been using
- Nitrox 1.8.1.0
- https://github.com/Okabintaro/SubmersedVR/releases - Sumbersed [0.2.0]
- https://github.com/TheGeeks0424/BuddySystem - Buddy System [1.10.6]
- https://www.nexusmods.com/site/mods/202 - Subnautica Support [3.3.3]
- https://www.nexusmods.com/subnautica/mods/1108 - Tobey's BepInEx Pack for Subnautica [5.4.23-pack.3.1.1]
## Test plan
- [x] Renamed a locker/sign as one player, confirmed the new name shows up immediately for a second player without a second edit, and persists correctly after a "resync base" / server restart.
- [x] Changed a locker's color via the color-cycle button only (no text edit) and confirmed it syncs live to a second client.
- [x] Confirmed the color dot shows the locker's true current color when not selected (not white), and reverts correctly after deselecting mid-edit.
- [x] Confirmed clicking the color button (both selecting the label first, and clicking it directly from outside edit mode) behaves correctly — no more falling through to the storage-open interaction.
- [x] Confirmed plain signs (no color button) are unaffected — rename-only behavior unchanged.