### PR TITLE
Fix Random.Range skipping a prefab inside CyclopsDamageProcessor

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/CyclopsDamageProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CyclopsDamageProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Nitrox.Model.DataStructures;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
@@ -85,7 +85,7 @@ internal sealed class CyclopsDamageProcessor(Fires fires) : IClientPacketProcess
                         // Copied from CyclopsExternalDamageManager.CreatePoint(), except without the random index pick.
                         damageManager.damagePoints[damagePointsIndex].gameObject.SetActive(true);
                         damageManager.damagePoints[damagePointsIndex].RestoreHealth();
-                        GameObject prefabGo = damageManager.fxPrefabs[Random.Range(0, damageManager.fxPrefabs.Length - 1)];
+                        GameObject prefabGo = damageManager.fxPrefabs[Random.Range(0, damageManager.fxPrefabs.Length)];
                         damageManager.damagePoints[damagePointsIndex].SpawnFx(prefabGo);
                         unusedDamagePoints.Remove(damageManager.damagePoints[damagePointsIndex]);
                     }


### PR DESCRIPTION
## Context

<img width="901" height="104" alt="image" src="https://github.com/user-attachments/assets/ab96de7b-8114-4036-bf08-9bd6b6dfdbd3" />

On Unity 2019.4, the upper bound of Random.Range for integers (different for floats)  is exclusive, not inclusive.
<img width="1265" height="215" alt="image" src="https://github.com/user-attachments/assets/4201bf0f-509e-4590-bcf5-de2ee0fbc9e8" />
https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Random.Range.html

Looking at the code referenced by the comment, the subnautica code looks right.

<img width="887" height="387" alt="image" src="https://github.com/user-attachments/assets/002c604a-8175-4513-a385-fb0a03174bbe" />

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)
