### PR TITLE
Fix beacon rename never broadcasting for VR players

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/BeaconLabel_SetLabel_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/BeaconLabel_SetLabel_Patch.cs
@@ -5,20 +5,33 @@ using Nitrox.Model.DataStructures;
 namespace NitroxPatcher.Patches.Dynamic;
 
 /// <summary>
-/// Adds a callback to broadcast beacon label change when edited.
+/// Broadcasts a beacon rename from BeaconLabel.SetLabel(string) rather than BeaconLabel.OnHandClick.
+///
+/// The previous version patched OnHandClick with a postfix that registered a one-shot callback on
+/// uGUI.main.userInput.callback, to fire once the player finished typing. That's the flat/desktop
+/// path only: BeaconLabel.OnHandClick's vanilla body calls uGUI.main.userInput.RequestString(...,
+/// SetLabel) to open the desktop naming dialog, whose callback eventually invokes SetLabel. But for
+/// VR, SubmersedVR's own ShowVirtualKeyboardOnBeacon patch is a PREFIX on OnHandClick that returns
+/// false -- skipping that vanilla body (and the RequestString call) entirely -- and instead opens
+/// its own SteamVR keyboard via VirtualKeyboard.OpenKeyboardWithText, whose completion callback
+/// calls BeaconLabel.SetLabel(label) directly. uGUI.main.userInput.callback is never touched by that
+/// path, so the old postfix's registered handler just sits there unfired: VR beacon renames update
+/// locally (SetLabel still runs and updates the visible label) but never broadcast at all.
+///
+/// SetLabel(string) is the one method both paths actually call -- RequestString's callback
+/// parameter *is* SetLabel (BeaconLabel.OnHandClick: "RequestString(..., SetLabel)"), and
+/// VirtualKeyboard's VR callback calls it directly -- so it's the right place to trigger the
+/// broadcast from, uniformly, instead of chasing each path's own click/deselect trigger.
 /// </summary>
-public sealed partial class BeaconLabel_OnHandClick_Patch : NitroxPatch, IDynamicPatch
+public sealed partial class BeaconLabel_SetLabel_Patch : NitroxPatch, IDynamicPatch
 {
-    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((BeaconLabel t) => t.OnHandClick(default));
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((BeaconLabel t) => t.SetLabel(default));
 
     public static void Postfix(BeaconLabel __instance)
     {
-        uGUI.main.userInput.callback += _ =>
+        if (__instance.transform.parent && __instance.transform.parent.TryGetIdOrWarn(out NitroxId id))
         {
-            if (__instance.transform.parent && __instance.transform.parent.TryGetIdOrWarn(out NitroxId id))
-            {
-                Resolve<Entities>().EntityMetadataChanged(__instance.transform.parent.GetComponent<Beacon>(), id);
-            }
-        };
+            Resolve<Entities>().EntityMetadataChanged(__instance.transform.parent.GetComponent<Beacon>(), id);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The existing broadcast trigger is a postfix on `BeaconLabel.OnHandClick` that registers a callback on `uGUI.main.userInput.callback`, fired once the player finishes typing in the desktop naming dialog that `OnHandClick`'s vanilla body opens via `uGUI.main.userInput.RequestString(..., SetLabel)`.
- VR mods that provide their own text-entry UI commonly patch `OnHandClick` as a prefix returning `false`, skipping that vanilla body — including the `RequestString` call — entirely, and call `BeaconLabel.SetLabel(label)` directly once their own UI submits. `uGUI.main.userInput.callback` is never touched by that path, so the existing trigger's registered handler never fires: renaming works locally (`SetLabel` still runs and updates the visible label) but never broadcasts to other players.
- `SetLabel(string)` is the one method both the desktop dialog and any VR-provided path actually call through — `RequestString`'s own callback parameter *is* `SetLabel` — so it's the correct place to trigger the broadcast from uniformly, instead of chasing each input path's own click/submit trigger.
## Mods I've been using
- Nitrox 1.8.1.0
- https://github.com/Okabintaro/SubmersedVR/releases - Sumbersed [0.2.0]
- https://github.com/TheGeeks0424/BuddySystem - Buddy System [1.10.6]
- https://www.nexusmods.com/site/mods/202 - Subnautica Support [3.3.3]
- https://www.nexusmods.com/subnautica/mods/1108 - Tobey's BepInEx Pack for Subnautica [5.4.23-pack.3.1.1]
## Test plan
- [x] Renamed a beacon via the desktop naming dialog, confirmed it still syncs correctly (regression check).
- [x] Renamed a beacon via a VR mod's own text-entry UI (which bypasses `OnHandClick`'s vanilla body), confirmed the new name now syncs to other clients — previously it never did.