### PR TITLE
Fix exosuit steeringWheelYaw

### DIFF
--- a/NitroxClient/MonoBehaviours/Vehicles/ExosuitMovementReplicator.cs
+++ b/NitroxClient/MonoBehaviours/Vehicles/ExosuitMovementReplicator.cs
@@ -106,7 +106,7 @@ public class ExosuitMovementReplicator : VehicleMovementReplicator
         float steeringWheelPitch = exosuitMovementData.SteeringWheelPitch;
 
         // See Vehicle.Update (reverse operation for vehicle.steeringWheel... = ...)
-        exosuit.steeringWheelYaw = steeringWheelPitch / 70f;
+        exosuit.steeringWheelYaw = steeringWheelYaw / 70f;
         exosuit.steeringWheelPitch = steeringWheelPitch / 45f;
 
         if (exosuit.mainAnimator)


### PR DESCRIPTION
## Description of Change

```cs
        float steeringWheelYaw = exosuitMovementData.SteeringWheelYaw;
        float steeringWheelPitch = exosuitMovementData.SteeringWheelPitch;

        // See Vehicle.Update (reverse operation for vehicle.steeringWheel... = ...)
        exosuit.steeringWheelYaw = steeringWheelPitch / 70f;
        exosuit.steeringWheelPitch = steeringWheelPitch / 45f;
```

Assigning Yaw = Pitch / 70 seems to be a oopsie, confirmed if we look at the code Vehicle.Update code mentionned in the comment

<img width="729" height="158" alt="image" src="https://github.com/user-attachments/assets/30f049d0-9d64-4457-813b-af33908b5cf6" />


## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)