### PR TITLE
Fix PipeSurfaceFloater (Floating Air Pump) losing oxygen supply on reconnect/reload

### DIFF
--- a/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
@@ -75,6 +75,23 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
         {
             PlacedWorldEntitySpawner.AdditionalSpawningSteps(gameObject);
         }
+
+        // PipeSurfaceFloater (Floating Air Pump) is in SubnauticaMap.GLOBAL_ROOT_TECH_TYPES, so it always
+        // spawns through this generic path -- but "deployed" is a purely client-local runtime flag vanilla
+        // only ever sets via the original placer's own OnToolUseAnim() tool-use callback (PipeSurfaceFloater
+        // doesn't derive from PlaceTool, so the block above never covers it). PipeSurfaceFloater.GetProvidesOxygen()
+        // returns false unconditionally while !deployed, and the entire OxygenPipe chain rooted at this floater
+        // (OxygenPipe.GetProvidesOxygen() ultimately asks GetRoot().GetProvidesOxygen()) silently stops
+        // providing oxygen as a result -- for every client except the original placer's own still-running
+        // session, i.e. any reconnect, and even the original placer after this GameObject's cell unloads and
+        // reloads. deployed also gates WorldForces.handleGravity, so an undeployed floater drifts instead of
+        // staying anchored. Any GlobalRootEntity of this TechType reaching this spawner is, by construction
+        // (Items.cs.Dropped()), already placed -- so it's always correct to force this here.
+        if (gameObject.TryGetComponent(out PipeSurfaceFloater pipeSurfaceFloater))
+        {
+            pipeSurfaceFloater.deployed = true;
+            UWE.Utils.SetIsKinematicAndUpdateInterpolation(pipeSurfaceFloater.rigidBody, true, false);
+        }
     }
 
     public static void SetupObjectInWaterPark(GameObject gameObject, LargeWorldEntity largeWorldEntity, WaterPark waterPark)

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/GlobalRootEntitySpawner.cs
@@ -76,21 +76,11 @@ public class GlobalRootEntitySpawner : SyncEntitySpawner<GlobalRootEntity>
             PlacedWorldEntitySpawner.AdditionalSpawningSteps(gameObject);
         }
 
-        // PipeSurfaceFloater (Floating Air Pump) is in SubnauticaMap.GLOBAL_ROOT_TECH_TYPES, so it always
-        // spawns through this generic path -- but "deployed" is a purely client-local runtime flag vanilla
-        // only ever sets via the original placer's own OnToolUseAnim() tool-use callback (PipeSurfaceFloater
-        // doesn't derive from PlaceTool, so the block above never covers it). PipeSurfaceFloater.GetProvidesOxygen()
-        // returns false unconditionally while !deployed, and the entire OxygenPipe chain rooted at this floater
-        // (OxygenPipe.GetProvidesOxygen() ultimately asks GetRoot().GetProvidesOxygen()) silently stops
-        // providing oxygen as a result -- for every client except the original placer's own still-running
-        // session, i.e. any reconnect, and even the original placer after this GameObject's cell unloads and
-        // reloads. deployed also gates WorldForces.handleGravity, so an undeployed floater drifts instead of
-        // staying anchored. Any GlobalRootEntity of this TechType reaching this spawner is, by construction
-        // (Items.cs.Dropped()), already placed -- so it's always correct to force this here.
+        // Any spawned PipeSurfaceFloater should be set as "deployed" per PipeSurfaceFloater.FixedUpdate
+        // the kinematic state will be restored by PipeSurfaceFloater.UpdateRigidBody if it's already surfaced
         if (gameObject.TryGetComponent(out PipeSurfaceFloater pipeSurfaceFloater))
         {
             pipeSurfaceFloater.deployed = true;
-            UWE.Utils.SetIsKinematicAndUpdateInterpolation(pipeSurfaceFloater.rigidBody, true, false);
         }
     }
 


### PR DESCRIPTION
## Summary
- `PipeSurfaceFloater.deployed` is a purely client-local runtime flag that vanilla only ever sets via the original placer's own tool-use callback (`OnToolUseAnim`) — but `PipeSurfaceFloater` doesn't derive from `PlaceTool`, so it's never covered by this spawner's existing `PlaceTool` handling.
- `PipeSurfaceFloater.GetProvidesOxygen()` returns `false` unconditionally while `!deployed`, and the entire `OxygenPipe` chain rooted at this floater ultimately asks `GetRoot().GetProvidesOxygen()` — so the whole chain silently stops providing oxygen for every client except the original placer's own still-running session, i.e. on any reconnect, and even for the original placer once this GameObject's cell unloads and reloads.
- `deployed` also gates `WorldForces.handleGravity`, so an undeployed floater drifts instead of staying anchored.
- Any `GlobalRootEntity` of this `TechType` reaching this spawner is, by construction, already placed (see `Items.cs`'s `Dropped()` checks), so it's always correct to force `deployed = true` and the matching kinematic/physics state here.
## Mods I've been using
- Nitrox 1.8.1.0
- https://github.com/Okabintaro/SubmersedVR/releases - Sumbersed [0.2.0]
- https://github.com/TheGeeks0424/BuddySystem - Buddy System [1.10.6]
- https://www.nexusmods.com/site/mods/202 - Subnautica Support [3.3.3]
- https://www.nexusmods.com/subnautica/mods/1108 - Tobey's BepInEx Pack for Subnautica [5.4.23-pack.3.1.1]
## Test plan
- [x] Placed a Floating Air Pump, connected an oxygen pipe chain to it, disconnected and reconnected to the server, confirmed oxygen supply continued working (previously stopped).
- [x] Confirmed a second player joining after the pump was placed sees it correctly providing oxygen immediately, without needing the original placer present.
- [x] Confirmed the pump stays anchored (doesn't drift) after reconnect.