### PR TITLE
[Linux] Add support for distro-managed Proton

### DIFF
--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -590,6 +590,7 @@ public sealed class Steam : IGamePlatform
                 catch (Exception ex)
                 {
                     Log.Error(ex, $"Failed to read toolmanifest.vdf for proton at '{protonPath}'");
+                    return null;
                 }
             }
 

--- a/Nitrox.Model/Platforms/Store/Steam.cs
+++ b/Nitrox.Model/Platforms/Store/Steam.cs
@@ -318,13 +318,7 @@ public sealed class Steam : IGamePlatform
                 }
             }
 
-            string sniperAppId = "1628350";
             SteamLibrariesVdf steamLibraries = SteamLibrariesVdf.Load(steamPath);
-            if (!steamLibraries.TryGetSteamAppLibraryPath(sniperAppId, out string steamRuntimeLibraryPath) || !Directory.Exists(steamRuntimeLibraryPath))
-            {
-                throw new Exception("Could not find or access the Steam compatibility runtime 'sniper'");
-            }
-            string steamRuntimePath = Path.Combine(steamRuntimeLibraryPath, "steamapps", "common", "SteamLinuxRuntime_sniper");
 
             string? protonVersion = GetProtonVersionOfSteamApp(Path.Combine(steamPath, "config", "config.vdf"), steamAppId.ToString());
             string? protonPath = protonVersion != null ? steamLibraries.GetProtonPathByVersion(protonVersion) : null;
@@ -334,6 +328,13 @@ public sealed class Steam : IGamePlatform
                 throw new Exception("Steam Proton is unavailable. Please try change game properties in Steam to use the Proton compatibility layer.");
             }
             Log.Debug($"Starting game with proton: {protonPath}");
+
+            // Each Proton build declares which Steam Linux Runtime container it needs to run inside
+            string? steamRuntimePath = steamLibraries.GetRuntimePathForProton(protonPath);
+            if (steamRuntimePath == null)
+            {
+                throw new Exception($"""Could not find or access the Steam Linux Runtime container required by proton "{Path.GetFileName(protonPath)}".""");
+            }
 
             result.FileName = Path.Combine(steamRuntimePath, "_v2-entry-point");
             result.Arguments = $" --verb=run -- \"{Path.Combine(protonPath, "proton")}\" run \"{gameFilePath}\" {args}";
@@ -405,13 +406,31 @@ public sealed class Steam : IGamePlatform
     /// <summary>
     ///     Helper class for extracting information based on Steam Libraries VDF file.
     /// </summary>
-    private class SteamLibrariesVdf
+    internal class SteamLibrariesVdf
     {
         private readonly string steamRootPath;
         private readonly string vdfContent;
         private List<string>? allLibraryPathsCache;
 
-        private string ProtonRootPath => Path.Combine(steamRootPath, "compatibilitytools.d");
+        private IEnumerable<string> ProtonRootPaths
+        {
+            get
+            {
+                yield return Path.Combine(steamRootPath, "compatibilitytools.d");
+
+                // Distro-packaged Proton builds register under a system-wide dir instead of the user's Steam folder,
+                // mirroring what Steam itself scans for compat tools.
+                string xdgDataDirs = Environment.GetEnvironmentVariable("XDG_DATA_DIRS");
+                if (string.IsNullOrWhiteSpace(xdgDataDirs))
+                {
+                    xdgDataDirs = "/usr/local/share:/usr/share";
+                }
+                foreach (string dataDir in xdgDataDirs.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    yield return Path.Combine(dataDir, "steam", "compatibilitytools.d");
+                }
+            }
+        }
 
         private SteamLibrariesVdf(string steamRootPath, string vdfContent)
         {
@@ -484,9 +503,9 @@ public sealed class Steam : IGamePlatform
                 return null;
             }
 
-            // If custom Proton (non-Steam), try path directly.
-            string customProtonPath = Path.Combine(ProtonRootPath, protonVersion);
-            return HasProtonExecutable(customProtonPath) ? customProtonPath : null;
+            // If custom Proton, try each known compatibility tool root directly.
+            return ProtonRootPaths.Select(rootPath => Path.Combine(rootPath, protonVersion))
+                                   .FirstOrDefault(HasProtonExecutable);
 
             static string? GetProtonPathFast(IEnumerable<string> steamLibraries, string protonVersion)
             {
@@ -544,7 +563,66 @@ public sealed class Steam : IGamePlatform
                                   .ThenByDescending(candidate => candidate.FolderName.Contains("Experimental", StringComparison.OrdinalIgnoreCase))
                                   .Select(candidate => candidate.Path)
                                   .FirstOrDefault();
-            return valveProton ?? EnumerateDirectories(ProtonRootPath).FirstOrDefault(HasProtonExecutable);
+            return valveProton ?? ProtonRootPaths.SelectMany(EnumerateDirectories).FirstOrDefault(HasProtonExecutable);
+        }
+
+        /// <summary>
+        /// Resolves the Steam Linux Runtime container a Proton build needs to run inside, per its tool manifest
+        /// Builds without one default to Steam Linux Runtime 3.0 (sniper)
+        /// This should pretty closely match how steam handles this.
+        /// </summary>
+        public string? GetRuntimePathForProton(string protonPath)
+        {
+            const string SNIPER_RUNTIME_APP_ID = "1628350";
+
+            string requiredRuntimeAppId = SNIPER_RUNTIME_APP_ID;
+            string toolManifestPath = Path.Combine(protonPath, "toolmanifest.vdf");
+            if (File.Exists(toolManifestPath))
+            {
+                try
+                {
+                    Match match = Regex.Match(File.ReadAllText(toolManifestPath), @"""require_tool_appid""\s*""(\d+)""");
+                    if (match.Success)
+                    {
+                        requiredRuntimeAppId = match.Groups[1].Value;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, $"Failed to read toolmanifest.vdf for proton at '{protonPath}'");
+                }
+            }
+
+            if (!TryGetSteamAppLibraryPath(requiredRuntimeAppId, out string libraryPath) || !Directory.Exists(libraryPath))
+            {
+                return null;
+            }
+            string steamAppsPath = Path.Combine(libraryPath, "steamapps");
+            if (GetAppInstallDirFromManifest(steamAppsPath, requiredRuntimeAppId) is not { } installDir)
+            {
+                return null;
+            }
+            string runtimePath = Path.Combine(steamAppsPath, "common", installDir);
+            return Directory.Exists(runtimePath) ? runtimePath : null;
+
+            static string? GetAppInstallDirFromManifest(string steamAppsPath, string appId)
+            {
+                string manifestPath = Path.Combine(steamAppsPath, $"appmanifest_{appId}.acf");
+                if (!File.Exists(manifestPath))
+                {
+                    return null;
+                }
+                try
+                {
+                    Match match = Regex.Match(File.ReadAllText(manifestPath), @"""installdir""\s*""([^""]+)""");
+                    return match.Success ? match.Groups[1].Value : null;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, $"Failed to read '{manifestPath}'");
+                    return null;
+                }
+            }
         }
 
         public IReadOnlyCollection<string> GetAllLibraryPaths()

--- a/Nitrox.Test/Model/Platforms/Store/SteamTest.cs
+++ b/Nitrox.Test/Model/Platforms/Store/SteamTest.cs
@@ -1,0 +1,160 @@
+using System.Runtime.Versioning;
+using Nitrox.Test.Model.Platforms;
+
+namespace Nitrox.Model.Platforms.Store;
+
+[TestClass]
+[SupportedOSPlatform("linux")]
+public class SteamTest
+{
+    private string tempRoot = null!;
+    private string? originalXdgDataDirs;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        tempRoot = Path.Combine(Path.GetTempPath(), $"NitroxSteamTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        originalXdgDataDirs = Environment.GetEnvironmentVariable("XDG_DATA_DIRS");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable("XDG_DATA_DIRS", originalXdgDataDirs);
+        Directory.Delete(tempRoot, true);
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void GetProtonPathByVersion_FindsCustomProton_InSystemWideXdgCompatToolsDir()
+    {
+        string steamRoot = CreateSteamRoot();
+        string xdgShare = Path.Combine(tempRoot, "xdg-share");
+        string systemProtonDir = Path.Combine(xdgShare, "steam", "compatibilitytools.d", "proton-cachyos-slr");
+        Directory.CreateDirectory(systemProtonDir);
+        File.WriteAllText(Path.Combine(systemProtonDir, "proton"), "");
+        Environment.SetEnvironmentVariable("XDG_DATA_DIRS", xdgShare);
+
+        Steam.SteamLibrariesVdf steamLibraries = Steam.SteamLibrariesVdf.Load(steamRoot);
+        string? result = steamLibraries.GetProtonPathByVersion("proton-cachyos-slr");
+
+        result.Should().Be(systemProtonDir);
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void GetProtonPathByVersion_ReturnsNull_WhenCustomProtonNotInstalledAnywhere()
+    {
+        string steamRoot = CreateSteamRoot();
+        Environment.SetEnvironmentVariable("XDG_DATA_DIRS", Path.Combine(tempRoot, "nonexistent-xdg-share"));
+
+        Steam.SteamLibrariesVdf steamLibraries = Steam.SteamLibrariesVdf.Load(steamRoot);
+        string? result = steamLibraries.GetProtonPathByVersion("proton-cachyos-slr");
+
+        result.Should().BeNull();
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void GetRuntimePathForProton_UsesRequireToolAppIdFromToolManifest()
+    {
+        const string runtimeAppId = "4183110";
+        string steamRoot = CreateSteamRoot();
+        string libraryPath = Path.Combine(tempRoot, "library");
+        CreateSteamApp(libraryPath, runtimeAppId, "SteamLinuxRuntime_4");
+        WriteLibraryFolders(steamRoot, libraryPath, runtimeAppId);
+
+        string protonPath = Path.Combine(tempRoot, "proton-cachyos-slr");
+        Directory.CreateDirectory(protonPath);
+        File.WriteAllText(Path.Combine(protonPath, "toolmanifest.vdf"), $$"""
+            "manifest"
+            {
+                "require_tool_appid" "{{runtimeAppId}}"
+            }
+            """);
+
+        Steam.SteamLibrariesVdf steamLibraries = Steam.SteamLibrariesVdf.Load(steamRoot);
+        string? result = steamLibraries.GetRuntimePathForProton(protonPath);
+
+        result.Should().Be(Path.Combine(libraryPath, "steamapps", "common", "SteamLinuxRuntime_4"));
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void GetRuntimePathForProton_DefaultsToSniper_WhenProtonHasNoToolManifest()
+    {
+        const string sniperAppId = "1628350";
+        string steamRoot = CreateSteamRoot();
+        string libraryPath = Path.Combine(tempRoot, "library");
+        CreateSteamApp(libraryPath, sniperAppId, "SteamLinuxRuntime_sniper");
+        WriteLibraryFolders(steamRoot, libraryPath, sniperAppId);
+
+        // GE Proton and similar builds ship without a toolmanifest.vdf.
+        string protonPath = Path.Combine(tempRoot, "GE-Proton10-34");
+        Directory.CreateDirectory(protonPath);
+
+        Steam.SteamLibrariesVdf steamLibraries = Steam.SteamLibrariesVdf.Load(steamRoot);
+        string? result = steamLibraries.GetRuntimePathForProton(protonPath);
+
+        result.Should().Be(Path.Combine(libraryPath, "steamapps", "common", "SteamLinuxRuntime_sniper"));
+    }
+
+    [OSTestMethod(OperatingSystems.Linux)]
+    public void GetRuntimePathForProton_ReturnsNull_WhenRequiredRuntimeLibraryIsUnknown()
+    {
+        string steamRoot = CreateSteamRoot();
+
+        string protonPath = Path.Combine(tempRoot, "proton-cachyos-slr");
+        Directory.CreateDirectory(protonPath);
+        File.WriteAllText(Path.Combine(protonPath, "toolmanifest.vdf"), """
+            "manifest"
+            {
+                "require_tool_appid" "4183110"
+            }
+            """);
+
+        Steam.SteamLibrariesVdf steamLibraries = Steam.SteamLibrariesVdf.Load(steamRoot);
+        string? result = steamLibraries.GetRuntimePathForProton(protonPath);
+
+        result.Should().BeNull();
+    }
+
+    private string CreateSteamRoot()
+    {
+        string steamRoot = Path.Combine(tempRoot, "steam-root");
+        Directory.CreateDirectory(Path.Combine(steamRoot, "config"));
+        File.WriteAllText(Path.Combine(steamRoot, "config", "libraryfolders.vdf"), """
+            "libraryfolders"
+            {
+            }
+            """);
+        return steamRoot;
+    }
+
+    private static void WriteLibraryFolders(string steamRoot, string libraryPath, string appId)
+    {
+        File.WriteAllText(Path.Combine(steamRoot, "config", "libraryfolders.vdf"), $$"""
+            "libraryfolders"
+            {
+                "0"
+                {
+                    "path"      "{{libraryPath}}"
+                    "apps"
+                    {
+                        "{{appId}}"     "1"
+                    }
+                }
+            }
+            """);
+    }
+
+    private static void CreateSteamApp(string libraryPath, string appId, string installDir)
+    {
+        string steamAppsPath = Path.Combine(libraryPath, "steamapps");
+        Directory.CreateDirectory(Path.Combine(steamAppsPath, "common", installDir));
+        File.WriteAllText(Path.Combine(steamAppsPath, $"appmanifest_{appId}.acf"), $$"""
+            "AppState"
+            {
+                "appid"     "{{appId}}"
+                "installdir"        "{{installDir}}"
+            }
+            """);
+    }
+}


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
Fixes #2857

## Description of Change

When a proton version is managed by a package manager, like PacMAN for Linux, proton doesn't install in the normal place we expect `<steamRootPath>/compatibilitytools.d`

We now take a collection ProtonRootPaths which yields the steam root path first, and then hops the XDG_DATA_DIRS looking for Proton too

There was also an issue with runtime tool choice. We'd always choose Steam's Sniper runtime, however Proton 11+ doesn't use that, and would throw an error. Now if a specific toolchain is required, we recognise and use. this is much closer to Steam's default behaviour

## Validation

1. Install proton outside of  `<steamRootPath>/compatibilitytools.d`
2. Observe Nitrox will start with that version

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has tests for the changes (if applicable)
- [x] Has a linked issue

---
🤖 This code was created with the help of AI.
Specifically, I had Claude's Opus model write my unit tests (because I'm lazy x)