### PR TITLE
Fix PlayerHeldItemChanged NRE for items with null inventoryItem

### DIFF
--- a/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
@@ -42,7 +42,10 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
         Pickupable pickupable = item.GetComponent<Pickupable>();
         Validate.IsTrue(pickupable);
 
-        Validate.NotNull(pickupable.inventoryItem);
+        // NB: Do NOT assert pickupable.inventoryItem here. It is null for items like the
+        // Mobile Vehicle Bay (Constructor), which is a Pickupable+PlayerTool without an
+        // inventory wrapper (see issue #2460). All uses below go through Pickupable directly,
+        // which is equivalent for normal items (inventoryItem.item is the same Pickupable).
 
         ItemsContainer inventory = player.Inventory;
         PlayerTool tool = item.GetComponent<PlayerTool>();
@@ -91,7 +94,8 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
                 {
                     floater.collider.enabled = true;
                 }
-                pickupable.inventoryItem.item.Reparent(inventory.tr);
+                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
+                pickupable.Reparent(inventory.tr);
                 foreach (Animator componentsInChild in tool.GetComponentsInChildren<Animator>())
                 {
                     componentsInChild.cullingMode = AnimatorCullingMode.CullUpdateTransforms;
@@ -107,15 +111,17 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
                 break;
 
             case PlayerHeldItemChanged.ChangeType.DRAW_AS_ITEM:
-                pickupable.inventoryItem.item.Reparent(player.ItemAttachPoint);
-                pickupable.inventoryItem.item.SetVisible(true);
-                Utils.SetLayerRecursively(pickupable.inventoryItem.item.gameObject, viewModelLayer);
+                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
+                pickupable.Reparent(player.ItemAttachPoint);
+                pickupable.SetVisible(true);
+                Utils.SetLayerRecursively(item, viewModelLayer);
                 break;
 
             case PlayerHeldItemChanged.ChangeType.HOLSTER_AS_ITEM:
-                pickupable.inventoryItem.item.Reparent(inventory.tr);
-                pickupable.inventoryItem.item.SetVisible(false);
-                Utils.SetLayerRecursively(pickupable.inventoryItem.item.gameObject, defaultLayer);
+                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
+                pickupable.Reparent(inventory.tr);
+                pickupable.SetVisible(false);
+                Utils.SetLayerRecursively(item, defaultLayer);
                 break;
 
             default:

--- a/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs
@@ -42,11 +42,6 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
         Pickupable pickupable = item.GetComponent<Pickupable>();
         Validate.IsTrue(pickupable);
 
-        // NB: Do NOT assert pickupable.inventoryItem here. It is null for items like the
-        // Mobile Vehicle Bay (Constructor), which is a Pickupable+PlayerTool without an
-        // inventory wrapper (see issue #2460). All uses below go through Pickupable directly,
-        // which is equivalent for normal items (inventoryItem.item is the same Pickupable).
-
         ItemsContainer inventory = player.Inventory;
         PlayerTool tool = item.GetComponent<PlayerTool>();
 
@@ -94,7 +89,6 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
                 {
                     floater.collider.enabled = true;
                 }
-                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
                 pickupable.Reparent(inventory.tr);
                 foreach (Animator componentsInChild in tool.GetComponentsInChildren<Animator>())
                 {
@@ -111,14 +105,12 @@ internal sealed class PlayerHeldItemChangedProcessor : IClientPacketProcessor<Pl
                 break;
 
             case PlayerHeldItemChanged.ChangeType.DRAW_AS_ITEM:
-                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
                 pickupable.Reparent(player.ItemAttachPoint);
                 pickupable.SetVisible(true);
                 Utils.SetLayerRecursively(item, viewModelLayer);
                 break;
 
             case PlayerHeldItemChanged.ChangeType.HOLSTER_AS_ITEM:
-                // inventoryItem can be null for items like the Mobile Vehicle Bay (Constructor, #2460)
                 pickupable.Reparent(inventory.tr);
                 pickupable.SetVisible(false);
                 Utils.SetLayerRecursively(item, defaultLayer);


### PR DESCRIPTION
## Linked Issues / Context

Fixes #2460

## Description of Change

Remote clients crashed with `ArgumentNullException: pickupable.inventoryItem` in `PlayerHeldItemChangedProcessor` whenever a player held an item that has no inventory wrapper, e.g. the Mobile Vehicle Bay (Constructor), which is a `Pickupable` + `PlayerTool` with null `inventoryItem`.

Changes in `NitroxClient/Communication/Packets/Processors/PlayerHeldItemChangedProcessor.cs`:
- Removed the `Validate.NotNull(pickupable.inventoryItem)` assertion that threw for such items.
- `HOLSTER_AS_TOOL`, `DRAW_AS_ITEM` and `HOLSTER_AS_ITEM` now reparent / show / hide via `Pickupable` directly (`pickupable.Reparent(...)`, `pickupable.SetVisible(...)`) and set layers on `item` instead of going through `pickupable.inventoryItem.item`. For normal items this is equivalent (`inventoryItem.item` is the same `Pickupable`); for items without an inventory wrapper it no longer throws.
- `DRAW_AS_TOOL` needed no change (never touched `inventoryItem`).

This ports the approach of #2591 (closed without merge) onto the current codebase.

## Validation

- `dotnet build NitroxClient`: 0 errors (only pre-existing DIMA001 warnings).
- `dotnet test Nitrox.Test`: 246 passed, 0 failed, 13 skipped (platform-specific).
- In-game validation still pending (needs 2 players, repro steps from #2460):
  1. Join with 2 players.
  2. [Player1] Craft and drop a Mobile Vehicle Bay, leave a quickslot empty, pick the bay up.
  3. [Player2] Before: error log + NRE. After: no error, bay visible in Player1 hand.

## PR Checklist

- [x] PR rebased on top of `master` (actual default branch) at the time of opening
- [x] Has tests for the changes (full existing suite passes with no regressions; no new unit test added as the processor requires the Unity runtime)
- [x] Has a linked issue (Fixes #2460)
- [ ] Has been tested in-game (if applicable) (pending, see validation steps above)
- [ ] Has been tested on Windows/Linux/macOS (if applicable) (pending)

---

<!-- For transparency regarding AI, please uncomment the following statement. -->
🤖 This description was translated with the help of AI.