### PR TITLE
Support multiple EntityMetadata instances for entities

### DIFF
--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/BaseLeakEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/BaseLeakEntity.cs
@@ -31,7 +31,7 @@ public class BaseLeakEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public BaseLeakEntity(float health, NitroxInt3 relativeCell, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public BaseLeakEntity(float health, NitroxInt3 relativeCell, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         Health = health;
         RelativeCell = relativeCell;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/BuildEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/BuildEntity.cs
@@ -33,7 +33,7 @@ public class BuildEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public BuildEntity(BaseData baseData, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public BuildEntity(BaseData baseData, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         BaseData = baseData;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/GhostEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/GhostEntity.cs
@@ -30,7 +30,7 @@ public class GhostEntity : ModuleEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public GhostEntity(NitroxBaseFace baseFace, BaseData baseData, float constructedAmount, bool isInside, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public GhostEntity(NitroxBaseFace baseFace, BaseData baseData, float constructedAmount, bool isInside, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(constructedAmount, isInside, transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         BaseFace = baseFace;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/InteriorPieceEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/InteriorPieceEntity.cs
@@ -33,7 +33,7 @@ public class InteriorPieceEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public InteriorPieceEntity(NitroxBaseFace baseFace, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public InteriorPieceEntity(NitroxBaseFace baseFace, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         BaseFace = baseFace;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MapRoomEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MapRoomEntity.cs
@@ -33,7 +33,7 @@ public class MapRoomEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public MapRoomEntity(NitroxInt3 cell, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public MapRoomEntity(NitroxInt3 cell, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         Cell = cell;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/ModuleEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/ModuleEntity.cs
@@ -33,7 +33,7 @@ public class ModuleEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public ModuleEntity(float constructedAmount, bool isInside, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public ModuleEntity(float constructedAmount, bool isInside, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         ConstructedAmount = constructedAmount;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MoonpoolEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/Bases/MoonpoolEntity.cs
@@ -31,7 +31,7 @@ public class MoonpoolEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public MoonpoolEntity(NitroxInt3 cell, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public MoonpoolEntity(NitroxInt3 cell, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities)
     {
         Cell = cell;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/CellRootEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/CellRootEntity.cs
@@ -31,7 +31,7 @@ public class CellRootEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public CellRootEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public CellRootEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         Id = id;
         TechType = techType;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/CreatureRespawnEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/CreatureRespawnEntity.cs
@@ -27,7 +27,7 @@ public class CreatureRespawnEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public CreatureRespawnEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, float spawnTime, NitroxTechType respawnTechType, List<string> addComponents) :
+    public CreatureRespawnEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, float spawnTime, NitroxTechType respawnTechType, List<string> addComponents) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         SpawnTime = spawnTime;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/EscapePodWorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/EscapePodWorldEntity.cs
@@ -22,7 +22,7 @@ public class EscapePodEntity : GlobalRootEntity
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public EscapePodEntity(NitroxVector3 position, NitroxId id, EntityMetadata metadata)
+    public EscapePodEntity(NitroxVector3 position, NitroxId id, List<EntityMetadata>? metadata)
     {
         Transform = new NitroxTransform(position, NitroxQuaternion.Identity, NitroxVector3.One);
         Id = id;
@@ -35,7 +35,7 @@ public class EscapePodEntity : GlobalRootEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public EscapePodEntity(List<PeerId> players, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public EscapePodEntity(List<PeerId> players, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         Players = players;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/GeyserWorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/GeyserWorldEntity.cs
@@ -24,7 +24,7 @@ public class GeyserWorldEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public GeyserWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, float randomIntervalVarianceMultiplier, float startEruptTime) :
+    public GeyserWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, float randomIntervalVarianceMultiplier, float startEruptTime) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         RandomIntervalVarianceMultiplier = randomIntervalVarianceMultiplier;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/GlobalRootEntity.cs
@@ -32,7 +32,7 @@ public class GlobalRootEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public GlobalRootEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata? metadata, NitroxId? parentId, List<Entity> childEntities) :
+    public GlobalRootEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId? parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     { }
 }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InstalledBatteryEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InstalledBatteryEntity.cs
@@ -21,7 +21,7 @@ public class InstalledBatteryEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public InstalledBatteryEntity(int componentIndex, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public InstalledBatteryEntity(int componentIndex, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         ComponentIndex = componentIndex;
         Id = id;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InstalledModuleEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InstalledModuleEntity.cs
@@ -24,7 +24,7 @@ public class InstalledModuleEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public InstalledModuleEntity(string slot, string classId, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public InstalledModuleEntity(string slot, string classId, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         Slot = slot;
         ClassId = classId;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InventoryEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InventoryEntity.cs
@@ -24,7 +24,7 @@ public class InventoryEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public InventoryEntity(int componentIndex, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public InventoryEntity(int componentIndex, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         ComponentIndex = componentIndex;
         Id = id;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InventoryItemEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/InventoryItemEntity.cs
@@ -21,7 +21,7 @@ public class InventoryItemEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public InventoryItemEntity(NitroxId id, string classId, NitroxTechType techType, EntityMetadata? metadata, NitroxId parentId, List<Entity> childEntities)
+    public InventoryItemEntity(NitroxId id, string classId, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         ClassId = classId;
         Id = id;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/OxygenPipeEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/OxygenPipeEntity.cs
@@ -27,7 +27,7 @@ public class OxygenPipeEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public OxygenPipeEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata? metadata, NitroxId? parentId, List<Entity> childEntities, NitroxId parentPipeId, NitroxId rootPipeId, NitroxVector3 parentPosition) :
+    public OxygenPipeEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId? parentId, List<Entity> childEntities, NitroxId parentPipeId, NitroxId rootPipeId, NitroxVector3 parentPosition) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         ParentPipeId = parentPipeId;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PathBasedChildEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PathBasedChildEntity.cs
@@ -21,7 +21,7 @@ public class PathBasedChildEntity : Entity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public PathBasedChildEntity(string path, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+    public PathBasedChildEntity(string path, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
     {
         Path = path;
         Id = id;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlacedWorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlacedWorldEntity.cs
@@ -18,6 +18,6 @@ public class PlacedWorldEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public PlacedWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public PlacedWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities) { }
 }

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlaceholderGroupWorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlaceholderGroupWorldEntity.cs
@@ -35,7 +35,7 @@ public class PlaceholderGroupWorldEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public PlaceholderGroupWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, int componentIndex) :
+    public PlaceholderGroupWorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, int componentIndex) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         ComponentIndex = componentIndex;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlanterEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlanterEntity.cs
@@ -27,7 +27,7 @@ public class PlanterEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public PlanterEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public PlanterEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities) {}
 
     public override string ToString()

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlayerEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PlayerEntity.cs
@@ -22,7 +22,7 @@ public class PlayerEntity : GlobalRootEntity
     /// Used for deserialization.
     /// <see cref="WorldEntity.SpawnedByServer"/> is set to true because this entity is meant to receive simulation locks
     /// </remarks>
-    public PlayerEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata? metadata, NitroxId? parentId, List<Entity> childEntities) :
+    public PlayerEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId? parentId, List<Entity> childEntities) :
         base(transform, level, classId, true, id, techType, metadata, parentId, childEntities) {}
 
     public override string ToString()

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PrefabChildEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PrefabChildEntity.cs
@@ -30,7 +30,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
 
-        public PrefabChildEntity(NitroxId id, string classId, NitroxTechType techType, int componentIndex, EntityMetadata metadata, NitroxId parentId)
+        public PrefabChildEntity(NitroxId id, string classId, NitroxTechType techType, int componentIndex, List<EntityMetadata>? metadata, NitroxId parentId)
         {
             Id = id;
             TechType = techType;
@@ -41,7 +41,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities
         }
 
         /// <remarks>Used for deserialization</remarks>
-        public PrefabChildEntity(int componentIndex, string classId, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities)
+        public PrefabChildEntity(int componentIndex, string classId, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities)
         {
             ComponentIndex = componentIndex;
             ClassId = classId;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PrefabPlaceholderEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/PrefabPlaceholderEntity.cs
@@ -39,7 +39,7 @@ public class PrefabPlaceholderEntity : WorldEntity
 
 
     /// <remarks>Used for deserialization</remarks>
-    public PrefabPlaceholderEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, int componentIndex) :
+    public PrefabPlaceholderEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, int componentIndex) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         ComponentIndex = componentIndex;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/RadiationLeakEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/RadiationLeakEntity.cs
@@ -24,12 +24,12 @@ public class RadiationLeakEntity : GlobalRootEntity
     {
         Id = id;
         ObjectIndex = objectIndex;
-        Metadata = metadata;
+        Metadata = [metadata];
         Transform = new();
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public RadiationLeakEntity(int objectIndex, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public RadiationLeakEntity(int objectIndex, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         ObjectIndex = objectIndex;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/ReefbackChildEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/ReefbackChildEntity.cs
@@ -29,7 +29,7 @@ public class ReefbackChildEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public ReefbackChildEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, ReefbackChildType type) :
+    public ReefbackChildEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, ReefbackChildType type) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         Type = type;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/ReefbackEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/ReefbackEntity.cs
@@ -24,7 +24,7 @@ public class ReefbackEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public ReefbackEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities, int grassIndex, NitroxVector3 originalPosition) :
+    public ReefbackEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities, int grassIndex, NitroxVector3 originalPosition) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         GrassIndex = grassIndex;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/SerializedWorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/SerializedWorldEntity.cs
@@ -59,7 +59,7 @@ public class SerializedWorldEntity : WorldEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public SerializedWorldEntity(List<SerializedComponent> components, int layer, NitroxInt3 batchId, NitroxInt3 cellId, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public SerializedWorldEntity(List<SerializedComponent> components, int layer, NitroxInt3 batchId, NitroxInt3 cellId, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         Components = components;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/VehicleEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/VehicleEntity.cs
@@ -24,7 +24,7 @@ public class VehicleEntity : GlobalRootEntity
         // Constructor for serialization. Has to be "protected" for json serialization.
     }
 
-    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata) :
+    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata) :
         base(transform, GLOBAL_ROOT_LEVEL, classId, spawnedByServer, id, techType, metadata, null, new List<Entity>())
     {
         SpawnerId = spawnerId;
@@ -32,7 +32,7 @@ public class VehicleEntity : GlobalRootEntity
     }
 
     /// <remarks>Used for deserialization</remarks>
-    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata metadata, NitroxId parentId, List<Entity> childEntities) :
+    public VehicleEntity(NitroxId spawnerId, float constructionTime, NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId parentId, List<Entity> childEntities) :
         base(transform, level, classId, spawnedByServer, id, techType, metadata, parentId, childEntities)
     {
         SpawnerId = spawnerId;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/WorldEntity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entities/WorldEntity.cs
@@ -78,7 +78,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities
         }
 
         /// <remarks>Used for deserialization</remarks>
-        public WorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, EntityMetadata? metadata, NitroxId? parentId, List<Entity> childEntities)
+        public WorldEntity(NitroxTransform transform, int level, string classId, bool spawnedByServer, NitroxId id, NitroxTechType techType, List<EntityMetadata>? metadata, NitroxId? parentId, List<Entity> childEntities)
         {
             Id = id;
             TechType = techType;

--- a/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entity.cs
+++ b/Nitrox.Model.Subnautica/DataStructures/GameLogic/Entity.cs
@@ -28,7 +28,7 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic
         public NitroxTechType TechType { get; set; }
 
         [DataMember(Order = 3)]
-        public EntityMetadata? Metadata { get; set; }
+        public List<EntityMetadata>? Metadata { get; set; }
 
         [DataMember(Order = 4)]
         public NitroxId? ParentId { get; set; }
@@ -42,9 +42,44 @@ namespace Nitrox.Model.Subnautica.DataStructures.GameLogic
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
 
+        public T? GetMetadata<T>() where T : EntityMetadata
+        {
+            if (Metadata != null)
+            {
+                foreach (EntityMetadata entry in Metadata)
+                {
+                    if (entry is T typed)
+                    {
+                        return typed;
+                    }
+                }
+            }
+            return null;
+        }
+
+        public bool TryGetMetadata<T>(out T metadata) where T : EntityMetadata
+        {
+            metadata = GetMetadata<T>();
+            return metadata != null;
+        }
+        
+        public void SetMetadata(EntityMetadata metadata)
+        {
+            Metadata ??= [];
+            for (int i = 0; i < Metadata.Count; i++)
+            {
+                if (Metadata[i].GetType() == metadata.GetType())
+                {
+                    Metadata[i] = metadata;
+                    return;
+                }
+            }
+            Metadata.Add(metadata);
+        }
+
         public override string ToString()
         {
-            return $"[Entity id: {Id} techType: {TechType} Metadata: {Metadata} ParentId: {ParentId} ChildEntities: {string.Join(",\n ", ChildEntities)}]";
+            return $"[Entity id: {Id} techType: {TechType} Metadata: {(Metadata != null ? string.Join(", ", Metadata) : null)} ParentId: {ParentId} ChildEntities: {string.Join(",\n ", ChildEntities)}]";
         }
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
+++ b/Nitrox.Server.Subnautica/Models/Commands/QueryCommand.cs
@@ -33,7 +33,7 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
         builder.AppendLine($" └ Id: {entity.Id}");
         builder.AppendLine($" └ TechType: {entity.TechType}");
         builder.AppendLine($" └ ParentId: {entity.ParentId?.ToString() ?? "<null>"}");
-        builder.AppendLine($" └ Metadata: {entity.Metadata?.ToString() ?? "<null>"}");
+        builder.AppendLine($" └ Metadata: {(entity.Metadata != null ? string.Join(", ", entity.Metadata) : "<null>")}");
         builder.AppendLine($" └ Children: {entity.ChildEntities.Count}");
         if (entity.ChildEntities.Count > 0)
         {
@@ -43,7 +43,7 @@ internal sealed class QueryCommand(EntityRegistry entityRegistry, SimulationOwne
                 builder.AppendLine($"     └ Type: {childEntity.GetType().Name}");
                 builder.AppendLine($"     └ Id: {childEntity.Id}");
                 builder.AppendLine($"     └ TechType: {childEntity.TechType}");
-                builder.AppendLine($"     └ Metadata: {childEntity.Metadata?.ToString() ?? "<null>"}");
+                builder.AppendLine($"     └ Metadata: {(childEntity.Metadata != null ? string.Join(", ", childEntity.Metadata) : "<null>")}");
                 builder.AppendLine($"     └ Children: {childEntity.ChildEntities.Count}");
             }
         }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/CrashHomeBootstrapper.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/CrashHomeBootstrapper.cs
@@ -9,6 +9,6 @@ internal sealed class CrashHomeBootstrapper : IEntityBootstrapper
     public void Prepare(ref WorldEntity entity, DeterministicGenerator deterministicBatchGenerator)
     {
         // Set 0 for spawnTime so that CrashHome.Update can spawn a Crash if Start() couldn't
-        entity.Metadata = new CrashHomeMetadata(0);
+        entity.SetMetadata(new CrashHomeMetadata(0));
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/GeyserBootstrapper.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/GeyserBootstrapper.cs
@@ -9,10 +9,12 @@ internal sealed class GeyserBootstrapper(XorRandom random) : IEntityBootstrapper
 
     public void Prepare(ref WorldEntity entity, DeterministicGenerator deterministicBatchGenerator)
     {
-        entity = new GeyserWorldEntity(entity.Transform, entity.Level, entity.ClassId,
+        GeyserWorldEntity geyserEntity = new(entity.Transform, entity.Level, entity.ClassId,
                                   entity.SpawnedByServer, entity.Id, entity.TechType,
-                                  entity.Metadata, entity.ParentId, entity.ChildEntities,
+                                  null, entity.ParentId, entity.ChildEntities,
                                   random.NextFloat(), 15 * random.NextFloat());
         // The value 15 doesn't mean anything in particular, it's just an initial eruption time window so geysers don't all erupt at the same time at first
+        geyserEntity.Metadata = entity.Metadata;
+        entity = geyserEntity;
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/ReefbackBootstrapper.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/ReefbackBootstrapper.cs
@@ -37,10 +37,12 @@ internal sealed class ReefbackBootstrapper : IEntityBootstrapper
         // In case the grassIndex is chosen randomly
         int grassIndex = random.NextIntRange(1, GRASS_VARIANTS_COUNT);
 
-        entity = new ReefbackEntity(entity.Transform, entity.Level, entity.ClassId,
+        ReefbackEntity reefbackEntity = new(entity.Transform, entity.Level, entity.ClassId,
                                     entity.SpawnedByServer, entity.Id, entity.TechType,
-                                    entity.Metadata, entity.ParentId, entity.ChildEntities,
+                                    null, entity.ParentId, entity.ChildEntities,
                                     grassIndex, entity.Transform.Position);
+        reefbackEntity.Metadata = entity.Metadata;
+        entity = reefbackEntity;
 
         NitroxTransform plantSlotsRootTransform = DuplicateTransform(PlantSlotsRootTransform);
         plantSlotsRootTransform.SetParent(entity.Transform, false);

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/StayAtLeashPositionBootstrapper.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/Spawning/StayAtLeashPositionBootstrapper.cs
@@ -8,6 +8,6 @@ internal sealed class StayAtLeashPositionBootstrapper : IEntityBootstrapper
 {
     public void Prepare(ref WorldEntity spawnedEntity, DeterministicGenerator generator)
     {
-        spawnedEntity.Metadata = new StayAtLeashPositionMetadata(spawnedEntity.Transform.Position);
+        spawnedEntity.SetMetadata(new StayAtLeashPositionMetadata(spawnedEntity.Transform.Position));
     }
 }

--- a/Nitrox.Server.Subnautica/Models/GameLogic/Entities/WorldEntityManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/Entities/WorldEntityManager.cs
@@ -74,7 +74,7 @@ internal sealed class WorldEntityManager
         // TODO: refactor if there are more entities that should not be persisted
         return GetGlobalRootEntities(true).Where(entity =>
         {
-            if (entity.Metadata is CyclopsMetadata cyclopsMetadata)
+            if (entity.TryGetMetadata(out CyclopsMetadata cyclopsMetadata))
             {
                 // Do not save cyclops wrecks
                 return !cyclopsMetadata.IsDestroyed;

--- a/Nitrox.Server.Subnautica/Models/GameLogic/EscapePodManager.cs
+++ b/Nitrox.Server.Subnautica/Models/GameLogic/EscapePodManager.cs
@@ -44,7 +44,7 @@ internal class EscapePodManager(RandomFactory randomFactory, EntityRegistry enti
 
     private async Task<EscapePodEntity> CreateNewEscapePodAsync()
     {
-        EscapePodEntity escapePod = new(await GetStartPositionAsync(), new NitroxId(), new EscapePodMetadata(false, false));
+        EscapePodEntity escapePod = new(await GetStartPositionAsync(), new NitroxId(), [new EscapePodMetadata(false, false)]);
 
         escapePod.ChildEntities.Add(new PrefabChildEntity(new NitroxId(), "5c06baec-0539-4f26-817d-78443548cc52", new NitroxTechType("Radio"), 0, null, escapePod.Id));
         escapePod.ChildEntities.Add(new PrefabChildEntity(new NitroxId(), "c0175cf7-0b6a-4a1d-938f-dad0dbb6fa06", new NitroxTechType("MedicalCabinet"), 0, null, escapePod.Id));

--- a/Nitrox.Server.Subnautica/Models/Packets/Processors/EntityMetadataUpdateProcessor.cs
+++ b/Nitrox.Server.Subnautica/Models/Packets/Processors/EntityMetadataUpdateProcessor.cs
@@ -22,7 +22,7 @@ internal sealed class EntityMetadataUpdateProcessor(PlayerManager playerManager,
 
         if (TryProcessMetadata(context.Sender, entity, packet.NewValue))
         {
-            entity.Metadata = packet.NewValue;
+            entity.SetMetadata(packet.NewValue);
             await SendUpdateToVisiblePlayersAsync(context, packet, entity);
         }
     }

--- a/Nitrox.Server.Subnautica/Models/Serialization/SaveDataUpgrades/Upgrade_V1900.cs
+++ b/Nitrox.Server.Subnautica/Models/Serialization/SaveDataUpgrades/Upgrade_V1900.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Nitrox.Server.Subnautica.Models.Serialization.SaveDataUpgrades;
+
+public class Upgrade_V1900(ILogger<Upgrade_V1900> logger) : SaveDataUpgrade(logger)
+{
+    public override Version TargetVersion { get; } = new(1, 9, 0, 0);
+
+    protected override void UpgradeEntityData(JObject data)
+    {
+        WrapMetadataInArray(data);
+    }
+
+    protected override void UpgradeGlobalRootData(JObject data)
+    {
+        WrapMetadataInArray(data);
+    }
+
+    // Entity.Metadata went from a single EntityMetadata object to a List<EntityMetadata>
+    private static void WrapMetadataInArray(JObject data)
+    {
+        foreach (JProperty property in data.DescendantsAndSelf().OfType<JProperty>().Where(p => p.Name == "Metadata"))
+        {
+            if (property.Value.Type == JTokenType.Object)
+            {
+                property.Value = new JArray(property.Value);
+            }
+        }
+    }
+}

--- a/Nitrox.Test/Server/Serialization/SaveDataUpgrades/Upgrade_V1900Test.cs
+++ b/Nitrox.Test/Server/Serialization/SaveDataUpgrades/Upgrade_V1900Test.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Nitrox.Model.Constants;
+
+namespace Nitrox.Server.Subnautica.Models.Serialization.SaveDataUpgrades;
+
+[TestClass]
+public sealed class Upgrade_V1900Test
+{
+    [TestMethod]
+    public void UpgradeSaveFiles_WrapsMetadataObjectsInArrays_AtAnyNestingDepth()
+    {
+        string saveDir = Path.Combine(Path.GetTempPath(), $"NitroxTest_{nameof(Upgrade_V1900Test)}_{Path.GetRandomFileName()}");
+        Directory.CreateDirectory(saveDir);
+        try
+        {
+            string entityDataPath = Path.Combine(saveDir, $"EntityData{NitroxConstants.SAVE_FILE_ENDING}");
+            File.WriteAllText(entityDataPath, /* lang=json */ """
+                {
+                  "Entities": [
+                    {
+                      "Id": "top-level",
+                      "Metadata": { "Health": 50.0 },
+                      "ChildEntities": [
+                        {
+                          "Id": "nested-child",
+                          "Metadata": { "Charge": 1.0 },
+                          "ChildEntities": []
+                        }
+                      ]
+                    },
+                    {
+                      "Id": "no-metadata-yet",
+                      "Metadata": null,
+                      "ChildEntities": []
+                    }
+                  ]
+                }
+                """);
+
+            Upgrade_V1900 upgrade = new(Substitute.For<ILogger<Upgrade_V1900>>());
+            upgrade.UpgradeSaveFiles(saveDir, NitroxConstants.SAVE_FILE_ENDING);
+
+            JArray entities = (JArray)JObject.Parse(File.ReadAllText(entityDataPath))["Entities"];
+
+            JToken topLevelMetadata = entities[0]["Metadata"];
+            Assert.AreEqual(JTokenType.Array, topLevelMetadata.Type);
+            Assert.AreEqual(50.0, (double)topLevelMetadata[0]["Health"]);
+
+            JToken nestedMetadata = entities[0]["ChildEntities"][0]["Metadata"];
+            Assert.AreEqual(JTokenType.Array, nestedMetadata.Type);
+            Assert.AreEqual(1.0, (double)nestedMetadata[0]["Charge"]);
+
+            Assert.AreEqual(JTokenType.Null, entities[1]["Metadata"].Type);
+        }
+        finally
+        {
+            Directory.Delete(saveDir, true);
+        }
+    }
+}

--- a/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldServiceTest.cs
@@ -163,73 +163,73 @@ internal sealed class WorldServiceTest
         Assert.AreEqual(entity.TechType, entityAfter.TechType);
         Assert.AreEqual(entity.ParentId, entityAfter.ParentId);
 
-        switch (entity.Metadata)
+        switch (entity.GetMetadata<EntityMetadata>())
         {
-            case KeypadMetadata metadata when entityAfter.Metadata is KeypadMetadata metadataAfter:
+            case KeypadMetadata metadata when entityAfter.TryGetMetadata(out KeypadMetadata metadataAfter):
                 Assert.AreEqual(metadata.Unlocked, metadataAfter.Unlocked);
                 break;
-            case SealedDoorMetadata metadata when entityAfter.Metadata is SealedDoorMetadata metadataAfter:
+            case SealedDoorMetadata metadata when entityAfter.TryGetMetadata(out SealedDoorMetadata metadataAfter):
                 Assert.AreEqual(metadata.Sealed, metadataAfter.Sealed);
                 Assert.AreEqual(metadata.OpenedAmount, metadataAfter.OpenedAmount);
                 break;
-            case PrecursorDoorwayMetadata metadata when entityAfter.Metadata is PrecursorDoorwayMetadata metadataAfter:
+            case PrecursorDoorwayMetadata metadata when entityAfter.TryGetMetadata(out PrecursorDoorwayMetadata metadataAfter):
                 Assert.AreEqual(metadata.IsOpen, metadataAfter.IsOpen);
                 break;
-            case PrecursorTeleporterMetadata metadata when entityAfter.Metadata is PrecursorTeleporterMetadata metadataAfter:
+            case PrecursorTeleporterMetadata metadata when entityAfter.TryGetMetadata(out PrecursorTeleporterMetadata metadataAfter):
                 Assert.AreEqual(metadata.IsOpen, metadataAfter.IsOpen);
                 break;
-            case PrecursorKeyTerminalMetadata metadata when entityAfter.Metadata is PrecursorKeyTerminalMetadata metadataAfter:
+            case PrecursorKeyTerminalMetadata metadata when entityAfter.TryGetMetadata(out PrecursorKeyTerminalMetadata metadataAfter):
                 Assert.AreEqual(metadata.Slotted, metadataAfter.Slotted);
                 break;
-            case PrecursorTeleporterActivationTerminalMetadata metadata when entityAfter.Metadata is PrecursorTeleporterActivationTerminalMetadata metadataAfter:
+            case PrecursorTeleporterActivationTerminalMetadata metadata when entityAfter.TryGetMetadata(out PrecursorTeleporterActivationTerminalMetadata metadataAfter):
                 Assert.AreEqual(metadata.Unlocked, metadataAfter.Unlocked);
                 break;
-            case StarshipDoorMetadata metadata when entityAfter.Metadata is StarshipDoorMetadata metadataAfter:
+            case StarshipDoorMetadata metadata when entityAfter.TryGetMetadata(out StarshipDoorMetadata metadataAfter):
                 Assert.AreEqual(metadata.DoorLocked, metadataAfter.DoorLocked);
                 Assert.AreEqual(metadata.DoorOpen, metadataAfter.DoorOpen);
                 break;
-            case WeldableWallPanelGenericMetadata metadata when entityAfter.Metadata is WeldableWallPanelGenericMetadata metadataAfter:
+            case WeldableWallPanelGenericMetadata metadata when entityAfter.TryGetMetadata(out WeldableWallPanelGenericMetadata metadataAfter):
                 Assert.AreEqual(metadata.LiveMixInHealth, metadataAfter.LiveMixInHealth);
                 break;
-            case IncubatorMetadata metadata when entityAfter.Metadata is IncubatorMetadata metadataAfter:
+            case IncubatorMetadata metadata when entityAfter.TryGetMetadata(out IncubatorMetadata metadataAfter):
                 Assert.AreEqual(metadata.Powered, metadataAfter.Powered);
                 Assert.AreEqual(metadata.Hatched, metadataAfter.Hatched);
                 break;
-            case EntitySignMetadata metadata when entityAfter.Metadata is EntitySignMetadata metadataAfter:
+            case EntitySignMetadata metadata when entityAfter.TryGetMetadata(out EntitySignMetadata metadataAfter):
                 Assert.AreEqual(metadata.Text, metadataAfter.Text);
                 Assert.AreEqual(metadata.ColorIndex, metadataAfter.ColorIndex);
                 Assert.AreEqual(metadata.ScaleIndex, metadataAfter.ScaleIndex);
                 Assert.IsTrue(metadata.Elements.SequenceEqual(metadataAfter.Elements));
                 Assert.AreEqual(metadata.Background, metadataAfter.Background);
                 break;
-            case ConstructorMetadata metadata when entityAfter.Metadata is ConstructorMetadata metadataAfter:
+            case ConstructorMetadata metadata when entityAfter.TryGetMetadata(out ConstructorMetadata metadataAfter):
                 Assert.AreEqual(metadata.Deployed, metadataAfter.Deployed);
                 break;
-            case FlashlightMetadata metadata when entityAfter.Metadata is FlashlightMetadata metadataAfter:
+            case FlashlightMetadata metadata when entityAfter.TryGetMetadata(out FlashlightMetadata metadataAfter):
                 Assert.AreEqual(metadata.On, metadataAfter.On);
                 break;
-            case BatteryMetadata metadata when entityAfter.Metadata is BatteryMetadata metadataAfter:
+            case BatteryMetadata metadata when entityAfter.TryGetMetadata(out BatteryMetadata metadataAfter):
                 Assert.AreEqual(metadata.Charge, metadataAfter.Charge);
                 break;
-            case EscapePodMetadata metadata when entityAfter.Metadata is EscapePodMetadata metadataAfter:
+            case EscapePodMetadata metadata when entityAfter.TryGetMetadata(out EscapePodMetadata metadataAfter):
                 Assert.AreEqual(metadata.PodRepaired, metadataAfter.PodRepaired);
                 Assert.AreEqual(metadata.RadioRepaired, metadataAfter.RadioRepaired);
                 break;
-            case CrafterMetadata metadata when entityAfter.Metadata is CrafterMetadata metadataAfter:
+            case CrafterMetadata metadata when entityAfter.TryGetMetadata(out CrafterMetadata metadataAfter):
                 Assert.AreEqual(metadata.TechType, metadataAfter.TechType);
                 Assert.AreEqual(metadata.StartTime, metadataAfter.StartTime);
                 Assert.AreEqual(metadata.Duration, metadataAfter.Duration);
                 break;
-            case PlantableMetadata metadata when entityAfter.Metadata is PlantableMetadata metadataAfter:
+            case PlantableMetadata metadata when entityAfter.TryGetMetadata(out PlantableMetadata metadataAfter):
                 Assert.AreEqual(metadata.TimeStartGrowth, metadataAfter.TimeStartGrowth);
                 Assert.AreEqual(metadata.SlotID, metadataAfter.SlotID);
                 // FruitPlantMetadata field is not checked before it's only temporary
                 break;
-            case FruitPlantMetadata metadata when entityAfter.Metadata is FruitPlantMetadata metadataAfter:
+            case FruitPlantMetadata metadata when entityAfter.TryGetMetadata(out FruitPlantMetadata metadataAfter):
                 Assert.IsTrue(metadata.PickedStates.SequenceEqual(metadataAfter.PickedStates));
                 Assert.AreEqual(metadata.TimeNextFruit, metadataAfter.TimeNextFruit);
                 break;
-            case CyclopsMetadata metadata when entityAfter.Metadata is CyclopsMetadata metadataAfter:
+            case CyclopsMetadata metadata when entityAfter.TryGetMetadata(out CyclopsMetadata metadataAfter):
                 Assert.AreEqual(metadata.SilentRunningOn, metadataAfter.SilentRunningOn);
                 Assert.AreEqual(metadata.ShieldOn, metadataAfter.ShieldOn);
                 Assert.AreEqual(metadata.SonarOn, metadataAfter.SonarOn);
@@ -237,37 +237,37 @@ internal sealed class WorldServiceTest
                 Assert.AreEqual(metadata.EngineMode, metadataAfter.EngineMode);
                 Assert.AreEqual(metadata.Health, metadataAfter.Health);
                 break;
-            case SeamothMetadata metadata when entityAfter.Metadata is SeamothMetadata metadataAfter:
+            case SeamothMetadata metadata when entityAfter.TryGetMetadata(out SeamothMetadata metadataAfter):
                 Assert.AreEqual(metadata.LightsOn, metadataAfter.LightsOn);
                 Assert.AreEqual(metadata.Health, metadataAfter.Health);
                 Assert.AreEqual(metadata.Name, metadataAfter.Name);
                 Assert.IsTrue(metadata.Colors.SequenceEqual(metadataAfter.Colors));
                 break;
-            case ExosuitMetadata metadata when entityAfter.Metadata is ExosuitMetadata metadataAfter:
+            case ExosuitMetadata metadata when entityAfter.TryGetMetadata(out ExosuitMetadata metadataAfter):
                 Assert.AreEqual(metadata.Health, metadataAfter.Health);
                 Assert.AreEqual(metadata.Name, metadataAfter.Name);
                 Assert.IsTrue(metadata.Colors.SequenceEqual(metadataAfter.Colors));
                 break;
-            case SubNameInputMetadata metadata when entityAfter.Metadata is SubNameInputMetadata metadataAfter:
+            case SubNameInputMetadata metadata when entityAfter.TryGetMetadata(out SubNameInputMetadata metadataAfter):
                 Assert.AreEqual(metadata.Name, metadataAfter.Name);
                 Assert.IsTrue(metadata.Colors.SequenceEqual(metadataAfter.Colors));
                 break;
-            case RocketMetadata metadata when entityAfter.Metadata is RocketMetadata metadataAfter:
+            case RocketMetadata metadata when entityAfter.TryGetMetadata(out RocketMetadata metadataAfter):
                 Assert.AreEqual(metadata.CurrentStage, metadataAfter.CurrentStage);
                 Assert.AreEqual(metadata.LastStageTransitionTime, metadataAfter.LastStageTransitionTime);
                 Assert.AreEqual(metadata.ElevatorState, metadataAfter.ElevatorState);
                 Assert.AreEqual(metadata.ElevatorPosition, metadataAfter.ElevatorPosition);
                 Assert.IsTrue(metadata.PreflightChecks.SequenceEqual(metadataAfter.PreflightChecks));
                 break;
-            case CyclopsLightingMetadata metadata when entityAfter.Metadata is CyclopsLightingMetadata metadataAfter:
+            case CyclopsLightingMetadata metadata when entityAfter.TryGetMetadata(out CyclopsLightingMetadata metadataAfter):
                 Assert.AreEqual(metadata.FloodLightsOn, metadataAfter.FloodLightsOn);
                 Assert.AreEqual(metadata.InternalLightsOn, metadataAfter.InternalLightsOn);
                 break;
-            case FireExtinguisherHolderMetadata metadata when entityAfter.Metadata is FireExtinguisherHolderMetadata metadataAfter:
+            case FireExtinguisherHolderMetadata metadata when entityAfter.TryGetMetadata(out FireExtinguisherHolderMetadata metadataAfter):
                 Assert.AreEqual(metadata.HasExtinguisher, metadataAfter.HasExtinguisher);
                 Assert.AreEqual(metadata.Fuel, metadataAfter.Fuel);
                 break;
-            case PlayerMetadata metadata when entityAfter.Metadata is PlayerMetadata metadataAfter:
+            case PlayerMetadata metadata when entityAfter.TryGetMetadata(out PlayerMetadata metadataAfter):
                 AssertHelper.IsListEqual(metadata.EquippedItems.OrderBy(x => x.Id), metadataAfter.EquippedItems.OrderBy(x => x.Id), (equippedItem, equippedItemAfter) =>
                 {
                     Assert.AreEqual(equippedItem.Id, equippedItemAfter.Id);
@@ -275,7 +275,7 @@ internal sealed class WorldServiceTest
                     Assert.AreEqual(equippedItem.TechType, equippedItemAfter.TechType);
                 });
                 break;
-            case GhostMetadata ghostMetadata when entityAfter.Metadata is GhostMetadata ghostMetadataAfter:
+            case GhostMetadata ghostMetadata when entityAfter.TryGetMetadata(out GhostMetadata ghostMetadataAfter):
                 Assert.AreEqual(ghostMetadata.TargetOffset, ghostMetadataAfter.TargetOffset);
 
                 if (ghostMetadata.GetType() != ghostMetadataAfter.GetType())
@@ -298,66 +298,66 @@ internal sealed class WorldServiceTest
                 }
 
                 break;
-            case WaterParkCreatureMetadata metadata when entityAfter.Metadata is WaterParkCreatureMetadata metadataAfter:
+            case WaterParkCreatureMetadata metadata when entityAfter.TryGetMetadata(out WaterParkCreatureMetadata metadataAfter):
                 Assert.AreEqual(metadata.Age, metadataAfter.Age);
                 Assert.AreEqual(metadata.MatureTime, metadataAfter.MatureTime);
                 Assert.AreEqual(metadata.TimeNextBreed, metadataAfter.TimeNextBreed);
                 Assert.AreEqual(metadata.BornInside, metadataAfter.BornInside);
                 break;
-            case FlareMetadata metadata when entityAfter.Metadata is FlareMetadata metadataAfter:
+            case FlareMetadata metadata when entityAfter.TryGetMetadata(out FlareMetadata metadataAfter):
                 Assert.AreEqual(metadata.EnergyLeft, metadataAfter.EnergyLeft);
                 Assert.AreEqual(metadata.HasBeenThrown, metadataAfter.HasBeenThrown);
                 Assert.AreEqual(metadata.FlareActivateTime, metadataAfter.FlareActivateTime);
                 break;
-            case BeaconMetadata metadata when entityAfter.Metadata is BeaconMetadata metadataAfter:
+            case BeaconMetadata metadata when entityAfter.TryGetMetadata(out BeaconMetadata metadataAfter):
                 Assert.AreEqual(metadata.Label, metadataAfter.Label);
                 break;
-            case RadiationMetadata metadata when entityAfter.Metadata is RadiationMetadata metadataAfter:
+            case RadiationMetadata metadata when entityAfter.TryGetMetadata(out RadiationMetadata metadataAfter):
                 Assert.AreEqual(metadata.Health, metadataAfter.Health);
                 Assert.AreEqual(metadata.FixRealTime, metadataAfter.FixRealTime);
                 break;
-            case CrashHomeMetadata metadata when entityAfter.Metadata is CrashHomeMetadata metadataAfter:
+            case CrashHomeMetadata metadata when entityAfter.TryGetMetadata(out CrashHomeMetadata metadataAfter):
                 Assert.AreEqual(metadata.SpawnTime, metadataAfter.SpawnTime);
                 break;
-            case EatableMetadata metadata when entityAfter.Metadata is EatableMetadata metadataAfter:
+            case EatableMetadata metadata when entityAfter.TryGetMetadata(out EatableMetadata metadataAfter):
                 Assert.AreEqual(metadata.TimeDecayStart, metadataAfter.TimeDecayStart);
                 break;
-            case SeaTreaderMetadata metadata when entityAfter.Metadata is SeaTreaderMetadata metadataAfter:
+            case SeaTreaderMetadata metadata when entityAfter.TryGetMetadata(out SeaTreaderMetadata metadataAfter):
                 Assert.AreEqual(metadata.ReverseDirection, metadataAfter.ReverseDirection);
                 Assert.AreEqual(metadata.GrazingEndTime, metadataAfter.GrazingEndTime);
                 Assert.AreEqual(metadata.LeashPosition, metadataAfter.LeashPosition);
                 break;
-            case StayAtLeashPositionMetadata metadata when entityAfter.Metadata is StayAtLeashPositionMetadata metadataAfter:
+            case StayAtLeashPositionMetadata metadata when entityAfter.TryGetMetadata(out StayAtLeashPositionMetadata metadataAfter):
                 Assert.AreEqual(metadata.LeashPosition, metadataAfter.LeashPosition);
                 break;
-            case EggMetadata metadata when entityAfter.Metadata is EggMetadata metadataAfter:
+            case EggMetadata metadata when entityAfter.TryGetMetadata(out EggMetadata metadataAfter):
                 Assert.AreEqual(metadata.TimeStartHatching, metadataAfter.TimeStartHatching);
                 Assert.AreEqual(metadata.Progress, metadataAfter.Progress);
                 break;
-            case DrillableMetadata metadata when entityAfter.Metadata is DrillableMetadata metadataAfter:
+            case DrillableMetadata metadata when entityAfter.TryGetMetadata(out DrillableMetadata metadataAfter):
                 Assert.IsTrue(metadata.ChunkHealth.SequenceEqual(metadataAfter.ChunkHealth));
                 Assert.AreEqual(metadata.TimeLastDrilled, metadataAfter.TimeLastDrilled);
                 break;
-            case PrecursorComputerTerminalMetadata metadata when entityAfter.Metadata is PrecursorComputerTerminalMetadata metadataAfter:
+            case PrecursorComputerTerminalMetadata metadata when entityAfter.TryGetMetadata(out PrecursorComputerTerminalMetadata metadataAfter):
                 Assert.AreEqual(metadata.Used, metadataAfter.Used);
                 break;
-            case GenericConsoleMetadata metadata when entityAfter.Metadata is GenericConsoleMetadata metadataAfter:
+            case GenericConsoleMetadata metadata when entityAfter.TryGetMetadata(out GenericConsoleMetadata metadataAfter):
                 Assert.AreEqual(metadata.GotUsed, metadataAfter.GotUsed);
                 break;
-            case BlueprintHandTargetMetadata metadata when entityAfter.Metadata is BlueprintHandTargetMetadata metadataAfter:
+            case BlueprintHandTargetMetadata metadata when entityAfter.TryGetMetadata(out BlueprintHandTargetMetadata metadataAfter):
                 Assert.AreEqual(metadata.Used, metadataAfter.Used);
                 break;
-            case PrecursorDisableGunTerminalMetadata metadata when entityAfter.Metadata is PrecursorDisableGunTerminalMetadata metadataAfter:
+            case PrecursorDisableGunTerminalMetadata metadata when entityAfter.TryGetMetadata(out PrecursorDisableGunTerminalMetadata metadataAfter):
                 Assert.AreEqual(metadata.FirstUse, metadataAfter.FirstUse);
                 break;
-            case OxygenMetadata metadata when entityAfter.Metadata is OxygenMetadata metadataAfter:
+            case OxygenMetadata metadata when entityAfter.TryGetMetadata(out OxygenMetadata metadataAfter):
                 Assert.AreEqual(metadata.OxygenAvailable, metadataAfter.OxygenAvailable);
                 break;
-            case BulkheadDoorMetadata metadata when entityAfter.Metadata is BulkheadDoorMetadata metadataAfter:
+            case BulkheadDoorMetadata metadata when entityAfter.TryGetMetadata(out BulkheadDoorMetadata metadataAfter):
                 Assert.AreEqual(metadata.Opened, metadataAfter.Opened);
                 break;
             default:
-                Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.Metadata?.GetType().Name} - {entityAfter.Metadata?.GetType().Name}");
+                Assert.Fail($"Runtime type of {nameof(Entity)}.{nameof(Entity.Metadata)} is not equal: {entity.GetMetadata<EntityMetadata>()?.GetType().Name} - {entityAfter.GetMetadata<EntityMetadata>()?.GetType().Name}");
                 break;
         }
 

--- a/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/BuildingResyncProcessor.cs
@@ -170,7 +170,7 @@ internal sealed class BuildingResyncProcessor(Entities entities, EntityMetadataM
     {
         Log.Info($"[Module RESYNC] Overwriting module with id {moduleEntity.Id}");
         ModuleEntitySpawner.ApplyModuleData(moduleEntity, constructable.gameObject);
-        entityMetadataManager.ApplyMetadata(constructable.gameObject, moduleEntity.Metadata);
+        entityMetadataManager.ApplyMetadata(constructable.gameObject, moduleEntity);
         yield break;
     }
 }

--- a/NitroxClient/GameLogic/Bases/BuildingHandler.cs
+++ b/NitroxClient/GameLogic/Bases/BuildingHandler.cs
@@ -130,7 +130,7 @@ public partial class BuildingHandler : MonoBehaviour
         yield return ModuleEntitySpawner.RestoreModule(parent, moduleEntity, result);
         if (result.value.HasValue)
         {
-            this.Resolve<EntityMetadataManager>().ApplyMetadata(result.value.Value.gameObject, moduleEntity.Metadata);
+            this.Resolve<EntityMetadataManager>().ApplyMetadata(result.value.Value.gameObject, moduleEntity);
         }
         BasesCooldown[moduleEntity.ParentId ?? moduleEntity.Id] = DateTimeOffset.UtcNow;
     }

--- a/NitroxClient/GameLogic/Entities.cs
+++ b/NitroxClient/GameLogic/Entities.cs
@@ -220,7 +220,7 @@ namespace NitroxClient.GameLogic
                     continue;
                 }
 
-                entityMetadataManager.ApplyMetadata(entityResult.Get().Value, entity.Metadata);
+                entityMetadataManager.ApplyMetadata(entityResult.Get().Value, entity);
                 simulationOwnership.ApplyNewerSimulation(entity.Id);
 
                 MarkAsSpawned(entity);
@@ -302,7 +302,7 @@ namespace NitroxClient.GameLogic
 #endif
                 return;
             }
-            entityMetadataManager.ApplyMetadata(gameObject, entity.Metadata);
+            entityMetadataManager.ApplyMetadata(gameObject, entity);
         }
 
         private void AddPendingParentEntity(Entity entity)

--- a/NitroxClient/GameLogic/EquipmentSlots.cs
+++ b/NitroxClient/GameLogic/EquipmentSlots.cs
@@ -43,7 +43,7 @@ public class EquipmentSlots
             NitroxTechType techType = pickupable.GetTechType().ToDto();
             EntityMetadata metadata = entityMetadataManager.Extract(pickupable.gameObject).OrNull();
 
-            InstalledModuleEntity moduleEntity = new(slot, classId, itemId, techType, metadata, ownerId, []);
+            InstalledModuleEntity moduleEntity = new(slot, classId, itemId, techType, metadata != null ? [metadata] : null, ownerId, []);
             entities.MarkAsSpawned(moduleEntity);
 
             if (packetSender.Send(new EntitySpawnedByClient(moduleEntity, true)))

--- a/NitroxClient/GameLogic/ItemContainers.cs
+++ b/NitroxClient/GameLogic/ItemContainers.cs
@@ -124,7 +124,7 @@ public class ItemContainers
 
         Optional<EntityMetadata> metadata = entityMetadataManager.Extract(battery);
 
-        InstalledBatteryEntity installedBattery = new(componentIndex, id, techType.ToDto(), metadata.OrNull(), parent.Id, []);
+        InstalledBatteryEntity installedBattery = new(componentIndex, id, techType.ToDto(), metadata.HasValue ? [metadata.Value] : null, parent.Id, []);
 
         EntitySpawnedByClient spawnedPacket = new(installedBattery);
         packetSender.Send(spawnedPacket);

--- a/NitroxClient/GameLogic/Items.cs
+++ b/NitroxClient/GameLogic/Items.cs
@@ -124,7 +124,7 @@ public class Items
         {
             // We cast it to an entity type that is always seeable by clients
             // therefore, the packet will be redirected to everyone
-            droppedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.Value.ToDto(), metadata.OrNull(), parentId, childrenEntities);
+            droppedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.Value.ToDto(), (metadata.HasValue ? [metadata.Value] : null), parentId, childrenEntities);
         }
         else if (gameObject.TryGetComponent(out OxygenPipe oxygenPipe))
         {
@@ -149,13 +149,13 @@ public class Items
             oxygenPipe.rootPipeUID = rootPipeId.ToString();
             oxygenPipe.parentPipeUID = parentPipeId.ToString();
 
-            droppedItem = new OxygenPipeEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.Value.ToDto(), metadata.OrNull(), null,
+            droppedItem = new OxygenPipeEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.Value.ToDto(), (metadata.HasValue ? [metadata.Value] : null), null,
                                               childrenEntities, parentPipeId, rootPipeId, parentConnection.GetAttachPoint().ToDto());
         }
         else
         {
             // Generic case
-            droppedItem = new(gameObject.transform.ToWorldDto(), level, classId, false, id, techType.Value.ToDto(), metadata.OrNull(), null, childrenEntities);
+            droppedItem = new(gameObject.transform.ToWorldDto(), level, classId, false, id, techType.Value.ToDto(), (metadata.HasValue ? [metadata.Value] : null), null, childrenEntities);
         }
 
         if (packetSender.Send(new EntitySpawnedByClient(droppedItem, true)))
@@ -185,14 +185,14 @@ public class Items
         switch (gameObject.AliveOrNull())
         {
             case not null when IsGlobalRootObject(gameObject):
-                placedItem = new GlobalRootEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
+                placedItem = new GlobalRootEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), (metadata.HasValue ? [metadata.Value] : null), null, childrenEntities);
                 break;
             case not null when Player.main.AliveOrNull()?.GetCurrentSub().AliveOrNull()?.TryGetNitroxId(out NitroxId parentId) == true:
-                placedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), parentId, childrenEntities);
+                placedItem = new GlobalRootEntity(gameObject.transform.ToLocalDto(), level, classId, true, id, techType.ToDto(), (metadata.HasValue ? [metadata.Value] : null), parentId, childrenEntities);
                 break;
             default:
                 // If the object is not under a SubRoot nor in GlobalRoot, it'll be under a CellRoot but we still want to remember its state
-                placedItem = new PlacedWorldEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), metadata.OrNull(), null, childrenEntities);
+                placedItem = new PlacedWorldEntity(gameObject.transform.ToWorldDto(), level, classId, true, id, techType.ToDto(), (metadata.HasValue ? [metadata.Value] : null), null, childrenEntities);
                 break;
         }
 
@@ -223,7 +223,7 @@ public class Items
                     TechTag techTag = prefab.gameObject.GetComponent<TechTag>();
                     TechType techType = techTag ? techTag.type : TechType.None;
 
-                    yield return new PrefabChildEntity(id, prefab.classId, techType.ToDto(), indexInGroup, metadata.Value, parentId);
+                    yield return new PrefabChildEntity(id, prefab.classId, techType.ToDto(), indexInGroup, [metadata.Value], parentId);
 
                     indexInGroup++;
                 }
@@ -259,7 +259,7 @@ public class Items
         Optional<EntityMetadata> metadata = entityMetadataManager.Extract(gameObject);
         List<Entity> children = GetPrefabChildren(gameObject, itemId, entityMetadataManager).ToList();
 
-        InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), metadata.OrNull(), parentId, children);
+        InventoryItemEntity inventoryItemEntity = new(itemId, classId, techType.ToDto(), (metadata.HasValue ? [metadata.Value] : null), parentId, children);
         BatteryChildEntityHelper.TryPopulateInstalledBattery(gameObject, inventoryItemEntity.ChildEntities, itemId);
 
         return inventoryItemEntity;
@@ -315,7 +315,7 @@ public class Items
                 Optional<EntityMetadata> metadata = entityMetadataManager.Extract(pickupable.gameObject);
                 List<Entity> children = GetPrefabChildren(pickupable.gameObject, itemId, entityMetadataManager).ToList();
 
-                entities.Add(new(itemEntry.Key, classId, itemId, pickupable.GetTechType().ToDto(), metadata.OrNull(), equipmentId, children));
+                entities.Add(new(itemEntry.Key, classId, itemId, pickupable.GetTechType().ToDto(), (metadata.HasValue ? [metadata.Value] : null), equipmentId, children));
             }
         }
         return entities;

--- a/NitroxClient/GameLogic/Spawning/Bases/GhostEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/GhostEntitySpawner.cs
@@ -6,6 +6,7 @@ using NitroxClient.GameLogic.Spawning.Abstract;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
 using NitroxClient.MonoBehaviours;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Bases;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata.Bases;
 using UnityEngine;
 
 namespace NitroxClient.GameLogic.Spawning.Bases;
@@ -48,7 +49,7 @@ public class GhostEntitySpawner : EntitySpawner<GhostEntity>
 
         if (constructableBase.TryGetComponentInChildren(out BaseGhost baseGhost, true))
         {
-            ghost.Metadata = GhostMetadataRetriever.GetMetadataForGhost(baseGhost);
+            ghost.SetMetadata(GhostMetadataRetriever.GetMetadataForGhost(baseGhost));
         }
 
         return ghost;
@@ -106,7 +107,7 @@ public class GhostEntitySpawner : EntitySpawner<GhostEntity>
         ghostBase.FinishDeserialization();
 
         // Apply the right metadata accordingly
-        IEnumerator baseDeconstructableInstructions = GhostMetadataApplier.ApplyMetadataToGhost(baseGhost, ghostEntity.Metadata, @base);
+        IEnumerator baseDeconstructableInstructions = GhostMetadataApplier.ApplyMetadataToGhost(baseGhost, ghostEntity.GetMetadata<GhostMetadata>(), @base);
         if (baseDeconstructableInstructions != null)
         {
             yield return baseDeconstructableInstructions;

--- a/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/Bases/InteriorPieceEntitySpawner.cs
@@ -106,7 +106,7 @@ public class InteriorPieceEntitySpawner : EntitySpawner<InteriorPieceEntity>
         {
             NitroxEntity.SetNewId(moduleObject, interiorPiece.Id);
             yield return BuildingPostSpawner.ApplyPostSpawner(moduleObject, interiorPiece.Id);
-            entityMetadataManager.ApplyMetadata(moduleObject, interiorPiece.Metadata);
+            entityMetadataManager.ApplyMetadata(moduleObject, interiorPiece);
             result.Set(moduleObject);
         }
     }

--- a/NitroxClient/GameLogic/Spawning/EscapePodEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/EscapePodEntitySpawner.cs
@@ -76,7 +76,7 @@ public class EscapePodEntitySpawner : SyncEntitySpawner<EscapePodEntity>
         pod.escapePodCinematicControl.StopAll();
 
         // Player is not new and has completed the intro cinematic. If not EscapePod repair status is handled by the intro cinematic.
-        if (escapePodEntity.Metadata is EscapePodMetadata metadata && localPlayer.IntroCinematicMode == IntroCinematicMode.COMPLETED)
+        if (escapePodEntity.TryGetMetadata(out EscapePodMetadata metadata) && localPlayer.IntroCinematicMode == IntroCinematicMode.COMPLETED)
         {
             using FMODSoundSuppressor soundSuppressor = FMODSystem.SuppressSubnauticaSounds();
             using PacketSuppressor<EntityMetadataUpdate> packetSuppressor = PacketSuppressor<EntityMetadataUpdate>.Suppress();

--- a/NitroxClient/GameLogic/Spawning/InventoryItemEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/InventoryItemEntitySpawner.cs
@@ -119,7 +119,7 @@ public class InventoryItemEntitySpawner(EntityMetadataManager entityMetadataMana
         {
             planter.Subscribe(subscribedValue);
 
-            if (entity.Metadata is PlantableMetadata metadata)
+            if (entity.TryGetMetadata(out PlantableMetadata metadata))
             {
                 PostponeAddNotification(() => planter.subscribed, () => planter, true, () =>
                 {

--- a/NitroxClient/GameLogic/Spawning/Metadata/EntityMetadataManager.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/EntityMetadataManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NitroxClient.GameLogic.Spawning.Metadata.Extractor.Abstract;
 using NitroxClient.GameLogic.Spawning.Metadata.Processor.Abstract;
 using Nitrox.Model.DataStructures;
+using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic.Entities.Metadata;
 using UnityEngine;
 
@@ -72,9 +73,10 @@ public class EntityMetadataManager
 
     public void ApplyMetadata(GameObject gameObject, EntityMetadata metadata)
     {
-        // In case a metadata update was received while this entity was in the spawn queue
+        // In case a same-typed metadata update was received while this entity was in the spawn queue
         if (gameObject.TryGetNitroxId(out NitroxId objectId) &&
-            newerMetadataById.TryGetValue(objectId, out EntityMetadata newMetadata))
+            newerMetadataById.TryGetValue(objectId, out EntityMetadata newMetadata) &&
+            newMetadata.GetType() == metadata.GetType())
         {
             metadata = newMetadata;
             newerMetadataById.Remove(objectId);
@@ -84,6 +86,18 @@ public class EntityMetadataManager
         if (metadataProcessor.HasValue)
         {
             metadataProcessor.Value.ProcessMetadata(gameObject, metadata);
+        }
+    }
+    
+    public void ApplyMetadata(GameObject gameObject, Entity entity)
+    {
+        if (entity.Metadata == null)
+        {
+            return;
+        }
+        foreach (EntityMetadata metadata in entity.Metadata)
+        {
+            ApplyMetadata(gameObject, metadata);
         }
     }
 

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/PlaceholderGroupWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/PlaceholderGroupWorldEntitySpawner.cs
@@ -106,7 +106,7 @@ internal sealed class PlaceholderGroupWorldEntitySpawner : IWorldEntitySpawner
             GameObject childObject = childResult.value.Value;
             entities.MarkAsSpawned(current);
             parentById[current.Id] = childObject;
-            entityMetadataManager.ApplyMetadata(childObject, current.Metadata);
+            entityMetadataManager.ApplyMetadata(childObject, current);
 
             // PlaceholderGroupWorldEntity's children spawning is already handled by this function which is called recursively
             if (current is not PlaceholderGroupWorldEntity)

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/RadiationLeakEntitySpawner.cs
@@ -33,7 +33,7 @@ public class RadiationLeakEntitySpawner : SyncEntitySpawner<RadiationLeakEntity>
         // This script is located under (Aurora Scene) //Aurora-Main/Aurora so it's a good starting point to search through the GameObjects
         CrashedShipExploder crashedShipExploder = CrashedShipExploder.main;
         LeakingRadiation leakingRadiation = LeakingRadiation.main;
-        if (!crashedShipExploder || !leakingRadiation || entity.Metadata is not RadiationMetadata metadata)
+        if (!crashedShipExploder || !leakingRadiation || !entity.TryGetMetadata(out RadiationMetadata metadata))
         {
             return true;
         }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleEntitySpawner.cs
@@ -94,7 +94,7 @@ public class VehicleEntitySpawner : EntitySpawner<VehicleEntity>
 
         NitroxEntity.SetNewId(gameObject, vehicleEntity.Id);
 
-        if (vehicleEntity.Metadata is CyclopsMetadata cyclopsMetadata && cyclopsMetadata.IsDestroyed)
+        if (vehicleEntity.TryGetMetadata(out CyclopsMetadata cyclopsMetadata) && cyclopsMetadata.IsDestroyed)
         {
             // Swap to destroyed look without triggering animations / effects
             gameObject.BroadcastMessage("SwapToDamagedModels");

--- a/NitroxPatcher/Patches/Dynamic/Drillable_OnDrill_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Drillable_OnDrill_Patch.cs
@@ -37,7 +37,7 @@ public sealed partial class Drillable_OnDrill_Patch : NitroxPatch, IDynamicPatch
             Optional<EntityMetadata> metadata = Resolve<EntityMetadataManager>().Extract(__instance.gameObject);
             Validate.IsPresent(metadata);
 
-            PathBasedChildEntity entity = new(__instance.name, id, NitroxTechType.None, metadata.Value, parentId, []);
+            PathBasedChildEntity entity = new(__instance.name, id, NitroxTechType.None, [metadata.Value], parentId, []);
             Resolve<IPacketSender>().Send(new EntitySpawnedByClient(entity));
         }
     }


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

Allows fixing of TODOs around multi-entity metadata, required for #2842 
This change is simply the scaffolding and backporting of existing entities to our new system

## Description of Change

Changes EntityMetadata to a List of EntityMetadata to allow multiple metadata pieces to belong to one Entity 

## Validation

Gone into game and tried game hasn't noticably regressed
Anyone with a server for 1.9.0.0 needs to remake a server after these changes go in due to the migration versioning (just Devs, and people playing off of master) 

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [x] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable) - loosely, this needs very thorough testing

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This code was created with the help of AI. - specifically
Tests, script writing to change most of those entities to a list of metadata without having to do manually, general sanity checks and self-review.
