### PR TITLE
[MSBuild] Add a basic nuget.config

### DIFF
--- a/Nitrox.slnx
+++ b/Nitrox.slnx
@@ -8,6 +8,7 @@
     <File Path="Nitrox.Shared.props" />
     <File Path="Nitrox.Shared.targets" />
     <File Path="Nitrox.slnx.DotSettings" />
+    <File Path="NuGet.config" />
   </Folder>
   <Project Path="Nitrox.Launcher/Nitrox.Launcher.csproj" />
   <Project Path="Nitrox.Assets.Subnautica/Nitrox.Assets.Subnautica.shproj" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- clear to make sure that everyone uses the same sources -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <!-- Resolve all packages from nuget.org by default -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2882 

## Description of Change

<!-- Describe what this PR changes and why -->
Nitrox doesn't use any custom nuget servers, so force the sources to be the same for all dev env, and also provide a package source mapping (not mandatory)

## Validation

<!-- Describe steps to validate your changes -->

* `dotnet restore` should work
* Adding a custom nuget sources shouldn't work (nitrox should not even see the source), and dotnet restore would still work
## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- [ ] Has tests for the changes (if applicable)
- [x] Has a linked issue
- [ ] Has been tested in-game (if applicable)
- [x] Has been tested on Windows/macOS 
