### PR TITLE
Fix XDG path resolution when env vars explicitly set

### DIFF
--- a/Nitrox.Model/Helper/NitroxDirectory.cs
+++ b/Nitrox.Model/Helper/NitroxDirectory.cs
@@ -300,11 +300,10 @@ public static class NitroxDirectory
             }
 
             string? xdgPath = Environment.GetEnvironmentVariable(GetXdgName(directory));
-            if (!string.IsNullOrWhiteSpace(xdgPath) && Path.IsPathRooted(xdgPath))
+            if (string.IsNullOrWhiteSpace(xdgPath) || !Path.IsPathRooted(xdgPath))
             {
-                return xdgPath;
+                xdgPath = GetXdgDefaultPath(directory);
             }
-            xdgPath = GetXdgDefaultPath(directory);
             xdgPath = Path.Combine([GetAsNitroxPath(xdgPath), ..folderNames]);
             Directory.CreateDirectory(xdgPath);
             return xdgPath;

--- a/Nitrox.Model/Helper/NitroxDirectory.cs
+++ b/Nitrox.Model/Helper/NitroxDirectory.cs
@@ -204,7 +204,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.CONFIG);
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.CONFIG);
             }
         }
 
@@ -216,7 +216,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.CACHE);
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.CACHE);
             }
         }
 
@@ -228,7 +228,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.DATA, "screenshots");
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.DATA, "screenshots");
             }
         }
 
@@ -240,7 +240,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.STATE, "crashes");
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.STATE, "crashes");
             }
         }
 
@@ -252,7 +252,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.STATE, "logs");
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.STATE, "logs");
             }
         }
 
@@ -264,7 +264,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.DATA, "saves");
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.DATA, "saves");
             }
         }
 
@@ -276,7 +276,7 @@ public static class NitroxDirectory
                 {
                     return field;
                 }
-                return field = GetXdgPathIfNotWineOrUserGiven(XdgDirectory.DATA, "backups");
+                return field = GetXdgPathIfNotUserGiven(XdgDirectory.DATA, "backups");
             }
         }
 
@@ -290,7 +290,7 @@ public static class NitroxDirectory
                 _ => NitroxDirectory.ConfigPath
             };
 
-        private string GetXdgPathIfNotWineOrUserGiven(XdgDirectory directory, params string[] folderNames)
+        private string GetXdgPathIfNotUserGiven(XdgDirectory directory, params string[] folderNames)
         {
             if (UserSpecifiedDataPath is { } userPath)
             {


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
Fixes #2847 

## Description of Change
When the XDG home env vars are explicitly set by the user in their Linux environment, the saves, configs, logs etc would try to grab them in the specified XDG_HOME or one of the other 3, rather than in the Nitrox subdirectory.

## Validation

1. Launch Nitrox with `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, or `XDG_STATE_HOME` explicitly to something like: `export XDG_DATA_HOME=$HOME/.local/share`.
2. Observe that it's now routing you into the Nitrox subfolder
3. Compare this to current Master which will try to route you to `~/.local/share` with no subfolder

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has a linked issue
---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
