### PR TITLE
WorldData : Remove Legacy Seed Data

### DIFF
--- a/Nitrox.Server.Subnautica/Models/Serialization/World/WorldData.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/World/WorldData.cs
@@ -10,9 +10,6 @@ internal class WorldData
 
     public GameData? GameData { get; set; }
 
-    [Obsolete("Use server.cfg seed instead - TODO: delete this but keep backward compat via save upgrade")]
-    public string? Seed { get; set; }
-
     public bool IsValid()
     {
         return ParsedBatchCells != null &&


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2854

## Description of Change

Removed obsolete `Seed` property from `WorldData` class. The seed is now stored in `server.cfg` instead.

## Validation

- Built successfully with no errors
- Server starts and loads worlds correctly
- World save/load works without issues

## PR Checklist

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/Linux/macOS (if applicable) - Windows only
