### PR TITLE
Fix WaitScreen progress never reaching 100%

### DIFF
--- a/NitroxClient/GameLogic/InitialSync/Abstract/InitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/Abstract/InitialSyncProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Nitrox.Model.Subnautica.Packets;
@@ -15,7 +15,7 @@ public abstract class InitialSyncProcessor : IInitialSyncProcessor
         for (int i = 0; i < Steps.Count; i++)
         {
             yield return Steps[i](packet);
-            waitScreenItem.SetProgress((float)i / Steps.Count);
+            waitScreenItem.SetProgress(i + 1, Steps.Count);
             yield return null;
         }
     }


### PR DESCRIPTION
## Description of Change

Since 2.0 the waitscreen is no longer visible during game load, and most initial sync step processors are overriding this method. But always good to have code working 😄 

<img width="468" height="269" alt="image" src="https://github.com/user-attachments/assets/d1604159-6186-4084-8a38-8e2c6bab3642" />


## PR Checklist

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [ ] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
