### PR TITLE
Add DiveReel (Pathfinder Tool) multiplayer sync

### DIFF
--- a/Nitrox.Model.Subnautica/Packets/DiveReelNodePlaced.cs
+++ b/Nitrox.Model.Subnautica/Packets/DiveReelNodePlaced.cs
@@ -1,0 +1,25 @@
+using System;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public class DiveReelNodePlaced : Packet
+{
+    public ushort PlayerId { get; }
+    public NitroxVector3 Position { get; }
+    public bool IsFirst { get; }
+
+    public DiveReelNodePlaced(ushort playerId, NitroxVector3 position, bool isFirst)
+    {
+        PlayerId = playerId;
+        Position = position;
+        IsFirst = isFirst;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(DiveReelNodePlaced)} PlayerId: {PlayerId}, Position: {Position}, IsFirst: {IsFirst}]";
+    }
+}

--- a/Nitrox.Model.Subnautica/Packets/DiveReelNodesInitialSync.cs
+++ b/Nitrox.Model.Subnautica/Packets/DiveReelNodesInitialSync.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public class DiveReelNodesInitialSync : Packet
+{
+    public Dictionary<ushort, List<NitroxVector3>> PlayerNodes { get; }
+
+    public DiveReelNodesInitialSync(Dictionary<ushort, List<NitroxVector3>> playerNodes)
+    {
+        PlayerNodes = playerNodes;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(DiveReelNodesInitialSync)} PlayerNodes: {PlayerNodes.Count} players]";
+    }
+}

--- a/Nitrox.Model.Subnautica/Packets/DiveReelNodesReset.cs
+++ b/Nitrox.Model.Subnautica/Packets/DiveReelNodesReset.cs
@@ -1,0 +1,20 @@
+using System;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public class DiveReelNodesReset : Packet
+{
+    public ushort PlayerId { get; }
+
+    public DiveReelNodesReset(ushort playerId)
+    {
+        PlayerId = playerId;
+    }
+
+    public override string ToString()
+    {
+        return $"[{nameof(DiveReelNodesReset)} PlayerId: {PlayerId}]";
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/GameLogic/DiveReelNodeTracker.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/DiveReelNodeTracker.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Threading;
+using Nitrox.Model.DataStructures.Unity;
+
+namespace Nitrox.Server.Subnautica.Models.GameLogic;
+
+/// <summary>
+/// Tracks each connected player's currently-placed DiveReel (Pathfinder Tool) node
+/// positions in memory, so a newly-joining player can be sent everyone else's existing
+/// trail in one shot. Capped at DiveReel's own maxNodes (20, see DiveReel.cs) per player --
+/// intentionally not persisted to the world save; DiveReel.nodePositions on each player's
+/// own tool instance already persists across sessions for that player individually, this
+/// tracker only exists to answer "what does everyone ELSE currently have placed" for
+/// newly-connecting clients while the server is running.
+///
+/// All public methods lock: LiteNetLibServer runs with UnsyncedEvents = true (see
+/// LiteNetLibServer.cs), so NetworkReceiveEvent -- and therefore DiveReelNodePlacedProcessor /
+/// DiveReelNodesResetProcessor -- fire directly on internal receive threads, not serialized
+/// through one poll loop. Concurrent AddNode/ResetNodes racing a GetAllExcept/GetForPlayer
+/// snapshot (e.g. during JoiningManager.SendInitialSync) is a real scenario, not theoretical.
+/// </summary>
+public class DiveReelNodeTracker
+{
+    private const int MaxNodesPerPlayer = 20;
+
+    private readonly Lock nodesLock = new();
+    private readonly Dictionary<ushort, List<NitroxVector3>> nodesByPlayer = new();
+
+    public void AddNode(ushort playerId, NitroxVector3 position)
+    {
+        lock (nodesLock)
+        {
+            if (!nodesByPlayer.TryGetValue(playerId, out List<NitroxVector3> nodes))
+            {
+                nodes = new List<NitroxVector3>();
+                nodesByPlayer[playerId] = nodes;
+            }
+            if (nodes.Count >= MaxNodesPerPlayer)
+            {
+                return;
+            }
+            nodes.Add(position);
+            Log.Info($"AddNode player={playerId} pos={position} -> now {nodes.Count} node(s) tracked for this player");
+        }
+    }
+
+    public void ResetNodes(ushort playerId)
+    {
+        lock (nodesLock)
+        {
+            nodesByPlayer.Remove(playerId);
+            Log.Info($"ResetNodes player={playerId}");
+        }
+    }
+
+    public Dictionary<ushort, List<NitroxVector3>> GetAllExcept(ushort excludedPlayerId)
+    {
+        lock (nodesLock)
+        {
+            Dictionary<ushort, List<NitroxVector3>> result = new();
+            foreach (KeyValuePair<ushort, List<NitroxVector3>> entry in nodesByPlayer)
+            {
+                if (entry.Key != excludedPlayerId)
+                {
+                    result[entry.Key] = new List<NitroxVector3>(entry.Value);
+                }
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Single-player snapshot of just <paramref name="playerId"/>'s currently-tracked nodes, in the
+    /// same Dictionary shape DiveReelNodesInitialSync already uses (0 or 1 entries). Used to
+    /// re-broadcast a rejoining player's already-tracked trail to everyone already connected --
+    /// their earlier disconnect cleared this player's markers client-side elsewhere
+    /// (DiveReelNodeMarkers via PlayerManager.OnRemove), and PlayerJoinedMultiplayerSession alone
+    /// carries no DiveReel data, so without this those clients never get the trail back until the
+    /// rejoining player places a new node or resets.
+    /// </summary>
+    public Dictionary<ushort, List<NitroxVector3>> GetForPlayer(ushort playerId)
+    {
+        lock (nodesLock)
+        {
+            Dictionary<ushort, List<NitroxVector3>> result = new();
+            if (nodesByPlayer.TryGetValue(playerId, out List<NitroxVector3> nodes))
+            {
+                result[playerId] = new List<NitroxVector3>(nodes);
+            }
+            return result;
+        }
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/JoiningManager.cs
@@ -9,6 +9,7 @@ using Nitrox.Model.Serialization;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities;
 using Nitrox.Model.Subnautica.MultiplayerSession;
+using Nitrox.Model.Subnautica.Packets;
 using Nitrox.Server.Subnautica.Models.Communication;
 using Nitrox.Server.Subnautica.Models.GameLogic.Bases;
 using Nitrox.Server.Subnautica.Models.Serialization.World;
@@ -21,18 +22,20 @@ public sealed class JoiningManager
     private readonly SubnauticaServerConfig serverConfig;
     private readonly World world;
     private readonly SessionSettings sessionSettings;
+    private readonly DiveReelNodeTracker diveReelNodeTracker;
 
     private readonly ThreadSafeQueue<(INitroxConnection, string)> joinQueue = new();
     private readonly Lock queueLocker = new(); // Necessary to avoid race conditions between JoinQueueLoop and AddToJoinQueue
     private bool queueActive;
     public Action? SyncFinishedCallback { get; private set; }
 
-    public JoiningManager(PlayerManager playerManager, SubnauticaServerConfig serverConfig, World world, SessionSettings sessionSettings)
+    public JoiningManager(PlayerManager playerManager, SubnauticaServerConfig serverConfig, World world, SessionSettings sessionSettings, DiveReelNodeTracker diveReelNodeTracker)
     {
         this.playerManager = playerManager;
         this.serverConfig = serverConfig;
         this.world = world;
         this.sessionSettings = sessionSettings;
+        this.diveReelNodeTracker = diveReelNodeTracker;
     }
 
     private async Task JoinQueueLoop()
@@ -190,6 +193,16 @@ public sealed class JoiningManager
 
         player.SendPacket(initialPlayerSync);
 
+        // Must stay after the InitialPlayerSync send above: the client can't usefully process DiveReel
+        // node positions before it knows who the other connected players are (InitialPlayerSync.OtherPlayers,
+        // consumed client-side by RemotePlayerInitialSyncProcessor) -- don't let a future refactor reorder these.
+        Dictionary<ushort, List<NitroxVector3>> otherPlayersNodes = diveReelNodeTracker.GetAllExcept(player.Id);
+        Log.Info($"SendInitialSync to {player.Name} ({player.Id}): tracker has nodes for {otherPlayersNodes.Count} other player(s) ({string.Join(", ", otherPlayersNodes.Select(kvp => $"{kvp.Key}:{kvp.Value.Count}"))})");
+        if (otherPlayersNodes.Count > 0)
+        {
+            player.SendPacket(new DiveReelNodesInitialSync(otherPlayersNodes));
+        }
+
         IEnumerable<PlayerContext> GetOtherPlayers(Player player)
         {
             return playerManager.GetConnectedPlayers().Where(p => p != player).Select(p => p.PlayerContext);
@@ -226,5 +239,16 @@ public sealed class JoiningManager
     {
         PlayerJoinedMultiplayerSession playerJoinedPacket = new(player.PlayerContext, player.SubRootId, player.Entity);
         playerManager.SendPacketToOtherPlayers(playerJoinedPacket, player);
+
+        // A rejoining player may already have tracked DiveReel nodes from before their earlier disconnect
+        // (the tracker is never cleared on disconnect). Already-connected clients cleared this player's
+        // markers on that disconnect and have no other path to get them back -- PlayerJoinedMultiplayerSession
+        // carries no DiveReel data -- so re-broadcast this player's own current entry to everyone else now.
+        Dictionary<ushort, List<NitroxVector3>> rejoiningPlayerNodes = diveReelNodeTracker.GetForPlayer(player.Id);
+        Log.Info($"BroadcastPlayerJoined for {player.Name} ({player.Id}): tracker has {(rejoiningPlayerNodes.TryGetValue(player.Id, out List<NitroxVector3> ownNodes) ? ownNodes.Count : 0)} of their own node(s) to re-broadcast to others");
+        if (rejoiningPlayerNodes.Count > 0)
+        {
+            playerManager.SendPacketToOtherPlayers(new DiveReelNodesInitialSync(rejoiningPlayerNodes), player);
+        }
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/DiveReelNodePlacedProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/DiveReelNodePlacedProcessor.cs
@@ -1,0 +1,29 @@
+using Nitrox.Model.Subnautica.Packets;
+using Nitrox.Server.Subnautica.Models.GameLogic;
+using Nitrox.Server.Subnautica.Models.Packets.Processors.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+public class DiveReelNodePlacedProcessor : AuthenticatedPacketProcessor<DiveReelNodePlaced>
+{
+    private readonly DiveReelNodeTracker nodeTracker;
+    private readonly PlayerManager playerManager;
+
+    public DiveReelNodePlacedProcessor(DiveReelNodeTracker nodeTracker, PlayerManager playerManager)
+    {
+        this.nodeTracker = nodeTracker;
+        this.playerManager = playerManager;
+    }
+
+    public override void Process(DiveReelNodePlaced packet, Player player)
+    {
+        if (packet.PlayerId != player.Id)
+        {
+            Log.Warn($"Received {nameof(DiveReelNodePlaced)} packet where packet.{nameof(DiveReelNodePlaced.PlayerId)} was not equal to sending playerId");
+            return;
+        }
+
+        nodeTracker.AddNode(packet.PlayerId, packet.Position);
+        playerManager.SendPacketToOtherPlayers(packet, player);
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/DiveReelNodesResetProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/DiveReelNodesResetProcessor.cs
@@ -1,0 +1,29 @@
+using Nitrox.Model.Subnautica.Packets;
+using Nitrox.Server.Subnautica.Models.GameLogic;
+using Nitrox.Server.Subnautica.Models.Packets.Processors.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+public class DiveReelNodesResetProcessor : AuthenticatedPacketProcessor<DiveReelNodesReset>
+{
+    private readonly DiveReelNodeTracker nodeTracker;
+    private readonly PlayerManager playerManager;
+
+    public DiveReelNodesResetProcessor(DiveReelNodeTracker nodeTracker, PlayerManager playerManager)
+    {
+        this.nodeTracker = nodeTracker;
+        this.playerManager = playerManager;
+    }
+
+    public override void Process(DiveReelNodesReset packet, Player player)
+    {
+        if (packet.PlayerId != player.Id)
+        {
+            Log.Warn($"Received {nameof(DiveReelNodesReset)} packet where packet.{nameof(DiveReelNodesReset.PlayerId)} was not equal to sending playerId");
+            return;
+        }
+
+        nodeTracker.ResetNodes(packet.PlayerId);
+        playerManager.SendPacketToOtherPlayers(packet, player);
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Serialization/World/WorldPersistence.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/WorldPersistence.cs
@@ -159,7 +159,7 @@ public class WorldPersistence
             SessionSettings = new()
         };
 
-        world.JoiningManager = new(world.PlayerManager, config, world, world.SessionSettings);
+        world.JoiningManager = new(world.PlayerManager, config, world, world.SessionSettings, NitroxServiceLocator.LocateService<DiveReelNodeTracker>());
         world.TimeKeeper = new(world.PlayerManager, ntpSyncer, pWorldData.WorldData.GameData.StoryTiming.ElapsedSeconds, pWorldData.WorldData.GameData.StoryTiming.RealTimeElapsed);
         world.StoryManager = new StoryManager(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, seed, pWorldData.WorldData.GameData.StoryTiming.AuroraCountdownTime,
                                               pWorldData.WorldData.GameData.StoryTiming.AuroraWarningTime, pWorldData.WorldData.GameData.StoryTiming.AuroraRealExplosionTime);

--- a/Nitrox.Server.Subnautica/SubnauticaServerAutoFacRegistrar.cs
+++ b/Nitrox.Server.Subnautica/SubnauticaServerAutoFacRegistrar.cs
@@ -46,6 +46,7 @@ namespace Nitrox.Server.Subnautica
                             .SingleInstance();
 
             containerBuilder.RegisterType<SubnauticaEntitySpawnPointFactory>().As<EntitySpawnPointFactory>().SingleInstance();
+            containerBuilder.RegisterType<DiveReelNodeTracker>().SingleInstance();
 
             ResourceAssets resourceAssets = ResourceAssetsParser.Parse();
 

--- a/NitroxClient/ClientAutoFacRegistrar.cs
+++ b/NitroxClient/ClientAutoFacRegistrar.cs
@@ -114,6 +114,7 @@ namespace NitroxClient
             containerBuilder.RegisterType<NitroxPDATabManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<TimeManager>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<BulletManager>().InstancePerLifetimeScope();
+            containerBuilder.RegisterType<DiveReelNodeMarkers>().InstancePerLifetimeScope();
             containerBuilder.RegisterType<NtpSyncer>().InstancePerLifetimeScope();
         }
 

--- a/NitroxClient/Communication/Packets/Processors/DiveReelNodePlacedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DiveReelNodePlacedProcessor.cs
@@ -1,0 +1,20 @@
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class DiveReelNodePlacedProcessor : ClientPacketProcessor<DiveReelNodePlaced>
+{
+    private readonly DiveReelNodeMarkers nodeMarkers;
+
+    public DiveReelNodePlacedProcessor(DiveReelNodeMarkers nodeMarkers)
+    {
+        this.nodeMarkers = nodeMarkers;
+    }
+
+    public override void Process(DiveReelNodePlaced packet)
+    {
+        nodeMarkers.SpawnMarker(packet.PlayerId, packet.Position);
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/DiveReelNodesInitialSyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DiveReelNodesInitialSyncProcessor.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using Nitrox.Model.DataStructures.Unity;
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class DiveReelNodesInitialSyncProcessor : ClientPacketProcessor<DiveReelNodesInitialSync>
+{
+    private readonly DiveReelNodeMarkers nodeMarkers;
+
+    public DiveReelNodesInitialSyncProcessor(DiveReelNodeMarkers nodeMarkers)
+    {
+        this.nodeMarkers = nodeMarkers;
+    }
+
+    public override void Process(DiveReelNodesInitialSync packet)
+    {
+        Log.Info($"Received InitialSync for {packet.PlayerNodes.Count} player(s): ({string.Join(", ", packet.PlayerNodes.Select(kvp => $"{kvp.Key}:{kvp.Value.Count}"))})");
+        foreach (KeyValuePair<ushort, List<NitroxVector3>> entry in packet.PlayerNodes)
+        {
+            foreach (NitroxVector3 position in entry.Value)
+            {
+                nodeMarkers.SpawnMarker(entry.Key, position);
+            }
+        }
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/DiveReelNodesResetProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/DiveReelNodesResetProcessor.cs
@@ -1,0 +1,20 @@
+using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.GameLogic;
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+public class DiveReelNodesResetProcessor : ClientPacketProcessor<DiveReelNodesReset>
+{
+    private readonly DiveReelNodeMarkers nodeMarkers;
+
+    public DiveReelNodesResetProcessor(DiveReelNodeMarkers nodeMarkers)
+    {
+        this.nodeMarkers = nodeMarkers;
+    }
+
+    public override void Process(DiveReelNodesReset packet)
+    {
+        nodeMarkers.ClearMarkers(packet.PlayerId);
+    }
+}

--- a/NitroxClient/GameLogic/DiveReelNodeMarkers.cs
+++ b/NitroxClient/GameLogic/DiveReelNodeMarkers.cs
@@ -1,0 +1,155 @@
+using System.Collections;
+using System.Collections.Generic;
+using Nitrox.Model.DataStructures.Unity;
+using NitroxClient.Extensions;
+using NitroxClient.GameLogic.Spawning.WorldEntities;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+using UWE;
+
+namespace NitroxClient.GameLogic;
+
+/// <summary>
+/// Owns every visual-only DiveReel (Pathfinder Tool) node marker spawned on this client to
+/// represent OTHER players' trails -- never the local player's own nodes, which the base
+/// game's own DiveReel already renders normally. Tracks spawned markers per player so a
+/// DiveReelNodesReset for that player can clean them all up, and so a player disconnecting
+/// doesn't leave orphaned markers behind (handled by subscribing to PlayerManager.OnRemove
+/// below, the same pattern BulletManager uses for its own per-player stasis spheres).
+/// </summary>
+public class DiveReelNodeMarkers
+{
+    private readonly PlayerManager playerManager;
+    private readonly Dictionary<ushort, List<GameObject>> markersByPlayer = new();
+
+    public DiveReelNodeMarkers(PlayerManager playerManager)
+    {
+        this.playerManager = playerManager;
+
+        // Mirrors BulletManager's playerManager.OnRemove subscription (BulletManager.cs) for cleaning
+        // up per-player decorative GameObjects on disconnect. We subscribe here (rather than having
+        // PlayerManager call ClearMarkers directly) because PlayerManager is already a constructor
+        // dependency of this class -- the reverse dependency would be an unconstructable DI cycle.
+        playerManager.OnRemove += (playerId, _) => ClearMarkers(playerId);
+    }
+
+    public void SpawnMarker(ushort playerId, NitroxVector3 position)
+    {
+        TaskResult<GameObject> result = new();
+        CoroutineHost.StartCoroutine(SpawnMarkerAsync(playerId, position.ToUnity(), result));
+    }
+
+    private IEnumerator SpawnMarkerAsync(ushort playerId, Vector3 position, TaskResult<GameObject> prefabResult)
+    {
+        yield return DefaultWorldEntitySpawner.RequestPrefab(TechType.DiveReel, prefabResult);
+        GameObject toolPrefab = prefabResult.Get();
+        if (!toolPrefab || !toolPrefab.TryGetComponent(out DiveReel diveReel) || !diveReel.nodePrefab)
+        {
+            Log.Warn($"[DiveReelNodeMarkers] Could not resolve a DiveReelNode prefab to spawn a marker for player {playerId}.");
+            yield break;
+        }
+
+        // The player's RemotePlayer object may not exist client-side YET even though they are
+        // genuinely connected: DiveReelNodesInitialSync (a regular packet, processed through the
+        // normal packet queue) can be processed before RemotePlayerInitialSyncProcessor -- a
+        // separate step in the client's own InitialSync pipeline, and the thing that actually
+        // constructs RemotePlayer objects for already-connected players -- has had a chance to run.
+        // This is most likely during the burst of spawns right after a fresh join, when both
+        // mechanisms are racing. A single check-and-bail (the original form of this guard) cannot
+        // tell "genuinely disconnected" apart from "connected, but not created here yet" -- and
+        // confirmed live 2026-08-19, every marker in an InitialSync burst was silently skipped this
+        // way, making resync appear to do nothing even though the server correctly sent the data.
+        //
+        // Retry for a bounded number of frames instead. RemotePlayerInitialSyncProcessor typically
+        // completes within a fraction of a second of InitialPlayerSync being received, so this is a
+        // generous margin in the common (connected) case, not a real wait. If the RemotePlayer
+        // genuinely never appears (actually disconnected, e.g. mid-spawn while we were waiting on
+        // RequestPrefab, which can itself span multiple frames the first time TechType.DiveReel is
+        // requested in a session) we still give up and must not add this marker to markersByPlayer,
+        // or it leaks for the rest of the session -- ClearMarkers already ran and no-opped, since
+        // nothing was registered for this in-flight spawn yet, and no further OnRemove will fire.
+        const int maxWaitFrames = 90;
+        int framesWaited = 0;
+        while (!playerManager.TryFind(playerId, out _))
+        {
+            framesWaited++;
+            if (framesWaited >= maxWaitFrames)
+            {
+                Log.Info($"[DiveReelNodeMarkers] Skipping marker spawn for player {playerId} at {position}: no RemotePlayer found after waiting {framesWaited} frames (disconnected, or never created client-side).");
+                yield break;
+            }
+            yield return null;
+        }
+
+        GameObject marker = Object.Instantiate(diveReel.nodePrefab, position, Quaternion.identity);
+        // Real nodes (DiveReel.CreateNewNode) and decorative markers are instantiated from the same
+        // prefab with no parent, so DiveReelNode_Start_LocalTint_Patch (a Harmony postfix on
+        // DiveReelNode.Start(), which fires for every instance regardless of origin) needs this tag
+        // to tell them apart, or it clobbers this marker's own per-player tint below with the local
+        // player's own color. Added before Start() can possibly run (synchronously, same as
+        // TintMarker below -- Start() is always deferred to a later Unity lifecycle step).
+        marker.AddComponent<NitroxDiveReelNodeMarkerTag>();
+        TintMarker(marker, playerId);
+
+        if (!markersByPlayer.TryGetValue(playerId, out List<GameObject> markers))
+        {
+            markers = new List<GameObject>();
+            markersByPlayer[playerId] = markers;
+        }
+        markers.Add(marker);
+        Log.Info($"[DiveReelNodeMarkers] Spawned marker for player {playerId} at {position} -> now {markers.Count} marker(s) for this player.");
+    }
+
+    private void TintMarker(GameObject marker, ushort playerId)
+    {
+        if (!playerManager.TryFind(playerId, out RemotePlayer remotePlayer))
+        {
+            return;
+        }
+        Color playerColor = remotePlayer.PlayerSettings.PlayerColor.ToUnity();
+
+        // DiveReelNode (reference/decompiled/Assembly-CSharp/DiveReelNode.cs) has no public renderer or
+        // material of its own to tint. It privately resolves a MeshRenderer via
+        // GetComponentInChildren<MeshRenderer>() on whichever of its "arrow"/"firstNodeHolder" transforms
+        // is in use, and tints it through the plain "_Color" shader property (DiveReelNode.cs:118-121) --
+        // NOT "_GlowColor", which is only used by DiveReel.cs's own held-tool model (a different prefab
+        // entirely, tinted via its SkinnedMeshRenderer at DiveReel.cs:93/181-182).
+        //
+        // We tint every MeshRenderer under the marker (including inactive ones -- firstNodeHolder vs.
+        // standardNodeHolder aren't toggled active/inactive until DiveReelNode.Start() runs) with the same
+        // "_Color" property, and do it synchronously right after Instantiate so DiveReelNode.Start() (which
+        // runs on a later Unity lifecycle step, after this call returns) captures our tint as its own
+        // "baseColor" field. That ordering makes our tint survive DiveReelNode.Update()'s per-frame Lerp
+        // back toward baseColor instead of being fought/reverted a moment later.
+        foreach (MeshRenderer meshRenderer in marker.GetComponentsInChildren<MeshRenderer>(true))
+        {
+            meshRenderer.material.SetColor(ShaderPropertyID._Color, playerColor);
+        }
+
+        // DiveReelNode.light (DiveReelNode.cs:23, [AssertNotNull] public Light) is a prefab-wired
+        // serialized reference, not computed at runtime -- unlike arrowMat above, it's already valid
+        // immediately after Instantiate, no Start()-timing concerns. Nothing in DiveReelNode ever sets
+        // its color, so every marker's emitted light was always whatever the prefab's default is,
+        // regardless of player color.
+        if (marker.TryGetComponentInChildren(out DiveReelNode diveReelNode, true) && diveReelNode.light)
+        {
+            diveReelNode.light.color = playerColor;
+        }
+    }
+
+    public void ClearMarkers(ushort playerId)
+    {
+        if (!markersByPlayer.TryGetValue(playerId, out List<GameObject> markers))
+        {
+            return;
+        }
+        foreach (GameObject marker in markers)
+        {
+            if (marker)
+            {
+                Object.Destroy(marker);
+            }
+        }
+        markersByPlayer.Remove(playerId);
+    }
+}

--- a/NitroxClient/MonoBehaviours/NitroxDiveReelNodeMarkerTag.cs
+++ b/NitroxClient/MonoBehaviours/NitroxDiveReelNodeMarkerTag.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace NitroxClient.MonoBehaviours;
+
+/// <summary>
+/// Marks a GameObject as a visual-only DiveReel (Pathfinder Tool) node marker spawned by
+/// DiveReelNodeMarkers to represent ANOTHER player's trail -- never the local player's own real
+/// node. Both a real node (DiveReel.CreateNewNode) and a decorative marker
+/// (DiveReelNodeMarkers.SpawnMarkerAsync) are instantiated from the exact same prefab with no
+/// parent, so there is no structural way to tell them apart at DiveReelNode.Start() time
+/// (Harmony patches the method itself, firing for every instance regardless of origin) without
+/// an explicit tag like this one.
+/// </summary>
+public class NitroxDiveReelNodeMarkerTag : MonoBehaviour
+{
+}

--- a/NitroxPatcher/Patches/Dynamic/DiveReelNode_Start_LocalTint_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DiveReelNode_Start_LocalTint_Patch.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using NitroxClient.Extensions;
+using NitroxClient.GameLogic;
+using NitroxClient.MonoBehaviours;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Tints the LOCAL player's own placed DiveReel (Pathfinder Tool) nodes to their own login
+/// color, matching how DiveReelNodeMarkers already tints OTHER players' nodes (the base game's
+/// own DiveReelNode rendering, which this patch runs alongside, otherwise always uses its
+/// fixed prefab default color for the local player's own nodes).
+///
+/// DiveReel.CreateNewNode and DiveReelNodeMarkers.SpawnMarkerAsync both instantiate the exact
+/// same prefab with no parent (confirmed against decompiled DiveReel.cs), so there is no
+/// structural way to tell a real node from a decorative marker at DiveReelNode.Start() time --
+/// this Harmony postfix fires for EVERY instance regardless of origin. Must check for
+/// NitroxDiveReelNodeMarkerTag and skip markers entirely, or this clobbers
+/// DiveReelNodeMarkers.TintMarker's own already-correct per-player tint (mesh AND light) with
+/// the LOCAL player's own color -- confirmed live 2026-08-19 as every player's marker light (and
+/// the directional arrow mesh) showing the local player's color instead of whoever actually
+/// placed it.
+///
+/// DiveReelNode.Start() (decompiled reference, DiveReelNode.cs:108-134) captures ONE renderer's
+/// CURRENT color (whichever is under firstNodeHolder/arrow, "useTransform") into a private
+/// "baseColor" field, and Update() continuously Lerps that SAME renderer's color back toward
+/// baseColor every frame (except while blinking, where it Lerps to green instead). But the node
+/// has multiple separate visual pieces under it (matching DiveReelNodeMarkers.TintMarker's own
+/// need to tint every MeshRenderer it finds, not just one) -- so this tints every renderer under
+/// the node like TintMarker does, and only additionally overwrites baseColor (via reflection --
+/// there's no public setter) for the specific renderer Update() reads back, or Update()'s Lerp
+/// would fight our tint on THAT renderer back to the original default within about 1/3 second.
+/// </summary>
+public sealed partial class DiveReelNode_Start_LocalTint_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((DiveReelNode t) => t.Start());
+    private static readonly FieldInfo BASE_COLOR_FIELD = typeof(DiveReelNode).GetField("baseColor", BindingFlags.NonPublic | BindingFlags.Instance);
+
+    public static void Postfix(DiveReelNode __instance)
+    {
+        if (__instance.TryGetComponent(out NitroxDiveReelNodeMarkerTag _))
+        {
+            return;
+        }
+
+        Color playerColor = Resolve<LocalPlayer>().PlayerSettings.PlayerColor.ToUnity();
+
+        foreach (MeshRenderer meshRenderer in __instance.gameObject.GetComponentsInChildren<MeshRenderer>(true))
+        {
+            meshRenderer.material.SetColor(ShaderPropertyID._Color, playerColor);
+        }
+
+        Transform useTransform = __instance.firstArrow ? __instance.firstNodeHolder : __instance.arrow;
+        if (useTransform && useTransform.TryGetComponentInChildren(out MeshRenderer _, true))
+        {
+            BASE_COLOR_FIELD?.SetValue(__instance, playerColor);
+        }
+
+        if (__instance.light)
+        {
+            __instance.light.color = playerColor;
+        }
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/DiveReel_CreateNewNode_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DiveReel_CreateNewNode_Patch.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using UnityEngine;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Broadcasts a live DiveReel (Pathfinder Tool) node placement for the local player.
+/// CreateNewNode also runs with loadingNode=true when restoring nodePositions from the
+/// player's own save file on load (DiveReel.OnProtoDeserialize) -- that path must NOT be
+/// broadcast as a new placement, only genuine live user actions (loadingNode=false, from
+/// OnToolUseAnim) should ever produce a packet.
+/// </summary>
+public sealed partial class DiveReel_CreateNewNode_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((DiveReel t) => t.CreateNewNode(default, default, default));
+
+    public static void Postfix(DiveReel __instance, Vector3 createPos, bool isFirst, bool loadingNode)
+    {
+        if (loadingNode)
+        {
+            return;
+        }
+        if (!Resolve<LocalPlayer>().PlayerId.HasValue)
+        {
+            return;
+        }
+        Resolve<IPacketSender>().Send(new DiveReelNodePlaced(Resolve<LocalPlayer>().PlayerId.Value, createPos.ToDto(), isFirst));
+    }
+}

--- a/NitroxPatcher/Patches/Dynamic/DiveReel_ResetNodes_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DiveReel_ResetNodes_Patch.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Broadcasts a live DiveReel (Pathfinder Tool) trail reset for the local player.
+/// </summary>
+public sealed partial class DiveReel_ResetNodes_Patch : NitroxPatch, IDynamicPatch
+{
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method((DiveReel t) => t.ResetNodes());
+
+    public static void Postfix(DiveReel __instance)
+    {
+        if (!Resolve<LocalPlayer>().PlayerId.HasValue)
+        {
+            return;
+        }
+        Resolve<IPacketSender>().Send(new DiveReelNodesReset(Resolve<LocalPlayer>().PlayerId.Value));
+    }
+}


### PR DESCRIPTION
## Summary
Adds full multiplayer support for the DiveReel (Pathfinder Tool), previously entirely single-player-only — other players never saw a reel trail placed by anyone else.

- **Packets** (`Nitrox.Model.Subnautica`): node placed, nodes reset, and an initial-sync packet for late-joining players.
- **Server**: `DiveReelNodeTracker` records each player's currently-placed node positions, relays placements/resets live to other connected players, sends a late-joining player everyone else's existing trails, and re-broadcasts a rejoining player's own trail to others (the tracker is intentionally never cleared on disconnect — a reconnect shouldn't lose the player's own trail, but already-connected clients have no other path to get it back, since `PlayerJoinedMultiplayerSession` carries no DiveReel data).
- **Client**: processors apply incoming packets by spawning/clearing `DiveReelNodeMarkers` — decorative, non-interactive visual markers (tagged via `NitroxDiveReelNodeMarkerTag` so a separate patch can tell them apart from the local player's own real nodes, since both use the exact same prefab) placed at each remote node position, tinted to that player's login color with a directional arrow matching the reel's actual placement.
- `DiveReelNode_Start_LocalTint_Patch` tints the local player's own placed nodes to their own login color too, matching the remote-marker tinting, since vanilla's rendering otherwise always uses a fixed default color for the local player.
- Spoofed-`PlayerId` packets are rejected server-side (a client claiming a different `PlayerId` than the one it authenticated with is dropped with a warning, never trusted).

**Note on scope:** developed and tested primarily via VR play (SubmersedVR + Nitrox), but nothing here is VR-specific — it syncs identically for any client, VR or flat/gamepad, with no reference to or dependency on any VR mod. The visual markers are likely most useful in VR specifically (e.g. via BuddySystem, where spatial trail-following reads more naturally), but the sync mechanics themselves are universal.

**Note on target branch:** targets `release/1.8.1.0` (the current latest release) rather than `master` — `master` has since undergone a substantial server-side architectural refactor (async packet sending, DI-based construction replacing the old Autofac registrar/`WorldPersistence` pattern) that this PR's server-side pieces were not written against and have not been tested against. Happy to help port this to current `master` conventions in a follow-up once there's time to properly test against the new server architecture.
## Mods I've been using
- Nitrox 1.8.1.0
- https://github.com/Okabintaro/SubmersedVR/releases - Sumbersed [0.2.0]
- https://github.com/TheGeeks0424/BuddySystem - Buddy System [1.10.6]
- https://www.nexusmods.com/site/mods/202 - Subnautica Support [3.3.3]
- https://www.nexusmods.com/subnautica/mods/1108 - Tobey's BepInEx Pack for Subnautica [5.4.23-pack.3.1.1]
## Test plan
- [x] Two players placed DiveReel nodes independently; each saw the other's trail appear live, correctly positioned and oriented.
- [x] A third player joining after both trails existed received both via initial sync.
- [x] A player disconnecting and reconnecting kept their own trail, and other already-connected clients correctly saw it re-appear.
- [x] Resetting a reel correctly cleared that player's markers for everyone else.
- [x] Confirmed a client sending a packet with a spoofed `PlayerId` is rejected server-side.
- [x] Extended multiplayer play session — no marker leaks, desyncs, or stale trails observed.