### PR TITLE
Add sync for CrashFish

### DIFF
--- a/Nitrox.Model.Subnautica/Packets/CrashAttackLastTarget.cs
+++ b/Nitrox.Model.Subnautica/Packets/CrashAttackLastTarget.cs
@@ -1,0 +1,18 @@
+using System;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Packets;
+
+namespace Nitrox.Model.Subnautica.Packets;
+
+[Serializable]
+public class CrashAttackLastTarget : Packet
+{
+    public NitroxId CreatureId { get; }
+    public NitroxId TargetId { get; }
+
+    public CrashAttackLastTarget(NitroxId creatureId, NitroxId targetId)
+    {
+        CreatureId = creatureId;
+        TargetId = targetId;
+    }
+}

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/CrashAttackLastTargetProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/CrashAttackLastTargetProcessor.cs
@@ -1,0 +1,14 @@
+using Nitrox.Server.Subnautica.Models.GameLogic;
+using Nitrox.Server.Subnautica.Models.GameLogic.Entities;
+using Nitrox.Server.Subnautica.Models.Packets.Core;
+using Nitrox.Server.Subnautica.Models.Packets.Processors.Core;
+
+namespace Nitrox.Server.Subnautica.Models.Packets.Processors;
+
+internal sealed class CrashAttackLastTargetProcessor(PlayerManager playerManager, EntityRegistry entityRegistry) : TransmitIfCanSeePacketProcessor<CrashAttackLastTarget>(playerManager, entityRegistry)
+{
+    public override async Task Process(AuthProcessorContext context, CrashAttackLastTarget packet)
+    {
+        await TransmitIfCanSeeEntitiesAsync(context, packet, [packet.CreatureId, packet.TargetId]);
+    }
+}

--- a/NitroxClient/Communication/Packets/Processors/CrashAttackLastTargetProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/CrashAttackLastTargetProcessor.cs
@@ -1,0 +1,14 @@
+using Nitrox.Model.Subnautica.Packets;
+using NitroxClient.Communication.Packets.Processors.Core;
+using NitroxClient.GameLogic;
+
+namespace NitroxClient.Communication.Packets.Processors;
+
+internal sealed class CrashAttackLastTargetProcessor : IClientPacketProcessor<CrashAttackLastTarget>
+{
+    public Task Process(ClientProcessorContext context, CrashAttackLastTarget packet)
+    {
+        AI.CrashAttackLastTarget(packet.CreatureId, packet.TargetId);
+        return Task.CompletedTask;
+    }
+}

--- a/NitroxClient/GameLogic/AI.cs
+++ b/NitroxClient/GameLogic/AI.cs
@@ -23,7 +23,7 @@ public sealed class AI
     /// </summary>
     private readonly HashSet<Type> creatureActionWhitelist =
     [
-        typeof(AttackLastTarget), typeof(RangedAttackLastTarget), typeof(AttackCyclops), typeof(Poop)
+        typeof(AttackLastTarget), typeof(RangedAttackLastTarget), typeof(AttackCyclops), typeof(Poop), typeof(ProtectCrashHome)
     ];
 
     /// <summary>
@@ -32,7 +32,7 @@ public sealed class AI
     /// </summary>
     private readonly HashSet<Type> syncedCreatureWhitelist =
     [
-        typeof(ReaperLeviathan), typeof(SeaDragon), typeof(SeaTreader), typeof(GhostLeviathan)
+        typeof(ReaperLeviathan), typeof(SeaDragon), typeof(SeaTreader), typeof(GhostLeviathan), typeof(Crash)
     ];
 
     public AI(IPacketSender packetSender)

--- a/NitroxClient/GameLogic/AI.cs
+++ b/NitroxClient/GameLogic/AI.cs
@@ -95,6 +95,22 @@ public sealed class AI
         }
     }
 
+    /// <summary>
+    /// Replicates the attack triggered by grabbing a <see cref="Crash"/> with the Propulsion Cannon and releasing it
+    /// TODO: We have a lot of single-entity behaviours here like AttackCyclopsTargetChanged etc. Should we refactor this? 
+    /// </summary>
+    public static void CrashAttackLastTarget(NitroxId creatureId, NitroxId targetId)
+    {
+        if (!NitroxEntity.TryGetComponentFrom(creatureId, out Crash crash) ||
+            !NitroxEntity.TryGetObjectFrom(targetId, out GameObject targetObject))
+        {
+            return;
+        }
+
+        crash.lastTarget.SetTarget(targetObject);
+        crash.AttackLastTarget();
+    }
+
     public static void AttackCyclopsTargetChanged(NitroxId creatureId, NitroxId targetId, float aggressiveToNoiseAmount)
     {
         if (!NitroxEntity.TryGetComponentFrom(creatureId, out AttackCyclops attackCyclops) ||

--- a/NitroxPatcher/Patches/Dynamic/Crash_OnRelease_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Crash_OnRelease_Patch.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using NitroxClient.Communication.Abstract;
+using NitroxClient.GameLogic;
+using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.Packets;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Broadcasts the attack triggered by grabbing a <see cref="Crash"/> with the Propulsion Cannon and releasing it
+/// </summary>
+public sealed partial class Crash_OnRelease_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method<Crash>(t => ((IPropulsionCannonAmmo)t).OnRelease());
+
+    public static void Postfix(Crash __instance)
+    {
+        if (!__instance.TryGetNitroxId(out NitroxId creatureId) || !Resolve<SimulationOwnership>().HasAnyLockType(creatureId) ||
+            !Player.main.TryGetIdOrWarn(out NitroxId targetId))
+        {
+            return;
+        }
+
+        Resolve<IPacketSender>().Send(new CrashAttackLastTarget(creatureId, targetId));
+    }
+}


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
Should conclude the fixes for: #2673

## Monos Status
* Crash (creature) : [X] - now Added crash to whitelist            
* ProtectCrashHome : [CAW] Safe to add, so added, now [X]
* AggressiveWhenSeeTarget (sibling) : [X]
* LastTarget : [X]              
* SwimBehaviour / Rigidbody : [X]
* LiveMixin : [X]
* CreatureFear : [X]
* IPropulsionCannonAmmo.OnRelease() : [X] - Added in this patch

## Description of Change

Added ProtectCrashHome to creatureActionWhitelist and Crash to syncedCreatureWhitelist
Synced up the prop cannon onrelease behaviour 

## Validation

Was able to see crash fish attacking as targeted player
Identified player B seeing crashfish aggro at player A after player A grabbed and released Crashfish with prop cannon

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [ ] Has been tested in-game (if applicable) -- Ideally would need a proper 2 person test as unsure if applies properly as i've done

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
