### PR TITLE
Add loading indicator to server embedded view

### DIFF
--- a/Nitrox.Launcher/Models/Design/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/Design/ServerEntry.cs
@@ -74,6 +74,9 @@ internal sealed partial class ServerEntry : ObservableObject
     public partial bool IsServerClosing { get; set; }
 
     [ObservableProperty]
+    public partial bool IsServerStarting { get; set; }
+
+    [ObservableProperty]
     public partial DateTime LastAccessedTime { get; set; } = DateTime.Now;
 
     private int lastProcessId;
@@ -285,6 +288,7 @@ internal sealed partial class ServerEntry : ObservableObject
         Process = ServerProcess.Start(Path.Combine(savesDir, Name), cts, embedded, existingProcessId);
 
         Output.Clear();
+        IsServerStarting = true;
         IsNewServer = false;
         IsOnline = true;
     }

--- a/Nitrox.Launcher/Models/Services/ServersManagement.cs
+++ b/Nitrox.Launcher/Models/Services/ServersManagement.cs
@@ -37,12 +37,20 @@ internal sealed class ServersManagement(ServerService serverService) : Streaming
         try
         {
             ServerEntry? entry = serverService.GetServerEntryByAnyOf(processId, saveName);
-            entry?.Output.Add(new OutputLine
+            if (entry != null)
             {
-                LogText = message,
-                LocalTime = localTime,
-                Type = (OutputLineType)level
-            });
+                // First output received, server is no longer starting
+                if (entry.IsServerStarting)
+                {
+                    entry.IsServerStarting = false;
+                }
+                entry.Output.Add(new OutputLine
+                {
+                    LogText = message,
+                    LocalTime = localTime,
+                    Type = (OutputLineType)level
+                });
+            }
         }
         catch (Exception ex)
         {

--- a/Nitrox.Launcher/Models/Services/ServersManagement.cs
+++ b/Nitrox.Launcher/Models/Services/ServersManagement.cs
@@ -40,10 +40,7 @@ internal sealed class ServersManagement(ServerService serverService) : Streaming
             if (entry != null)
             {
                 // First output received, server is no longer starting
-                if (entry.IsServerStarting)
-                {
-                    entry.IsServerStarting = false;
-                }
+                entry.IsServerStarting = false;
                 entry.Output.Add(new OutputLine
                 {
                     LogText = message,

--- a/Nitrox.Launcher/Models/Services/ServersManagement.cs
+++ b/Nitrox.Launcher/Models/Services/ServersManagement.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using Grpc.Core;
 using MagicOnion.Server.Hubs;
 using Nitrox.Launcher.Models.Design;
@@ -32,29 +33,32 @@ internal sealed class ServersManagement(ServerService serverService) : Streaming
         return CompletedTask;
     }
 
-    public ValueTask AddOutputLine(string category, DateTimeOffset? localTime, int level, string message)
+    public async ValueTask AddOutputLine(string category, DateTimeOffset? localTime, int level, string message)
     {
         try
         {
-            ServerEntry? entry = serverService.GetServerEntryByAnyOf(processId, saveName);
-            if (entry != null)
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                // First output received, server is no longer starting
-                entry.IsServerStarting = false;
-                entry.Output.Add(new OutputLine
+                ServerEntry? entry = serverService.GetServerEntryByAnyOf(processId, saveName);
+                if (entry != null)
                 {
-                    LogText = message,
-                    LocalTime = localTime,
-                    Type = (OutputLineType)level
-                });
-            }
+
+                    // First output received, server is no longer starting
+                    entry.IsServerStarting = false;
+                    entry.Output.Add(new OutputLine
+                    {
+                        LogText = message,
+                        LocalTime = localTime,
+                        Type = (OutputLineType)level
+                    });
+                }
+            });
         }
         catch (Exception ex)
         {
             Log.Error(ex);
             throw;
         }
-        return CompletedTask;
     }
 
     protected override async ValueTask OnConnected()

--- a/Nitrox.Launcher/Views/EmbeddedServerView.axaml
+++ b/Nitrox.Launcher/Views/EmbeddedServerView.axaml
@@ -58,12 +58,21 @@
             Grid.Row="1"
             Margin="0,20,0,20"
             x:Name="ScrollViewer">
-            <!--  Transparent background for improved QoL selecting text (otherwise, putting the cursor between lines won't allow for text selection)  -->
-            <ItemsControl x:Name="ItemsControl"
-                          Background="Transparent"
-                          HorizontalAlignment="Left"
-                          SizeChanged="ItemsControl_OnSizeChanged"
-                          ItemsSource="{Binding ServerOutput}">
+            <Grid>
+                <!--  Loading indicator shown while server is starting  -->
+                <TextBlock
+                    Text="Server is starting..."
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource BrandSubText}"
+                    IsVisible="{Binding ServerEntry.IsServerStarting}" />
+                <!--  Transparent background for improved QoL selecting text (otherwise, putting the cursor between lines won't allow for text selection)  -->
+                <ItemsControl x:Name="ItemsControl"
+                              Background="Transparent"
+                              HorizontalAlignment="Left"
+                              SizeChanged="ItemsControl_OnSizeChanged"
+                              ItemsSource="{Binding ServerOutput}"
+                              IsVisible="{Binding !ServerEntry.IsServerStarting}">
                 <ItemsControl.Styles>
                     <Style Selector="Run.command">
                         <Setter Property="Foreground" Value="{DynamicResource BrandPrimary}" />
@@ -106,6 +115,7 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
+            </Grid>
         </ScrollViewer>
         <Grid ColumnDefinitions="*,Auto" Grid.Row="2">
             <TextBox


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2856

## Description of Change

Added a loading indicator to the embedded server view that displays "Server is starting..." between when the server process starts and when the first log output is received. The indicator appears centered in the output area and automatically disappears once logs begin streaming. It's pretty basic so feel free to suggest any ideas and i'll add it.

**Implementation:**
- Added `IsServerStarting` observable property to `ServerEntry` to track server startup state
- Set flag to `true` when `StartAsync()` clears output, `false` when first log line arrives in `AddOutputLine()`
- Added centered TextBlock in `EmbeddedServerView.axaml` with visibility binding to the flag

## Validation

Tested by starting multiple embedded servers and verifying:
- Loading indicator appears immediately when starting a server
- Indicator disappears when first log output is received (~1 second)
- Normal server output displays correctly after indicator disappears

## PR Checklist

- [x] PR rebased on top of `master` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested on Windows
