### PR TITLE
Fix OxygenPipe bug on destroying it

### DIFF
--- a/NitroxPatcher/Patches/Dynamic/OxygenPipe_OnDestroy_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/OxygenPipe_OnDestroy_Patch.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// Forces the destruction of an oxygen pipe to be "natural", for example when another player picks up an oxygen pipe, the parent will be notified of it.
+/// </summary>
+public sealed partial class OxygenPipe_OnDestroy_Patch : NitroxPatch, IDynamicPatch
+{
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((OxygenPipe t) => t.OnDestroy());
+
+    public static void Prefix(OxygenPipe __instance)
+    {
+        IPipeConnection parent = __instance.GetParent();
+        if (parent != null)
+        {
+            parent.RemoveChild(__instance);
+        }
+    }
+}


### PR DESCRIPTION
<!-- 🚨 Before filing a pull request, please read our guidelines: https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md, and make sure NOT to skip the instructions below. 🚨 -->

<!-- 👉 If you want to work on a non-trivial feature, or a feature without an existing issue, we recommend contacting us on Discord https://discord.gg/E8B4X9s before investing your time. -->

<!-- 👉 Please keep PRs focused on **ONE ISSUE PER PR**. Avoid mixing unrelated changes unless they are directly connected. -->

<!-- 👉 Please keep the "☑️ Allow edits by maintainers" option enabled in the Pull Request settings. It helps our team collaborate with you by allowing small fixes directly on your PR branch from your fork, such as typo fixes or forgotten StyleCop issues during review. Let us help you help us! 🎉 -->

## Linked Issues / Context

<!-- Add links to issues (e.g., Fixes #123) or relevant context -->
<!-- Fixes #<ISSUE_NUMBER> -->

Fix Oxygen Pipe pickup destroying its parent's oxygen output on remote players

## Description of Change

<!-- Describe what this PR changes and why -->

when an oxygen pipe gets destroyed (by remote player pickup for example), we notify its parent (if it has one) so that it knows about it

## Validation

<!-- Describe steps to validate your changes -->
- place pipes (at least 2) from a pipe surface floater or base pipe input
- player A picks up a pipe
- player b observes no issue with the pipe

## PR Checklist

<!-- This checklist is a basic reminder. Feel free to edit, add, or remove items to fit your PR. -->

- [x] PR rebased on top of `main` at the time of opening
- ~~Has tests for the changes (if applicable)~~
- ~~Has a linked issue~~
- [x] Has been tested in-game (if applicable)
- ~~Has been tested on Windows/Linux/macOS (if applicable) (for cross-platform code)~~

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
<!-- 🤖 This code was created with the help of AI. -->
