### PR TITLE
Fixed multiple capture scopes conflicting with each other

### DIFF
--- a/Nitrox.Model/Configuration/SubnauticaServerOptions.cs
+++ b/Nitrox.Model/Configuration/SubnauticaServerOptions.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Options;
 using Nitrox.Model.Constants;
 using Nitrox.Model.DataStructures.GameLogic;
 using Nitrox.Model.Serialization;
-using Nitrox.Model.Server;
 
 namespace Nitrox.Model.Configuration;
 

--- a/Nitrox.Server.Subnautica/Extensions/LoggingBuilderExtensions.cs
+++ b/Nitrox.Server.Subnautica/Extensions/LoggingBuilderExtensions.cs
@@ -50,9 +50,13 @@ internal static class LoggingBuilderExtensions
                            o.Redactors = provider.GetRequiredService<IEnumerable<IRedactor>>()?.ToArray() ?? [];
                        }).OutputFunc = (entry, formatter, generator, writer) =>
                        {
-                           if (entry.TryGetProperty(out CaptureScope scope))
+                           if (entry.TryGetAllProperties<CaptureScope>() is [_, ..] scopes)
                            {
-                               scope.Capture(generator(entry, formatter, writer));
+                               string log = generator(entry, formatter, writer);
+                               foreach (CaptureScope captureScope in scopes)
+                               {
+                                   captureScope.Capture(log);
+                               }
                            }
                            return Task.CompletedTask;
                        };

--- a/Nitrox.Server.Subnautica/Extensions/ZLoggerFormattableExtensions.cs
+++ b/Nitrox.Server.Subnautica/Extensions/ZLoggerFormattableExtensions.cs
@@ -25,7 +25,7 @@ internal static class ZLoggerFormattableExtensions
         return false;
     }
 
-    public static bool TryGetProperty<T>(this IZLoggerEntry entry, [NotNullWhen(true)] out T? result) where T : class
+    public static bool TryGetFirstProperty<T>(this IZLoggerEntry entry, [NotNullWhen(true)] out T? result) where T : class
     {
         if (entry.LogInfo.ScopeState is { } scope)
         {
@@ -41,5 +41,23 @@ internal static class ZLoggerFormattableExtensions
         }
         result = null;
         return false;
+    }
+
+    public static IReadOnlyList<T> TryGetAllProperties<T>(this IZLoggerEntry entry) where T : class
+    {
+        List<T>? result = null;
+        if (entry.LogInfo.ScopeState is { } scope)
+        {
+            foreach (KeyValuePair<string, object?> keyValuePair in scope.Properties)
+            {
+                object value = keyValuePair.Value;
+                if (value is T matchedValue)
+                {
+                    result ??= [];
+                    result.Add(matchedValue);
+                }
+            }
+        }
+        return result ?? [];
     }
 }

--- a/Nitrox.Server.Subnautica/Models/Logging/NitroxZLoggerFormatter.cs
+++ b/Nitrox.Server.Subnautica/Models/Logging/NitroxZLoggerFormatter.cs
@@ -28,7 +28,7 @@ internal sealed class NitroxZLoggerFormatter : MiddlewareZLoggerFormatter
         }
         if (options.IsOmittedOnCapture)
         {
-            yield return new BreakLoggerMiddleware { BreakCondition = static (ref context) => context.Entry.TryGetProperty(out CaptureScope _) };
+            yield return new BreakLoggerMiddleware { BreakCondition = static (ref context) => context.Entry.TryGetFirstProperty(out CaptureScope _) };
         }
         if (options.RequiredPropertyTypes.Length > 0)
         {
@@ -38,7 +38,7 @@ internal sealed class NitroxZLoggerFormatter : MiddlewareZLoggerFormatter
         {
             Writer = static (ref context) =>
             {
-                if (context.Entry.TryGetProperty(out PrefixScope scope))
+                if (context.Entry.TryGetFirstProperty(out PrefixScope scope))
                 {
                     context.Writer.Write(scope.Prefix);
                 }
@@ -48,7 +48,7 @@ internal sealed class NitroxZLoggerFormatter : MiddlewareZLoggerFormatter
         {
             yield return new ConditionalGroupLoggerMiddleware
             {
-                Condition = static context => !context.Entry.TryGetProperty(out PlainScope _),
+                Condition = static context => !context.Entry.TryGetFirstProperty(out PlainScope _),
                 TrueGroup =
                 [
                     new WriteTimeLoggerMiddleware { Format = options.TimestampFormat ?? "" },

--- a/Nitrox.Server.Subnautica/Models/Logging/ZLogger/ZLoggerAtomicConsoleLoggerProvider.cs
+++ b/Nitrox.Server.Subnautica/Models/Logging/ZLogger/ZLoggerAtomicConsoleLoggerProvider.cs
@@ -75,7 +75,7 @@ internal sealed class ZLoggerAtomicConsoleLoggerProvider : ILoggerProvider, ISup
 
         public void Post(IZLoggerEntry log)
         {
-            if (log.TryGetProperty(out AtomicScope scope))
+            if (log.TryGetFirstProperty(out AtomicScope scope))
             {
                 scope.Locker = postLocker;
                 scope.AddLogEntry(log, Processor);

--- a/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
+++ b/Nitrox.Server.Subnautica/Services/ServersManagementService.cs
@@ -173,7 +173,7 @@ internal sealed class ServersManagementService(PlayerManager playerManager, IPac
                 LogLevel.Error => 3,
                 _ => 0
             };
-            bool isPlain = log.Entry.TryGetProperty(out PlainScope _);
+            bool isPlain = log.Entry.TryGetFirstProperty(out PlainScope _);
             string? message = log.Generator(log.Entry, log.Formatter, log.Writer); // Generator will dispose of the log data, so this needs to be called "last".
             if (message is "")
             {


### PR DESCRIPTION
Indirectly fixes the summary command because it caused 2 `CaptureScope`s which conflicted with each other.