### PR TITLE
Allow playing through the intro cinematic in singleplayer

### DIFF
--- a/NitroxClient/MonoBehaviours/IntroCinematicUpdater.cs
+++ b/NitroxClient/MonoBehaviours/IntroCinematicUpdater.cs
@@ -7,7 +7,7 @@ namespace NitroxClient.MonoBehaviours;
 
 public class IntroCinematicUpdater : MonoBehaviour
 {
-    public static RemotePlayer Partner;
+    public static RemotePlayer? Partner;
     private static Transform modelRoot;
 
     private static readonly Transform playerTransform = Player.main.transform;

--- a/NitroxPatcher/GlobalUsings.cs
+++ b/NitroxPatcher/GlobalUsings.cs
@@ -2,3 +2,4 @@ global using Nitrox.Model.Extensions;
 global using Nitrox.Model.Subnautica.Extensions;
 global using Nitrox.Model.Helper;
 global using NitroxClient.Extensions;
+global using Object = UnityEngine.Object;

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_HandleInput_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_HandleInput_Patch.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using Nitrox.Model.Subnautica.DataStructures.GameLogic;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.PlayerLogic;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -61,22 +62,10 @@ public sealed partial class uGUI_SceneIntro_HandleInput_Patch : NitroxPatch, IDy
     // Partial copied from GameInput.GetInputStateForButton()
     private static void ResetTimeDownForButton(GameInput.Button button)
     {
-        // TODO: rewrite this for new input system
-        /*
-        for (int index1 = 0; index1 < GameInput.numDevices; ++index1)
+        // There are multiple implementations of IGameInput, but GameInputSystem is the only one used
+        if (GameInput.input is GameInputSystem input)
         {
-            for (int index2 = 0; index2 < GameInput.numBindingSets; ++index2)
-            {
-                int bindingInternal = GameInput.GetBindingInternal((GameInput.Device)index1, button, (GameInput.BindingSet)index2);
-                if (bindingInternal != -1)
-                {
-                    GameInput.InputState inputState = GameInput.inputStates[bindingInternal];
-                    inputState.flags = GameInput.InputStateFlags.Up;
-                    inputState.timeDown = Time.unscaledTime + 1f; // 1 sec cooldown
-                    GameInput.inputStates[bindingInternal] = inputState;
-                }
-            }
+            input.startTimes[input.actions[button].id] = Time.unscaledTime + 1f; // Add 1 second before the button is considered held again
         }
-        */
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_IntroSequence_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_IntroSequence_Patch.cs
@@ -1,6 +1,6 @@
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -17,6 +17,12 @@ namespace NitroxPatcher.Patches.Dynamic;
 public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, IDynamicPatch
 {
     private static readonly MethodInfo targetMethod = AccessTools.EnumeratorMoveNext(Reflect.Method((uGUI_SceneIntro si) => si.IntroSequence()));
+
+    private static RemotePlayer? partner;
+    private static bool callbackRun;
+    private static bool packetSend;
+
+    public static bool IsWaitingForPartner { get; private set; }
 
     public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
@@ -81,11 +87,52 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
                .InstructionEnumeration();
     }
 
-    public static bool IsWaitingForPartner { get; private set; }
+    public static void EnqueueStartCinematic(uGUI_SceneIntro uGuiSceneIntro)
+    {
+        IsWaitingForPartner = false;
+        uGuiSceneIntro.skipHintStartTime = -1;
+        uGuiSceneIntro.moveNext = false;
+        uGuiSceneIntro.mainText.FadeOut(0.2f, uGuiSceneIntro.Callback);
+        callbackRun = true;
+    }
 
-    private static RemotePlayer partner;
-    private static bool callbackRun;
-    private static bool packetSend;
+    public static void SkipLocalCinematic(uGUI_SceneIntro uGuiSceneIntro, bool wasNewPlayer)
+    {
+        LiveMixin radioLiveMixin = EscapePod.main.radioSpawner.spawnedObj.GetComponent<Radio>().liveMixin;
+        float radioHealthBefore = radioLiveMixin.health;
+
+        uGuiSceneIntro.Stop(true);
+
+        if (!wasNewPlayer)
+        {
+            // EscapePod.DamageRadio() is called by GuiSceneIntro.Stop(true) but is undesired. We revert it here
+            radioLiveMixin.health = radioHealthBefore;
+        }
+
+        if (radioLiveMixin.IsFullHealth())
+        {
+            Object.Destroy(radioLiveMixin.loopingDamageEffectObj);
+        }
+
+        Transform introFireHolder = EscapePod.main.transform.Find("Intro");
+        if (introFireHolder) // Can be null if called very early
+        {
+            introFireHolder.GetComponentInChildren<FMOD_CustomEmitter>(true).ReleaseEvent(); // Not releasing it before destroying results in infinite unstoppable pain
+            Object.DestroyImmediate(introFireHolder.gameObject); // Like in Fire.Extinguished() but without delay
+        }
+
+        // From uGUI_SceneIntro.IntroSequence() after "if (XRSettings.enabled && VROptions.skipIntro)"
+        if (UnityObjectExtensions.TryFind("fire_extinguisher_01_tp", out GameObject gameObject1))
+        {
+            Object.Destroy(gameObject1);
+        }
+        if (UnityObjectExtensions.TryFind("IntroFireExtinugisherPickup", out GameObject gameObject2))
+        {
+            Object.Destroy(gameObject2);
+        }
+
+        Resolve<PlayerCinematics>().SetLocalIntroCinematicMode(IntroCinematicMode.COMPLETED);
+    }
 
     // ReSharper disable once UnusedMethodReturnValue.Local
     private static bool IsWorldSettledAndInitialSyncCompleted()
@@ -156,20 +203,9 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
         return false;
     }
 
-    private static bool ShouldSkipIntroForDebug()
-    {
-        return !NitroxEnvironment.IsReleaseMode && !NitroxEnvironment.CommandLineArgs.Any(
-            x => x.Equals("--noskipintro", StringComparison.OrdinalIgnoreCase));
-    }
-
-    public static void EnqueueStartCinematic(uGUI_SceneIntro uGuiSceneIntro)
-    {
-        IsWaitingForPartner = false;
-        uGuiSceneIntro.skipHintStartTime = -1;
-        uGuiSceneIntro.moveNext = false;
-        uGuiSceneIntro.mainText.FadeOut(0.2f, uGuiSceneIntro.Callback);
-        callbackRun = true;
-    }
+    private static bool ShouldSkipIntroForDebug() =>
+        !NitroxEnvironment.IsReleaseMode &&
+        !NitroxEnvironment.CommandLineArgs.Any(x => x.Equals("--noskipintro", StringComparison.OrdinalIgnoreCase));
 
     private static void StartRemoteCinematic()
     {
@@ -193,7 +229,7 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
             IntroCinematicUpdater introCinematicUpdater = partner.Body.GetComponent<IntroCinematicUpdater>();
             if (introCinematicUpdater)
             {
-                UnityEngine.Object.DestroyImmediate(introCinematicUpdater);
+                Object.DestroyImmediate(introCinematicUpdater);
                 IntroCinematicUpdater.Partner = null;
             }
 
@@ -207,43 +243,6 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
         Resolve<PlayerCinematics>().SetLocalIntroCinematicMode(IntroCinematicMode.COMPLETED);
     }
 
+    [MemberNotNullWhen(true, nameof(partner))]
     private static bool IsPartnerValid() => partner != null && Resolve<PlayerManager>().Find(partner.SessionId).HasValue;
-
-    public static void SkipLocalCinematic(uGUI_SceneIntro uGuiSceneIntro, bool wasNewPlayer)
-    {
-        LiveMixin radioLiveMixin = EscapePod.main.radioSpawner.spawnedObj.GetComponent<Radio>().liveMixin;
-        float radioHealthBefore = radioLiveMixin.health;
-
-        uGuiSceneIntro.Stop(true);
-
-        if (!wasNewPlayer)
-        {
-            // EscapePod.DamageRadio() is called by GuiSceneIntro.Stop(true) but is undesired. We revert it here
-            radioLiveMixin.health = radioHealthBefore;
-        }
-
-        if (radioLiveMixin.IsFullHealth())
-        {
-            UnityEngine.Object.Destroy(radioLiveMixin.loopingDamageEffectObj);
-        }
-
-        Transform introFireHolder = EscapePod.main.transform.Find("Intro");
-        if (introFireHolder) // Can be null if called very early
-        {
-            introFireHolder.GetComponentInChildren<FMOD_CustomEmitter>(true).ReleaseEvent(); // Not releasing it before destroying results in infinite unstoppable pain
-            UnityEngine.Object.DestroyImmediate(introFireHolder.gameObject); // Like in Fire.Extinguished() but without delay
-        }
-
-        // From uGUI_SceneIntro.IntroSequence() after "if (XRSettings.enabled && VROptions.skipIntro)"
-        if (UnityObjectExtensions.TryFind("fire_extinguisher_01_tp", out GameObject gameObject1))
-        {
-            UnityEngine.Object.Destroy(gameObject1);
-        }
-        if (UnityObjectExtensions.TryFind("IntroFireExtinugisherPickup", out GameObject gameObject2))
-        {
-            UnityEngine.Object.Destroy(gameObject2);
-        }
-
-        Resolve<PlayerCinematics>().SetLocalIntroCinematicMode(IntroCinematicMode.COMPLETED);
-    }
 }

--- a/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_IntroSequence_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_SceneIntro_IntroSequence_Patch.cs
@@ -1,4 +1,7 @@
+
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -120,7 +123,7 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
         }
 
         // Skipping intro if creative like in normal SN or in debug configuration
-        if (!NitroxEnvironment.IsReleaseMode ||
+        if (ShouldSkipIntroForDebug() ||
             GameModeUtils.currentGameMode.HasFlag(GameModeOption.Creative))
         {
             SkipLocalCinematic(uGuiSceneIntro, true);
@@ -151,6 +154,12 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
         }
 
         return false;
+    }
+
+    private static bool ShouldSkipIntroForDebug()
+    {
+        return !NitroxEnvironment.IsReleaseMode && !NitroxEnvironment.CommandLineArgs.Any(
+            x => x.Equals("--noskipintro", StringComparison.OrdinalIgnoreCase));
     }
 
     public static void EnqueueStartCinematic(uGUI_SceneIntro uGuiSceneIntro)
@@ -184,7 +193,7 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
             IntroCinematicUpdater introCinematicUpdater = partner.Body.GetComponent<IntroCinematicUpdater>();
             if (introCinematicUpdater)
             {
-                Object.DestroyImmediate(introCinematicUpdater);
+                UnityEngine.Object.DestroyImmediate(introCinematicUpdater);
                 IntroCinematicUpdater.Partner = null;
             }
 
@@ -215,24 +224,24 @@ public sealed partial class uGUI_SceneIntro_IntroSequence_Patch : NitroxPatch, I
 
         if (radioLiveMixin.IsFullHealth())
         {
-            Object.Destroy(radioLiveMixin.loopingDamageEffectObj);
+            UnityEngine.Object.Destroy(radioLiveMixin.loopingDamageEffectObj);
         }
 
         Transform introFireHolder = EscapePod.main.transform.Find("Intro");
         if (introFireHolder) // Can be null if called very early
         {
             introFireHolder.GetComponentInChildren<FMOD_CustomEmitter>(true).ReleaseEvent(); // Not releasing it before destroying results in infinite unstoppable pain
-            Object.DestroyImmediate(introFireHolder.gameObject); // Like in Fire.Extinguished() but without delay
+            UnityEngine.Object.DestroyImmediate(introFireHolder.gameObject); // Like in Fire.Extinguished() but without delay
         }
 
         // From uGUI_SceneIntro.IntroSequence() after "if (XRSettings.enabled && VROptions.skipIntro)"
         if (UnityObjectExtensions.TryFind("fire_extinguisher_01_tp", out GameObject gameObject1))
         {
-            Object.Destroy(gameObject1);
+            UnityEngine.Object.Destroy(gameObject1);
         }
         if (UnityObjectExtensions.TryFind("IntroFireExtinugisherPickup", out GameObject gameObject2))
         {
-            Object.Destroy(gameObject2);
+            UnityEngine.Object.Destroy(gameObject2);
         }
 
         Resolve<PlayerCinematics>().SetLocalIntroCinematicMode(IntroCinematicMode.COMPLETED);


### PR DESCRIPTION
## Description of Change

This PR fixes a bug where skipping waiting for another player to begin the intro sequence would unintentionally skip the intro sequence as well. This is because, when moving to a newer Subnautica version with a new input system, some code was never ported over which properly reset the held time of the Escape key. Since both of these skips involve holding the same key for 1.5s, the code skipped both as soon as that 1.5s time was reached.

I also added a new command-line argument, `--noskipintro`, which allows playing through the intro sequence when not on a release build. The old behavior was to always skip this sequence for development builds, and that is still the default.

Put together, these two changes allow easy testing of the intro sequence, since it is now accessible on a development build and with only one player.

## Validation

1. Create a new server in Survival mode and join it with one player. You should see the text "Waiting for another player to join", which would never appear previously on a development build.
2. Hold Escape to skip this prompt. You should see the text "Unknown World Entertainment and the Nitrox Team present", and keeping the Escape key held down should start to skip this prompt as well. Previously, this text could never appear and the player would instantly get put into regular gameplay in a post-intro escape pod.

## PR Checklist

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [ ] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---
