### PR TITLE
Fix launcher being unable to find world backups

### DIFF
--- a/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/BackupRestoreViewModel.cs
@@ -77,7 +77,7 @@ public partial class BackupRestoreViewModel : ModalViewModelBase
         {
             yield break;
         }
-        string backupDir = Path.Combine(saveDirectory, "Backups");
+        string backupDir = Path.Combine(saveDirectory, "backups");
         if (!Directory.Exists(backupDir))
         {
             yield break;


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2879 

## Description of Change

The launcher and server used two different names of the world backups folder, so the launcher couldn't find backups made by the server. This PR changes them to use the same name.

## Validation

Create and start a server, and ensure it saves the world at least once. Then find the server in the launcher and click Manage, then click Restore a Backup. You should see at least one backup listed; previously the list was always empty.

## PR Checklist

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [x] Has been tested in-game (if applicable)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)

---
